### PR TITLE
Add visualization capabilities to the WindTunnel scenario

### DIFF
--- a/inductiva/fluids/scenarios/_openfoam_post_processing.py
+++ b/inductiva/fluids/scenarios/_openfoam_post_processing.py
@@ -1,4 +1,10 @@
-"""Post process OpenFOAM simulation outputs."""
+"""Post process OpenFOAM simulation outputs.
+
+Visualization Features:
+- Scalar fields over object.
+- Streamlines with scalar field coloring
+- Cutting plane with scalar field coloring.
+"""
 import os
 import pyvista as pv
 
@@ -58,6 +64,8 @@ class OpenFOAMSimulationOutput:
                            time_step: int,
                            scalars: str = "p"):
         """Render streamlines flowing by object with scalar color map.
+
+        The streamlines are immediately obtained as outputs of 
         
         Args:
             time_step: The time frame for which we want to plot

--- a/inductiva/fluids/scenarios/_openfoam_post_processing.py
+++ b/inductiva/fluids/scenarios/_openfoam_post_processing.py
@@ -12,6 +12,7 @@ from inductiva.types import Path
 
 
 class OpenFOAMSimulationOutput:
+    """Post process WindTunnel simulation outputs."""
 
     def __init__(self, sim_output_path: Path):
         """Initializes a `OpenFOAMSimulationOutput` object.

--- a/inductiva/fluids/scenarios/_openfoam_post_processing.py
+++ b/inductiva/fluids/scenarios/_openfoam_post_processing.py
@@ -1,0 +1,119 @@
+"""Post process OpenFOAM simulation outputs."""
+import os
+import pyvista as pv
+
+from inductiva.types import Path
+
+
+class OpenFOAMSimulationOutput:
+
+    def __init__(self, sim_output_path: Path):
+        """Initializes a `OpenFOAMSimulationOutput` object.
+
+        Args:
+            sim_output_path: Path to simulation output files.
+        
+        Attributes:
+            sim_output_dir: path to the simulation directory
+            object_path: path to the object insert in the WindTunnel
+            post_processing_path: path to the post-processing data.
+        """
+
+        self.sim_output_dir = sim_output_path
+        self.object_path = os.path.join(
+            sim_output_path, "constant",
+            "triSurface", "object.obj")
+        self.post_processing_path = os.path.join(
+            sim_output_path, "postProcessing")
+
+    def render_scalar_field(self,
+                            time_step: int,
+                            scalars: str ="p"):
+        """Render a scalar field over an object from OpenFOAM data.
+        
+        Args:
+            time_step: The time frame for which we want to plot
+                the scalar field over the object.
+            scalars: The scalar field to plot. Meaningfull ones are
+                the pressure "p" and velocity magnitude "U".
+        """
+
+        reading_file = os.path.join(self.sim_output_dir,
+                                    "foam.foam")
+
+        # Create the reading file for the WindTunnel scenarios
+        open(reading_file, "w", encoding="utf-8").close()
+
+        # Initialize reader and define reading time-step
+        reader = pv.POpenFOAMReader(reading_file)
+        reader.set_active_time_value(time_step)
+
+        # Read mesh and mesh properties
+        mesh = reader.read()
+        object_mesh = mesh[1][5:]
+
+        object_mesh.plot(scalars=scalars)
+
+    def render_streamlines(self,
+                           time_step: int,
+                           scalars: str = "p"):
+        """Render streamlines flowing by object with scalar color map.
+        
+        Args:
+            time_step: The time frame for which we want to plot
+                the scalar field over the object.
+            scalars: The scalar field used to color the streamlines.
+                Meaningfull ones are the pressure "p"
+                and velocity magnitude "U".
+        """
+
+        object_mesh = pv.read(self.object_path)
+
+        streamlines_path = os.path.join(
+            self.post_processing_path, "sets", "streamLines",
+            str(time_step))
+
+        streamlines_file = "track0_" + scalars + ".vtk"
+        streamlines_mesh = pv.read(os.path.join(streamlines_path,
+                                           streamlines_file))
+
+        plot = pv.Plotter()
+        plot.add_mesh(streamlines_mesh, scalars=scalars)
+        plot.add_mesh(object_mesh)
+
+        plot.show()
+
+    def render_cutting_plane(self,
+                             time_step: int,
+                             scalars: str = "p"):
+        """Render the cutting plane obtain from the simulation.
+        
+        The cutting plane contains the scalar field properties over
+        a plane over the domain. It is easier to see some of the
+        properties of the flow.
+
+        For now the only cutting plane being computed is orthogonal to
+        the y-axis.
+
+        Args:
+            time_step: The time frame for which we want to plot
+                the scalar field over the object.
+            scalars: The scalar field used to color the streamlines.
+                Meaningfull ones are the pressure "p"
+                and velocity magnitude "U".
+        """
+        object_mesh = pv.read(self.object_path)
+
+        cutting_plane_path = os.path.join(
+            self.post_processing_path, "cuttingPlane",
+            str(time_step))
+
+        cutting_plane_file = scalars + "_yNormal.vtk"
+        cutting_plane_mesh = pv.read(os.path.join(
+            cutting_plane_path, cutting_plane_file))
+
+        plot = pv.Plotter()
+        plot.add_mesh(cutting_plane_mesh, scalars=scalars)
+        plot.add_mesh(object_mesh)
+
+        plot.show()

--- a/inductiva/fluids/scenarios/templates/wind_tunnel/openfoam/system/streamLines
+++ b/inductiva/fluids/scenarios/templates/wind_tunnel/openfoam/system/streamLines
@@ -23,7 +23,7 @@ streamLines
     direction       forward;
 
     // Names of fields to sample. Should contain above velocity field!
-    fields (p U k);
+    fields (p U);
 
     // Steps particles can travel before being removed
     lifeTime        10000;

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -13,9 +13,11 @@ from inductiva.simulation import Simulator
 from inductiva.fluids.simulators import OpenFOAM
 from inductiva.utils.templates import batch_replace_params_in_template
 from inductiva.utils.files import remove_files_with_tag
+from inductiva.fluids.scenarios._openfoam_post_processing import OpenFOAMSimulationOutput
 
-OPENFOAM_TEMPLATE_INPUT_DIR = "openfoam_template"
-
+SCENARIO_TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "..",
+                                     "templates", "wind_tunnel")
+OPENFOAM_TEMPLATE_INPUT_DIR = "openfoam"
 
 class WindTunnel(Scenario):
     """Physical scenario of a configurable wind tunnel simulation.
@@ -76,7 +78,7 @@ class WindTunnel(Scenario):
             openfoam_solver="simpleFoam",
         )
 
-        return output_path
+        return OpenFOAMSimulationOutput(output_path)
 
     @singledispatchmethod
     @classmethod
@@ -105,7 +107,7 @@ def _(self, simulator: OpenFOAM):  # pylint: disable=unused-argument
 @WindTunnel.gen_aux_files.register
 def _(self, simulator: OpenFOAM, input_dir):  # pylint: disable=unused-argument
     # The WindTunnel with OpenFOAM requires changing multiple files
-    template_dir = os.path.join(os.path.dirname(__file__),
+    template_dir = os.path.join(SCENARIO_TEMPLATE_DIR,
                                 OPENFOAM_TEMPLATE_INPUT_DIR)
 
     # Copy all files from the template dir to the input directory
@@ -122,12 +124,14 @@ def _(self, simulator: OpenFOAM, input_dir: str):  # pylint: disable=unused-argu
     """Generates the configuration files for OpenFOAM."""
 
     # The WindTunnel with OpenFOAM requires changing multiple files
-    template_dir = os.path.join(os.path.dirname(__file__),
+    template_dir = os.path.join(SCENARIO_TEMPLATE_DIR,
                                 OPENFOAM_TEMPLATE_INPUT_DIR)
 
     # Add object path to its respective place
+    object_input_dir_path = os.path.join(input_dir, "constant", "triSurface")
+    os.mkdir(object_input_dir_path)
     shutil.copy(self.object_path,
-                os.path.join(input_dir, "constant/triSurface", "object.obj"))
+                os.path.join(object_input_dir_path, "object.obj"))
 
     batch_replace_params_in_template(
         templates_dir=template_dir,
@@ -141,7 +145,7 @@ def _(self, simulator: OpenFOAM, input_dir: str):  # pylint: disable=unused-argu
         params={
             "flow_velocity": self.flow_velocity,
             "simulation_time": self.simulation_time,
-            "write_interval": self.write_interval,
+            "output_time_step": self.output_time_step,
             "n_cores": self.n_cores,
             "domain": self.domain,
         },


### PR DESCRIPTION
This PR implements some visualizations capabilities for the WindTunnel scenario. 

Recall, OpenFOAM already provides post-processing features and the respective outputs are provided with the rest of the simulation results. In particular, we are providing: streamLines, cutting planes and force coefficients.

With this in mind, we use `pyvista` to implement visualization capabilities that allow users to understand the flow over the object in the WindTunnel. We point three main visualizations:
- scalar fields over the object surface;
- streamlines with scalar field coloring;
- cutting plane with scalar field coloring.

These visualizations aren't neither specific of the WindTunnel scenario or general enough for all OpenFOAM possible simulations. Due to this, the  implementation was done via the class `OpenFOAMSimulationOutput` analogously to what was done with SPH scenarios. 
In this way, after receiving the outputs with `output = scenario.simulate(...)` users can immediately render their results with `output.render_streamlines(time_step=10, scalars="p")`. 

We may want to refactor this methodology in the near future, but I leave it like this to fit the WindTunnel scenario.