### PR TITLE
Update dam break scenario parameters

### DIFF
--- a/inductiva/fluids/scenarios.py
+++ b/inductiva/fluids/scenarios.py
@@ -46,13 +46,13 @@ class DamBreak:
                 "The values of `fluid_dimensions` cannot exceed 1.")
         if min(fluid_dimensions) < 0.1:
             raise ValueError(
-                "The values of `fluid_dimensions` must be larger than 0.01.")
+                "The values of `fluid_dimensions` must be larger than 0.1.")
         if len(fluid_dimensions) != 3:
             raise ValueError("`fluid_dimensions` must have 3 values.")
 
         self.fluid_dimensions = fluid_dimensions
 
-        if fluid_position is not None:
+        if fluid_position is None:
             self.fluid_position = [0.0, 0.0, 0.0]
 
         if len(fluid_position) != 3:


### PR DESCRIPTION
In this PR I added an extra check for fluid dimensions and add maximum time as a parameter. 
I removed the check from particle radius and  didn't add one to the maximum time. I will set those once Ivan experiments with different values and finds upper and lower boundaries of those parameters.

I will open another branch to set the `particle_radius` to high, medium, low. 