### PR TITLE
Add device option to run simulation

### DIFF
--- a/demos/dam_break_simulation.py
+++ b/demos/dam_break_simulation.py
@@ -22,6 +22,8 @@ flags.DEFINE_string(
     "scatter plot.")
 flags.DEFINE_string("output_dir", None,
                     "Destination directory for output files.")
+flags.DEFINE_string("device", "cpu",
+                    "Device in which device the simulation will run.")
 
 
 def main(_):
@@ -38,7 +40,8 @@ def main(_):
             FLAGS.fluid_position),
         resolution=FLAGS.resolution)
 
-    simulation_output = scenario.simulate(output_dir=FLAGS.output_dir)
+    simulation_output = scenario.simulate(output_dir=FLAGS.output_dir,
+                                          device=FLAGS.device)
     simulation_output.render(color_quantity=FLAGS.color_quantity)
 
     logging.info("Local time: %s", time.perf_counter() - time_start)

--- a/inductiva/fluids/scenarios/dam_break.py
+++ b/inductiva/fluids/scenarios/dam_break.py
@@ -1,15 +1,16 @@
 """Describes the physical scenarios and runs its simulation via API."""
 import tempfile
-import numpy as np
 from enum import Enum
+from typing import List, Literal, Optional
 
-from typing import List, Optional, Literal
+import inductiva_sph
+import numpy as np
+from absl import logging
+from inductiva_sph import sph_core
 
 import inductiva
-import inductiva_sph
-from inductiva_sph import sph_core
-from inductiva.fluids._output_post_processing import SimulationOutput
 from inductiva.fluids._fluid_types import WATER
+from inductiva.fluids._output_post_processing import SimulationOutput
 from inductiva.types import Path
 
 # Glabal variables to define a scenario
@@ -87,7 +88,9 @@ class DamBreak:
         #     raise ValueError("`time_max` cannot exceed {TIME_MAX} seconds.")
         self.time_max = time_max
 
-    def simulate(self, output_dir: Optional[Path] = None):
+    def simulate(self,
+                 device: Literal["cpu", "gpu"] = "cpu",
+                 output_dir: Optional[Path] = None):
         """Runs SPH simulation of the Dam Break scenario.
 
         Args:
@@ -110,12 +113,14 @@ class DamBreak:
             viscosity_method=VISCOSITY_SOLVER,
             output_directory=input_temp_dir.name)
 
+        logging.info(input_temp_dir)
+
         # Create input file
         simulation.create_input_file()
 
         # Invoke API
         sim_output_path = inductiva.sph.splishsplash.run_simulation(
-            input_temp_dir.name, output_dir=output_dir)
+            sim_dir=input_temp_dir.name, device=device, output_dir=output_dir)
         simulation._output_directory = sim_output_path  #pylint: disable=protected-access
 
         simulation._convert_output_files(False)  #pylint: disable=protected-access

--- a/inductiva/fluids/splishsplash.py
+++ b/inductiva/fluids/splishsplash.py
@@ -1,6 +1,7 @@
 """SplishSplash module of the API."""
 import os
 import pathlib
+from typing import Literal
 
 import inductiva
 from inductiva.types import Path
@@ -27,7 +28,9 @@ class SPlisHSPlasH:
         if not os.path.isdir(sim_dir):
             raise ValueError("The provided path is not a directory.")
 
-    def simulate(self, output_dir=None) -> Path:
+    def simulate(self,
+                 device: Literal["gpu", "cpu"] = "cpu",
+                 output_dir=None) -> Path:
         """Run the simulation.
 
         Args:
@@ -35,4 +38,5 @@ class SPlisHSPlasH:
         """
         return inductiva.sph.splishsplash.run_simulation(self.sim_dir,
                                                          self.input_filename,
+                                                         device=device,
                                                          output_dir=output_dir)

--- a/inductiva/sph/splishsplash.py
+++ b/inductiva/sph/splishsplash.py
@@ -5,7 +5,7 @@ Inductiva client. For instance, `scenario.simulate()` uses the `run_simulation`
 function.
 """
 import pathlib
-from typing import Optional
+from typing import Literal, Optional
 
 from inductiva.api import invoke_api
 from inductiva.types import Path
@@ -15,6 +15,7 @@ from inductiva.types import Path
 
 def run_simulation(sim_dir: Path,
                    input_filename: str = "splishsplash_input.json",
+                   device: Literal["gpu", "cpu"] = "cpu",
                    output_dir: Optional[Path] = None) -> pathlib.Path:
     """Run SplishSplash in the API.
 

--- a/inductiva/utils/data.py
+++ b/inductiva/utils/data.py
@@ -121,6 +121,7 @@ def pack_input(params, type_annotations, zip_name: str) -> str:
         located in the temporary directory of the OS (`/tmp` in linux).
     """
     with tempfile.TemporaryDirectory() as tmpdir_path:
+        logging.debug("PACKING INPUT")
         input_params = {}
 
         for variable in params:


### PR DESCRIPTION
This PR adds the option to run splishsplash with or without GPU. 
I also want to bring to the discussion if `device` is the right keyword for this option, since splishsplash only uses the GPU for one particular step of the computation (neighborhood search), and saying that the simulation runs on GPU may induce the user in error, thinking that the only simulation runs on GPU. For instance, `device` in PyTorch actually tells the device in which the tensor/weights are stored. 
Do you think something like "use_gpu=True" or "use_gpu_acceleration=True" would be better here?  

Related to #26.