### PR TITLE
Update gitignore to allow client/tags to be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -607,3 +607,6 @@ tags
 
 # Misc
 output/
+
+# Allow client submodule tags to be committed
+!inductiva/client/**/tags


### PR DESCRIPTION
I was facing an issue when generating the client in which the `tags` directory generated by the client wasn't being committed due to an entry in our gitignore. This should fix that.