### PR TITLE
Fix logging status on get_task_status function

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -164,7 +164,6 @@ def get_task_status(api_instance: TasksApi, task_id: str) -> TaskStatus:
         path_params={"task_id": task_id})
 
     status = api_response.body["status"]
-    logging.info("Task status: %s", status)
 
     return status
 

--- a/inductiva/tasks/methods.py
+++ b/inductiva/tasks/methods.py
@@ -21,6 +21,7 @@ def get_task_status(task_id: str):
         api_instance = TasksApi(client)
 
         status = api.get_task_status(api_instance, task_id)
+    logging.info("Task status: %s", status)
 
     return status
 


### PR DESCRIPTION
This removes the logging of the status on the `api.get_task_status` since that would lead to multiple logging messages of the status over the sync and async calls. 

The status is already processed in the sync functions calls, so we are not removing any logging information with this.