### PR TITLE
Change cfl_method to be "no"

### DIFF
--- a/inductiva/fluids/scenarios/dam_break.py
+++ b/inductiva/fluids/scenarios/dam_break.py
@@ -93,10 +93,10 @@ class DamBreak:
               - "medium"
               - "low"
             time_max: Maximum time of simulation, in seconds.
-            cfl_method: cfl_method: Courant-Friedrichs-Lewy (CFL) method used for
-              adaptive time stepping. Used to find a time step as large as
-              possible to achieve high performance but sufficiently small to
-              maintain stability.
+            cfl_method: cfl_method: Courant-Friedrichs-Lewy (CFL) method used
+              for adaptive time stepping. Used to find a time step as large
+              as possible to achieve high performance but sufficiently small
+              to maintain stability.
               The available options are:
               - 'no': No adaptive time-stepping is used.
               - 'cfl': Use CFL condition.


### PR DESCRIPTION
The cfl_method default is "cfl". Here, I change it so that the DamBreak scenario used "no" clf_method.

A reminder: "cfl_method" is a parameter that allows SlishSplash to use adaptive time-step or no adaptive time-step.

This is important for Maria dataset creation, but I wanted to check how the simulations are visualised in this sense with different types of fluid.