### PR TITLE
Sph script for dambreak scenario

### DIFF
--- a/inductiva/fluids/__init__.py
+++ b/inductiva/fluids/__init__.py
@@ -1,4 +1,4 @@
-# pylint disable=missing-module-docstring
+#pylint: disable=missing-module-docstring
 from ._fluid_types import WATER
 from .scenarios import DamBreak
 from . import scenarios

--- a/inductiva/fluids/_fluid_types.py
+++ b/inductiva/fluids/_fluid_types.py
@@ -1,7 +1,8 @@
 """Physical properties of different fluid types."""
 
 from inductiva_sph.sph_core.fluids import FluidProperties
+
 WATER = FluidProperties(
     density=1e3,
     kinematic_viscosity=1e-6,
-    )
+)

--- a/inductiva/fluids/scenarios.py
+++ b/inductiva/fluids/scenarios.py
@@ -1,3 +1,4 @@
+"""Describes the physical scenarios and runs its simulation via API."""
 import inductiva_sph
 from inductiva_sph import sph_core
 
@@ -5,36 +6,35 @@ from inductiva_sph import sph_core
 TIME_MAX = 0.6
 PARTICLE_RADIUS = 0.002
 COLUMN_VELOCITY = [0.0, 0.0, 0.0]
-SIMULATION_METHOD = "divergence-free-SPH"
-BOUNDARY_HANDLING_METHOD = "volume-maps"
 BOUNDARY_RESOLUTION = [20, 20, 20]
 OUTPUT_TIME_STEP = 1. / 60.
 TANK_LENGTH = 0.84
 TANK_WIDTH = 0.5715
 TANK_HEIGHT = 0.12
-TANK_DIMENTION = [0.84, 0.05715, 0.12]
+TANK_DIMENSION = [0.84, 0.05715, 0.12]
 COLUMN_POSITION = [0.0, 0.0, 0.0]
 
 
 class DamBreak:
     """Physical scenario of a dam break simulation."""
 
-    def __init__(self, fluid: sph_core.fluids.FluidProperties, 
-                 fluid_dimentions: list[float, float, float]) -> None:
+    def __init__(self, fluid: sph_core.fluids.FluidProperties,
+                 fluid_dimensions: list[float, float, float]) -> None:
         """Initializes a `DamBreak` object.
 
         Args:
             fluid: A fluid type of the simulation.
-            fluid_dimentions: A list containing the fluid column dimentions relative to the tank's dimentions."""
+            fluid_dimensions: A list containing the fluid column dimensions
+            relative to the tank dimensions."""
 
         self.fluid = fluid
 
-        #  Set fluid block dimentions according to the input
-        if max(fluid_dimentions) <= 1:
-            self.fluid_dimention = [
-                fluid_dimentions[0] * TANK_LENGTH, 
-                fluid_dimentions[1] * TANK_WIDTH, 
-                fluid_dimentions[2] * TANK_HEIGHT
+        #  Set fluid block dimensions according to the input
+        if max(fluid_dimensions) <= 1:
+            self.fluid_dimension = [
+                fluid_dimensions[0] * TANK_LENGTH,
+                fluid_dimensions[1] * TANK_WIDTH,
+                fluid_dimensions[2] * TANK_HEIGHT
             ]
 
     def simulate(self):
@@ -44,33 +44,31 @@ class DamBreak:
         scenario = self.__create_scenario()
 
         # Create simulation
+        # pylint: disable=unused-variable
         simulation = inductiva_sph.splishsplash.SPlisHSPlasHSimulation(
             scenario=scenario,
             time_max=TIME_MAX,
             particle_radius=PARTICLE_RADIUS,
-            simulation_method=SIMULATION_METHOD,
-            boundary_handling_method=BOUNDARY_HANDLING_METHOD,
             boundary_resolution=BOUNDARY_RESOLUTION,
             output_time_step=OUTPUT_TIME_STEP)
 
-        # Create input files
-        simulation._create_input_file()
-
+        #  TODO
+        # Create input JSON
+        # input_json = simulation.create_input_json()
         # Invoke API
-        # run_simulation()
+        # inductiva.sph(input_json)
 
     def __create_scenario(self):
-        fluid_properties = sph_core.fluids.FluidProperties(self.fluid)
 
         # Create fluid column
         fluid_block = sph_core.fluids.BoxFluidBlock(
-            fluid_properties=fluid_properties,
+            fluid_properties=self.fluid,
             position=COLUMN_POSITION,
-            dimensions=self.fluid_dimention,
+            dimensions=self.fluid_dimension,
             initial_velocity=COLUMN_VELOCITY)
 
         # Set up scenario
         scenario = sph_core.scenarios.DamBreakSPHScenario(
-            dimensions=TANK_DIMENTION, fluid_blocks=[fluid_block])
+            dimensions=TANK_DIMENSION, fluid_blocks=[fluid_block])
 
         return scenario


### PR DESCRIPTION
I have created a fluid method that takes creates the scenario and an input file for the SPlisHSPlasH simulation.
There is gmesh used when creating those files and some obj files, which are defined in inductiva_sphh. Can we actually create a full input file from the client side?