### PR TITLE
Fix bug with processing of Visual Frames 

### DIFF
--- a/inductiva/utils/visualization.py
+++ b/inductiva/utils/visualization.py
@@ -2,7 +2,6 @@
 
 import os
 import tempfile
-import pathlib
 from typing import Dict, List, Optional
 
 from absl import logging


### PR DESCRIPTION
This PR fixes a small bug that was occurring with the processing of the vtk frame files in the new visualizations from pyvista.

I was using `pathlib.Path(frame_file)` which was working for SplishSPlash, but not for DualSPHysics. I reverted to a previous iteration I had that was completely working, by just using the `os.path.join(vtk_output_dir, frame_file)`. In this case, `frame_file` is obtained with sorting function, which outputs a list with ordered files inside the given folder.

Simulations with both SplishSPlash and DualSPH are now smooth!