### PR TITLE
Addition of WindTunnel Executer

### DIFF
--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -48,7 +48,7 @@ class WindTunnel(Scenario):
             self.domain = domain
 
     def simulate(self,
-                 simulator: Simulator = OpenFOAM(),
+                 simulator: Simulator = OpenFOAM("windtunnel.openfoam.run_simulation"),
                  output_dir: Optional[Path] = None,
                  object_path: Optional[Path] = None,
                  simulation_time: float = 100,
@@ -79,13 +79,13 @@ class WindTunnel(Scenario):
             simulator,
             output_dir=output_dir,
             n_cores=n_cores,
-            openfoam_solver="simpleFoam",
+            method_name="simpleFoam",
         )
 
         return output_path
 
     def simulate_async(self,
-                       simulator: Simulator = OpenFOAM(),
+                       simulator: Simulator = OpenFOAM("windtunnel.openfoam.run_simulation"),
                        object_path: Optional[Path] = None,
                        simulation_time: float = 100,
                        output_time_step: float = 50,
@@ -114,7 +114,7 @@ class WindTunnel(Scenario):
         task_id = super().simulate_async(
             simulator,
             n_cores=n_cores,
-            openfoam_solver="simpleFoam",
+            method_name="simpleFoam",
         )
 
         return task_id

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -48,7 +48,8 @@ class WindTunnel(Scenario):
             self.domain = domain
 
     def simulate(self,
-                 simulator: Simulator = OpenFOAM("windtunnel.openfoam.run_simulation"),
+                 simulator: Simulator = OpenFOAM(
+                     "windtunnel.openfoam.run_simulation"),
                  output_dir: Optional[Path] = None,
                  object_path: Optional[Path] = None,
                  simulation_time: float = 100,
@@ -85,7 +86,8 @@ class WindTunnel(Scenario):
         return output_path
 
     def simulate_async(self,
-                       simulator: Simulator = OpenFOAM("windtunnel.openfoam.run_simulation"),
+                       simulator: Simulator = OpenFOAM(
+                           "windtunnel.openfoam.run_simulation"),
                        object_path: Optional[Path] = None,
                        simulation_time: float = 100,
                        output_time_step: float = 50,

--- a/inductiva/fluids/simulators/openfoam.py
+++ b/inductiva/fluids/simulators/openfoam.py
@@ -9,15 +9,19 @@ from inductiva.simulation import Simulator
 class OpenFOAM(Simulator):
     """Class to invoke a generic DualSPHysics simulation on the API."""
 
+    def __init__(self, api_method: str = "fvm.openfoam.run_simulation"):
+        super().__init__()
+        self.api_method = api_method
+
     @property
     def api_method_name(self) -> str:
-        return "fvm.openfoam.run_simulation"
+        return self.api_method
 
     def run(
         self,
         input_dir: types.Path,
+        method_name: str,
         output_dir: Optional[types.Path] = None,
-        openfoam_solver: str = "interFoam",
         n_cores: int = 1,
         track_logs: bool = False,
     ) -> pathlib.Path:
@@ -35,14 +39,14 @@ class OpenFOAM(Simulator):
             input_dir,
             output_dir=output_dir,
             track_logs=track_logs,
-            openfoam_solver=openfoam_solver,
+            method_name=method_name,
             n_cores=n_cores,
         )
 
     def run_async(
         self,
         input_dir: types.Path,
-        openfoam_solver: str = "interFoam",
+        method_name: str,
         n_cores: int = 1,
     ) -> str:
         """Run the simulation asynchronously.
@@ -57,5 +61,5 @@ class OpenFOAM(Simulator):
             """
 
         return super().run_async(input_dir,
-                                 openfoam_solver=openfoam_solver,
+                                 method_name=method_name,
                                  n_cores=n_cores)

--- a/inductiva/fluids/simulators/openfoam.py
+++ b/inductiva/fluids/simulators/openfoam.py
@@ -35,14 +35,12 @@ class OpenFOAM(Simulator):
             openfoam_flags: Flags to pass to the openfoam method_name.
             other arguments: See the documentation of the base class.
         """
-        return super().run(
-            input_dir,
-            output_dir=output_dir,
-            track_logs=track_logs,
-            method_name=method_name,
-            n_cores=n_cores,
-            user_flags=openfoam_flags
-        )
+        return super().run(input_dir,
+                           output_dir=output_dir,
+                           track_logs=track_logs,
+                           method_name=method_name,
+                           n_cores=n_cores,
+                           user_flags=openfoam_flags)
 
     def run_async(
         self,

--- a/inductiva/fluids/simulators/openfoam.py
+++ b/inductiva/fluids/simulators/openfoam.py
@@ -24,15 +24,15 @@ class OpenFOAM(Simulator):
         output_dir: Optional[types.Path] = None,
         n_cores: int = 1,
         track_logs: bool = False,
+        **openfoam_flags: Optional[str],
     ) -> pathlib.Path:
         """Run the simulation.
 
         Args:
             n_cores: Number of MPI cores to use for the simulation.
-            openfoam_solver: specific solver to simulate with OpenFOAM.
-                OpenFOAM contains lots of solvers inside of it, which are used
-                to call the run simulation through terminal, e.g.,
-                [isoFoam, sonicFoam, ...]. The default solver is interFoam.
+            method_name: OpenFOAM method to run. This involves commands
+                from pre-processing, to solvers and post-processing.
+            openfoam_flags: Flags to pass to the openfoam method_name.
             other arguments: See the documentation of the base class.
         """
         return super().run(
@@ -41,6 +41,7 @@ class OpenFOAM(Simulator):
             track_logs=track_logs,
             method_name=method_name,
             n_cores=n_cores,
+            user_flags=openfoam_flags
         )
 
     def run_async(
@@ -48,18 +49,19 @@ class OpenFOAM(Simulator):
         input_dir: types.Path,
         method_name: str,
         n_cores: int = 1,
+        **openfoam_flags: Optional[str],
     ) -> str:
         """Run the simulation asynchronously.
         
         Args:
             n_cores: Number of MPI cores to use for the simulation.
-            openfoam_solver: specific solver to simulate with OpenFOAM.
-                OpenFOAM contains lots of solvers inside of it, which are used
-                to call the run simulation through terminal, e.g.,
-                [isoFoam, sonicFoam, ...]. The default solver is interFoam.
+            method_name: OpenFOAM method to run. This involves commands
+                from pre-processing, to solvers and post-processing.
+            openfoam_flags: Flags to pass to the openfoam method_name.
             other arguments: See the documentation of the base class.
             """
 
         return super().run_async(input_dir,
                                  method_name=method_name,
-                                 n_cores=n_cores)
+                                 n_cores=n_cores,
+                                 user_flags=openfoam_flags)


### PR DESCRIPTION
This PR implements connects the WindTunnel scenario simulation to its own executer on the backend. In practice, we just need to change on the client the name of the api_method to call on the backend, which is changed inside the scenario without users configuration. In this sense, no interference occurs on the user side!

Previously, the backend for OpenFOAM was hard-coded to support simulations of the WindTunnel. However, this implies that no other CFD simulations can be run with OpenFOAM. The next step is to add the low-level implementation of OpenFOAM to run all possible/available commands (like GROMACs) through the use of the Commands&Flags methodology.

A PR on the backend will follow!

Disclaimer: The perfect solution we are working towards is a Pipe of commands run always under the same input folder. However, this will still take some time and practical discussion. Therefore, in the meantime we do not compromise both the low-level and the WindTunnel.