### PR TITLE
Async Sim for WindTunnel Scenario

### DIFF
--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -48,7 +48,7 @@ class WindTunnel(Scenario):
             self.domain = domain
 
     def simulate(self,
-                 object_path: str,
+                 object_path: Path,
                  simulator: Simulator = OpenFOAM(),
                  output_dir: Optional[Path] = None,
                  simulation_time: float = 100,
@@ -65,6 +65,7 @@ class WindTunnel(Scenario):
             write_interval: Interval between simulation outputs, in seconds.
             n_cores: Number of cores to use for the simulation.
             """
+
         self.object_path = object_path
         self.simulation_time = simulation_time
         self.output_time_step = output_time_step
@@ -80,7 +81,7 @@ class WindTunnel(Scenario):
         return output_path
 
     def simulate_async(self,
-                       object_path: str,
+                       object_path: Path,
                        simulator: Simulator = OpenFOAM(),
                        simulation_time: float = 100,
                        output_time_step: float = 50,

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -48,8 +48,8 @@ class WindTunnel(Scenario):
             self.domain = domain
 
     def simulate(self,
-                 object_path: Path,
                  simulator: Simulator = OpenFOAM(),
+                 object_path: Optional[Path] = None,
                  output_dir: Optional[Path] = None,
                  simulation_time: float = 100,
                  output_time_step: float = 50,
@@ -66,7 +66,11 @@ class WindTunnel(Scenario):
             n_cores: Number of cores to use for the simulation.
             """
 
-        self.object_path = object_path
+        if object_path:
+            self.object_path = object_path
+        else:
+            logging.info("WindTunnel is empty. Object path not specified.")
+
         self.simulation_time = simulation_time
         self.output_time_step = output_time_step
         self.n_cores = n_cores
@@ -81,8 +85,8 @@ class WindTunnel(Scenario):
         return output_path
 
     def simulate_async(self,
-                       object_path: Path,
                        simulator: Simulator = OpenFOAM(),
+                       object_path: Optional[Path] = None,
                        simulation_time: float = 100,
                        output_time_step: float = 50,
                        n_cores: int = 1):
@@ -97,7 +101,12 @@ class WindTunnel(Scenario):
             write_interval: Interval between simulation outputs, in seconds.
             n_cores: Number of cores to use for the simulation.
             """
-        self.object_path = object_path
+
+        if object_path:
+            self.object_path = object_path
+        else:
+            logging.info("WindTunnel is empty. Object path not specified.")
+
         self.simulation_time = simulation_time
         self.output_time_step = output_time_step
         self.n_cores = n_cores

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -49,8 +49,8 @@ class WindTunnel(Scenario):
 
     def simulate(self,
                  simulator: Simulator = OpenFOAM(),
-                 object_path: Optional[Path] = None,
                  output_dir: Optional[Path] = None,
+                 object_path: Optional[Path] = None,
                  simulation_time: float = 100,
                  output_time_step: float = 50,
                  n_cores: int = 1):

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -28,20 +28,17 @@ class WindTunnel(Scenario):
     """
 
     def __init__(self,
-                 object_path: str,
                  flow_velocity: List[float],
                  domain: Optional[List[float]] = None):
-        """Initializes a `WindTunnel` object.
+        """Initializes the `WindTunnel` conditions.
         
         Args:
-            object_path: Path to the object that is inserted in the wind tunnel.
             flow_velocity: Velocity of the air flow in m/s.
             domain: List containing the lower and upper boundary of the wind
                 tunnel in each (x, y, z) direction. It is the natural
                 description with the default OpenFOAM simulator.
         """
 
-        self.object_path = object_path
         self.flow_velocity = flow_velocity
 
         if domain is None:
@@ -51,14 +48,16 @@ class WindTunnel(Scenario):
             self.domain = domain
 
     def simulate(self,
+                 object_path: str,
                  simulator: Simulator = OpenFOAM(),
                  output_dir: Optional[Path] = None,
                  simulation_time: float = 100,
                  output_time_step: float = 50,
                  n_cores: int = 1):
-        """Simulates the wind tunnel scenario.
+        """Simulates the wind tunnel scenario synchronously.
         
         Args:
+            object_path: Path to object inserted in the wind tunnel.
             simulator: Simulator to use for the simulation.
             output_dir: Path to the directory where the simulation output
                 is downloaded.
@@ -66,7 +65,7 @@ class WindTunnel(Scenario):
             write_interval: Interval between simulation outputs, in seconds.
             n_cores: Number of cores to use for the simulation.
             """
-
+        self.object_path = object_path
         self.simulation_time = simulation_time
         self.output_time_step = output_time_step
         self.n_cores = n_cores
@@ -79,6 +78,36 @@ class WindTunnel(Scenario):
         )
 
         return output_path
+
+    def simulate_async(self,
+                       object_path: str,
+                       simulator: Simulator = OpenFOAM(),
+                       simulation_time: float = 100,
+                       output_time_step: float = 50,
+                       n_cores: int = 1):
+        """Simulates the wind tunnel scenario asynchronously.
+        
+        Args:
+            object_path: Path to object inserted in the wind tunnel.
+            simulator: Simulator to use for the simulation.
+            output_dir: Path to the directory where the simulation output
+                is downloaded.
+            simulation_time: Simulation time, in seconds.
+            write_interval: Interval between simulation outputs, in seconds.
+            n_cores: Number of cores to use for the simulation.
+            """
+        self.object_path = object_path
+        self.simulation_time = simulation_time
+        self.output_time_step = output_time_step
+        self.n_cores = n_cores
+
+        task_id = super().simulate_async(
+            simulator,
+            n_cores=n_cores,
+            openfoam_solver="simpleFoam",
+        )
+
+        return task_id
 
     @singledispatchmethod
     @classmethod

--- a/inductiva/scenarios.py
+++ b/inductiva/scenarios.py
@@ -45,3 +45,28 @@ class Scenario(ABC):
             )
 
         return output_path
+
+    def simulate_async(
+        self,
+        simulator: Simulator,
+        **kwargs,
+    ):
+        """Simulates the scenario asychronously."""
+
+        with tempfile.TemporaryDirectory() as input_dir:
+
+            self.gen_aux_files(simulator, input_dir)
+            self.gen_config(simulator, input_dir)
+
+            args = ()
+            config_filename = self.get_config_filename(simulator)
+            if config_filename:
+                args += (config_filename,)
+
+            task_id = simulator.run_async(
+                input_dir,
+                *args,
+                **kwargs,
+            )
+
+        return task_id


### PR DESCRIPTION
This PR introduces the async runs for the WindTunnel scenario. The implementation follows the one for the low-level, where two separate functions where established for sync and async simulation. The main reason for this is that the inputs and outputs differ slightly in nature.

Moreover, this PR also changes the WindTunnel definition, which came to light during the development of the async run. Now, the object is only established on the simulation part and not on the definition of the scenario. The reason is clear, since the object is the central piece of this scenario we want to change it between runs, even though we keep the domain fixed.