### PR TITLE
Convert global constants to parameters in `FluidTank.simulate()` method

### DIFF
--- a/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
+++ b/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
@@ -37,7 +37,7 @@ class ParticleRadius(Enum):
 
 @dataclass
 class TimeStep(Enum):
-    """Sets particle radius according to resolution."""
+    """Sets time step according to resolution."""
     HIGH = 0.0025
     MEDIUM = 0.005
     LOW = 0.01


### PR DESCRIPTION
This PR adds a few parameters to the `FluidTank.simulate` method, namely:
- `simulation_time`: controls the total simulation time.
- `resolution`: defines the particle radius and time step to be used in a simulation.
- `output_time_step`: controls the time step between output files (or, equivalently, the frequency with which data is written to disk).
- `particle_sorting`: controls whether particles should be sorted during a simulation.

These parameters were previously set as global constants.