### PR TITLE
Update particle radius in resolution and a viscosity solver

### DIFF
--- a/demos/dambreak_simulation.py
+++ b/demos/dambreak_simulation.py
@@ -11,7 +11,7 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_string("api_url", "http://api.inductiva.ai",
                     "Base URL of the Inductiva API.")
-flags.DEFINE_list("fluid_dimensions", [0.2, 0.8, 0.8],
+flags.DEFINE_list("fluid_dimensions", [0.2, 1, 1],
                   "Dimensions of the fluid column.")
 flags.DEFINE_list("fluid_position", [0.0, 0.0, 0.0],
                   "Position of the fluid column in the tank.")

--- a/inductiva/fluids/scenarios.py
+++ b/inductiva/fluids/scenarios.py
@@ -15,7 +15,7 @@ from ._fluid_types import WATER
 # Glabal variables to define a scenario
 COLUMN_VELOCITY = [0.0, 0.0, 0.0]
 OUTPUT_TIME_STEP = 1. / 60.
-TANK_DIMENSIONS = [1.5, 1, 1]
+TANK_DIMENSIONS = [1, 1, 1]
 FLUID_DIMENSION_LOWER_BOUNDARY = 0.1
 FLUID_DIMENSION_UPPER_BOUNDARY = 1
 VISCOSITY_SOLVER = "Weiler-2018"


### PR DESCRIPTION
I changed the particle radius to to give following outputs for each resolution:

Low resolution ~1k particles, takes a few (3-5) seconds to simulate and generate a video.

https://user-images.githubusercontent.com/65309160/221913434-46fb478d-6128-45f2-ad51-0061df29e189.mp4



Medium resolution ~10k particles, takes a few (8-10) seconds to simulate and generate a video.

https://user-images.githubusercontent.com/65309160/221913479-6f1d0961-1b88-4d2f-b35c-dd2c8ff515c3.mp4



High resolution ~40k particles, takes about 1.5-2 mins to simulate and generate a video.

https://user-images.githubusercontent.com/65309160/221913511-950bb7eb-06ba-405a-ba9a-05d8a7699302.mp4



I wanted to add a VERY_HIGH parameter with 150k particles, but that takes around 10 mins to simulate and generate a video,  I didn't include it here because it takes too long.



