### PR TITLE
Resolve vtk_dir to use working dir

### DIFF
--- a/inductiva/utils/visualization.py
+++ b/inductiva/utils/visualization.py
@@ -98,7 +98,8 @@ def create_movie_from_vtk(vtk_output_dir: str,
         pv.start_xvfb()
 
     pv.global_theme.background = "white"
-
+    
+    vtk_output_dir = files.resolve_path(vtk_ouput_dir)
     vtk_files = get_sorted_files(vtk_output_dir, ".vtk")
 
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/inductiva/utils/visualization.py
+++ b/inductiva/utils/visualization.py
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 from tqdm import tqdm
 import xarray as xr
 
-from inductiva.utils.files import get_sorted_files
+from inductiva.utils import files
 
 MPL_CONFIG_PARAMS = {
     "font.size": 14,
@@ -99,7 +99,7 @@ def create_movie_from_vtk(vtk_output_dir: str,
 
     pv.global_theme.background = "white"
     vtk_output_dir = files.resolve_path(vtk_output_dir)
-    vtk_files = get_sorted_files(vtk_output_dir, ".vtk")
+    vtk_files = files.get_sorted_files(vtk_output_dir, ".vtk")
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         logging.info("Creating movie frames...")

--- a/inductiva/utils/visualization.py
+++ b/inductiva/utils/visualization.py
@@ -98,8 +98,7 @@ def create_movie_from_vtk(vtk_output_dir: str,
         pv.start_xvfb()
 
     pv.global_theme.background = "white"
-    
-    vtk_output_dir = files.resolve_path(vtk_ouput_dir)
+    vtk_output_dir = files.resolve_path(vtk_output_dir)
     vtk_files = get_sorted_files(vtk_output_dir, ".vtk")
 
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
The path `vtk_output_dir` in the pyvista visualizations was not yet resolved to be attached to the working dir. This PR serves for just that.