### PR TITLE
Modifications to kill_task function

### DIFF
--- a/inductiva/core/test.py
+++ b/inductiva/core/test.py
@@ -4,7 +4,7 @@ from inductiva.api import invoke_api_from_fn_ptr
 
 
 def sleep(secs: float) -> None:
-    return invoke_api_from_fn_ptr(locals(), sleep, track_logs=False)
+    return invoke_api_from_fn_ptr(locals(), sleep)
 
 
 # pylint: enable=unused-argument, enable=redefined-builtin


### PR DESCRIPTION
This PR adds changes to the kill_task function in order to not block waiting for the task to be killed, fixes a bug in the function that polls for the task status, and fixes a bug in the follow_logs function.