### PR TITLE
Add batch template for multiple files

### DIFF
--- a/inductiva/utils/templates.py
+++ b/inductiva/utils/templates.py
@@ -1,6 +1,6 @@
 """Utils related to template files."""
 
-from typing import Dict
+from typing import Dict, List
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -17,3 +17,30 @@ def replace_params_in_template(
     template = environment.get_template(template_filename)
     stream = template.stream(**params)
     stream.dump(output_file_path)
+
+
+def batch_replace_params_in_template(
+    templates_dir: str,
+    template_filename_paths: List[str],
+    params: Dict,
+    output_filename_paths: List[str],
+) -> None:
+    """Replaces parameters in a set of template files.
+    
+    For some simulators, more than one file needs to be changed.
+    Moreover, some parameters are altered in different input files.
+    To simplify, we can do a batch change for the same params dict.
+
+    Args:
+        templates_dir: Directory with the template files.
+        template_filename_paths: List containing all template files to
+            be changed.
+        params: Dictionary of params that are inserted in the template
+            files.
+        output_filename_paths: List containing the output files in regard of
+            the template files.
+    """
+
+    for index, template_filename in enumerate(template_filename_paths):
+        replace_params_in_template(templates_dir, template_filename, params,
+                                   output_filename_paths[index])

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ meshio
 vtk
 xarray
 matplotlib
+imageio
 pyvista
 imageio-ffmpeg
 ipython

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     gmsh
     meshio
     vtk
+    imageio
     pyvista
     imageio-ffmpeg
     ipython


### PR DESCRIPTION
As a requirement for further scenarios we may need to iterate with multiple template files to start a simulation.

In this sense, to not use `replace_params_in_template` multiple times when defining the scenario functions, this function brings this capability directly in the `templates.py`.