### PR TITLE
Fix file format

### DIFF
--- a/inductiva/design.py
+++ b/inductiva/design.py
@@ -30,13 +30,14 @@ def explore_design_space(simulator: Simulator,
         extra_sim_kwargs: Extra keyword arguments to pass to the simulator.
     """
     input_dir = pathlib.Path(input_dir)
+    file_format = os.path.splitext(template_filename)[1]
 
     logging.info("Exploring design space for attribute \"%s\".", tag)
 
     for value in values:
         logging.info("Running simulation for %s=%s.", tag, value)
 
-        input_filename = f"input_file_{value}.sws"
+        input_filename = f"input_file_{value}{file_format}"
         input_file = os.path.join(input_dir, input_filename)
 
         templates.replace_params_in_template(


### PR DESCRIPTION
In this PR, I fix the file format on the explore_design_space function, that was fixed for ".sws" by mistake. As such, we read the file format from the template file and add it at the end of the new input file.