### PR TITLE
Add other fluids types

### DIFF
--- a/inductiva/fluids/__init__.py
+++ b/inductiva/fluids/__init__.py
@@ -1,5 +1,6 @@
 #pylint: disable=missing-module-docstring
-from ._fluid_types import *
+from ._fluid_types import WATER, OLIVE_OIL, LIQUID_PROPANE
+from ._fluid_types import JET_FUEL, GEAR_OIL, BEER
 from .scenarios import DamBreak
 from . import scenarios
 from ._output_post_processing import SimulationOutput

--- a/inductiva/fluids/_fluid_types.py
+++ b/inductiva/fluids/_fluid_types.py
@@ -3,36 +3,31 @@
 from inductiva_sph.sph_core.fluids import FluidProperties
 
 WATER = FluidProperties(
-    density = 1e3,
-    kinematic_viscosity = 1e-6,
+    density=1e3,
+    kinematic_viscosity=1e-6,
 )
 
 OLIVE_OIL = FluidProperties(
-    density = 905,
-    kinematic_viscosity = 4.3200e-5,
-)
-
-TEST = FluidProperties(
-    density = 2e3,
-    kinematic_viscosity = 1e-3,
+    density=905,
+    kinematic_viscosity=4.32e-5,
 )
 
 LIQUID_PROPANE = FluidProperties(
-    density = 580,
-    kinematic_viscosity = 2.73e-7,
+    density=580,
+    kinematic_viscosity=2.73e-7,
 )
 
 JET_FUEL = FluidProperties(
-    density = 802.5,
-    kinematic_viscosity = 7.6e-6,
+    density=802.5,
+    kinematic_viscosity=7.6e-6,
 )
 
 BEER = FluidProperties(
-    density = 1.007e3,
-    kinematic_viscosity = 1.8e-6,
+    density=1.007e3,
+    kinematic_viscosity=1.8e-6,
 )
 
 GEAR_OIL = FluidProperties(
-    density = 860,
-    kinematic_viscosity = 4.2e-6,
+    density=860,
+    kinematic_viscosity=4.2e-6,
 )


### PR DESCRIPTION
In this PR, I add various other types of fluids. These are mainly determined by their density and viscosity and allows it to combine with the introduced viscosity solvers.

Types: WATER, OLIVE OIL, GEAR OIL, LIQUID PROPANE, BEER, JET FUEL.