### PR TITLE
Add more logs to invoke_api steps

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -153,8 +153,6 @@ def block_until_status_is(api_instance: TasksApi,
     Returns:
         Returns info related to the task, containing two fields,
     """
-    prev_queue_info = None
-
     prev_status = None
 
     while True:


### PR DESCRIPTION
This PR adds logs to more steps of invoke_api function, such as downloading and extracting outputs.
It also removes the logs related to the status of the Redis stream. The reason for doing so is that the information isn't always consistent, because it relies on the number of consumers that are part of the consumer group for a stream provided by Redis. When the executer dockers are killed, the consumer is not removed from the consumer group, so the information related to the consumer group doesn't match with the actual number of executers.