### PR TITLE
Add resource pool ID to simulate calls/Remove track logs functionality

### DIFF
--- a/inductiva/fluids/scenarios/dam_break/dam_break.py
+++ b/inductiva/fluids/scenarios/dam_break/dam_break.py
@@ -2,6 +2,7 @@
 from typing import List, Literal, Optional
 from enum import Enum
 from dataclasses import dataclass
+from uuid import UUID
 
 from inductiva.simulation import Simulator
 from inductiva.fluids.simulators import DualSPHysics
@@ -53,6 +54,7 @@ class DamBreak(FluidBlock):
         self,
         simulator: Simulator = DualSPHysics(),
         output_dir: Optional[Path] = None,
+        resource_pool_id: Optional[UUID] = None,
         device: Literal["cpu", "gpu"] = "gpu",
         resolution: Literal["high", "medium", "low"] = "medium",
         simulation_time: float = 1,
@@ -71,6 +73,7 @@ class DamBreak(FluidBlock):
 
         sim_output_path = super().simulate(simulator=simulator,
                                            output_dir=output_dir,
+                                           resource_pool_id=resource_pool_id,
                                            device=device,
                                            particle_radius=particle_radius,
                                            simulation_time=simulation_time)

--- a/inductiva/fluids/scenarios/fluid_block/fluid_block.py
+++ b/inductiva/fluids/scenarios/fluid_block/fluid_block.py
@@ -4,6 +4,7 @@ from functools import singledispatchmethod
 import os
 from typing import List, Literal, Optional
 import shutil
+from uuid import UUID
 
 from inductiva.types import Path
 from inductiva.scenarios import Scenario
@@ -68,6 +69,7 @@ class FluidBlock(Scenario):
         self,
         simulator: Simulator = DualSPHysics(),
         output_dir: Optional[Path] = None,
+        resource_pool_id: Optional[UUID] = None,
         device: Literal["cpu", "gpu"] = "gpu",
         particle_radius: float = 0.02,
         simulation_time: float = 1,
@@ -101,6 +103,7 @@ class FluidBlock(Scenario):
         output_path = super().simulate(
             simulator,
             output_dir=output_dir,
+            resource_pool_id=resource_pool_id,
             device=device,
         )
 

--- a/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
+++ b/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
@@ -5,6 +5,7 @@ from enum import Enum
 from functools import singledispatchmethod
 import os
 from typing import List, Literal, Optional
+from uuid import UUID
 
 from inductiva.types import Path
 from inductiva.scenarios import Scenario
@@ -148,6 +149,7 @@ class FluidTank(Scenario):
         self,
         simulator: Simulator = SPlisHSPlasH(),
         output_dir: Optional[Path] = None,
+        resource_pool_id: Optional[UUID] = None,
         device: Literal["cpu", "gpu"] = "cpu",
         simulation_time: float = 5,
         resolution: Literal["low", "medium", "high"] = "low",
@@ -176,6 +178,7 @@ class FluidTank(Scenario):
         output_path = super().simulate(
             simulator,
             output_dir=output_dir,
+            resource_pool_id=resource_pool_id,
             device=device,
         )
 

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -6,6 +6,7 @@ import shutil
 from typing import Optional, List, Literal
 from enum import Enum
 from dataclasses import dataclass
+from uuid import UUID
 
 from absl import logging
 
@@ -31,7 +32,7 @@ class MeshResolution(Enum):
 
 class WindTunnel(Scenario):
     """Physical scenario of a configurable wind tunnel simulation.
-    
+
     In this scenario, an object is inserted in a wind tunnel described by the
     user. The object is then subject to an air flow determined for which the
     direction and magnitude is defined by the user.
@@ -41,7 +42,7 @@ class WindTunnel(Scenario):
                  flow_velocity: List[float] = None,
                  domain: Optional[dict] = None):
         """Initializes the `WindTunnel` conditions.
-        
+
         Args:
             flow_velocity (dict): Velocity of the air flow in m/s.
             domain (dict): List containing the lower and upper boundary of
@@ -71,13 +72,14 @@ class WindTunnel(Scenario):
                  simulator: Simulator = OpenFOAM(
                      "windtunnel.openfoam.run_simulation"),
                  output_dir: Optional[Path] = None,
+                 resource_pool_id: Optional[UUID] = None,
                  object_path: Optional[Path] = None,
                  simulation_time: float = 100,
                  output_time_step: float = 50,
                  resolution: Literal["high", "medium", "low"] = "medium",
                  n_cores: int = 1):
         """Simulates the wind tunnel scenario synchronously.
-        
+
         Args:
             object_path: Path to object inserted in the wind tunnel.
             simulator: Simulator to use for the simulation.
@@ -101,6 +103,7 @@ class WindTunnel(Scenario):
         output_path = super().simulate(
             simulator,
             output_dir=output_dir,
+            resource_pool_id=resource_pool_id,
             n_cores=n_cores,
             method_name="simpleFoam",
         )
@@ -110,13 +113,14 @@ class WindTunnel(Scenario):
     def simulate_async(self,
                        simulator: Simulator = OpenFOAM(
                            "windtunnel.openfoam.run_simulation"),
+                       resource_pool_id: Optional[UUID] = None,
                        object_path: Optional[Path] = None,
                        simulation_time: float = 100,
                        output_time_step: float = 50,
                        resolution: Literal["high", "medium", "low"] = "medium",
                        n_cores: int = 1):
         """Simulates the wind tunnel scenario asynchronously.
-        
+
         Args:
             object_path: Path to object inserted in the wind tunnel.
             simulator: Simulator to use for the simulation.
@@ -139,6 +143,7 @@ class WindTunnel(Scenario):
 
         task_id = super().simulate_async(
             simulator,
+            resource_pool_id=resource_pool_id,
             n_cores=n_cores,
             method_name="simpleFoam",
         )

--- a/inductiva/fluids/simulators/dualsphysics.py
+++ b/inductiva/fluids/simulators/dualsphysics.py
@@ -1,6 +1,7 @@
 """DualSPHysics module of the API."""
 import pathlib
 from typing import Literal, Optional
+from uuid import UUID
 
 from inductiva import types
 from inductiva.simulation import Simulator
@@ -19,7 +20,7 @@ class DualSPHysics(Simulator):
         sim_config_filename: str,
         output_dir: Optional[types.Path] = None,
         device: Literal["gpu", "cpu"] = "cpu",
-        track_logs: bool = False,
+        resource_pool_id: Optional[UUID] = None,
     ) -> pathlib.Path:
         """Run the simulation.
 
@@ -30,7 +31,7 @@ class DualSPHysics(Simulator):
         """
         return super().run(input_dir,
                            output_dir=output_dir,
-                           track_logs=track_logs,
+                           resource_pool_id=resource_pool_id,
                            device=device,
                            input_filename=sim_config_filename)
 
@@ -39,9 +40,10 @@ class DualSPHysics(Simulator):
         input_dir: types.Path,
         sim_config_filename: str,
         device: Literal["gpu", "cpu"] = "cpu",
+        resource_pool_id: Optional[UUID] = None,
     ) -> str:
         """Run the simulation asynchronously.
-        
+
         Args:
             sim_config_filename: Name of the simulation configuration file.
             device: Device in which to run the simulation.
@@ -49,5 +51,6 @@ class DualSPHysics(Simulator):
             """
 
         return super().run_async(input_dir,
+                                 resource_pool_id=resource_pool_id,
                                  device=device,
                                  input_filename=sim_config_filename)

--- a/inductiva/fluids/simulators/openfoam.py
+++ b/inductiva/fluids/simulators/openfoam.py
@@ -1,6 +1,7 @@
 """OpenFOAM module of the API for fluid dynamics."""
 import pathlib
 from typing import Optional, List
+from uuid import UUID
 
 from inductiva import types
 from inductiva.simulation import Simulator
@@ -22,8 +23,8 @@ class OpenFOAM(Simulator):
         input_dir: types.Path,
         commands: List[dict],
         output_dir: Optional[types.Path] = None,
+        resource_pool_id: Optional[UUID] = None,
         n_cores: int = 1,
-        track_logs: bool = False,
     ) -> pathlib.Path:
         """Run the simulation.
 
@@ -35,8 +36,8 @@ class OpenFOAM(Simulator):
         return super().run(
             input_dir,
             output_dir=output_dir,
+            resource_pool_id=resource_pool_id,
             n_cores=n_cores,
-            track_logs=track_logs,
             commands=commands,
         )
 
@@ -44,11 +45,12 @@ class OpenFOAM(Simulator):
         self,
         input_dir: types.Path,
         method_name: str,
+        resource_pool_id: Optional[UUID] = None,
         n_cores: int = 1,
         **openfoam_flags: Optional[str],
     ) -> str:
         """Run the simulation asynchronously.
-        
+
         Args:
             n_cores: Number of MPI cores to use for the simulation.
             method_name: OpenFOAM method to run. This involves commands
@@ -58,6 +60,7 @@ class OpenFOAM(Simulator):
             """
 
         return super().run_async(input_dir,
+                                 resource_pool_id=resource_pool_id,
                                  method_name=method_name,
                                  n_cores=n_cores,
                                  user_flags=openfoam_flags)

--- a/inductiva/fluids/simulators/splishsplash.py
+++ b/inductiva/fluids/simulators/splishsplash.py
@@ -1,6 +1,7 @@
 """DualSPHysics module of the API."""
 import pathlib
 from typing import Literal, Optional
+from uuid import UUID
 
 from inductiva import types
 from inductiva.simulation import Simulator
@@ -18,8 +19,8 @@ class SPlisHSPlasH(Simulator):
         input_dir: types.Path,
         sim_config_filename: str,
         output_dir: Optional[types.Path] = None,
+        resource_pool_id: Optional[UUID] = None,
         device: Literal["gpu", "cpu"] = "cpu",
-        track_logs: bool = False,
     ) -> pathlib.Path:
         """Run the simulation.
 
@@ -31,7 +32,7 @@ class SPlisHSPlasH(Simulator):
         return super().run(
             input_dir,
             output_dir=output_dir,
-            track_logs=track_logs,
+            resource_pool_id=resource_pool_id,
             device=device,
             input_filename=sim_config_filename,
         )
@@ -40,10 +41,11 @@ class SPlisHSPlasH(Simulator):
         self,
         input_dir: types.Path,
         sim_config_filename: str,
+        resource_pool_id: Optional[UUID] = None,
         device: Literal["gpu", "cpu"] = "cpu",
     ) -> str:
         """Run the simulation asynchronously.
-        
+
         Args:
             sim_config_filename: Name of the simulation configuration file.
             device: Device in which to run the simulation.
@@ -51,5 +53,6 @@ class SPlisHSPlasH(Simulator):
             """
 
         return super().run_async(input_dir,
+                                 resource_pool_id=resource_pool_id,
                                  device=device,
                                  input_filename=sim_config_filename)

--- a/inductiva/fluids/simulators/swash.py
+++ b/inductiva/fluids/simulators/swash.py
@@ -1,6 +1,7 @@
 """SWASH module of the API."""
 import pathlib
 from typing import Optional
+from uuid import UUID
 from inductiva.simulation import Simulator
 from inductiva import types
 
@@ -17,8 +18,8 @@ class SWASH(Simulator):
         input_dir: types.Path,
         sim_config_filename: str,
         output_dir: Optional[types.Path] = None,
+        resource_pool_id: Optional[UUID] = None,
         n_cores: int = 1,
-        track_logs: bool = False,
     ) -> pathlib.Path:
         """Run the simulation.
 
@@ -28,7 +29,7 @@ class SWASH(Simulator):
             other arguments: See the documentation of the base class.
         """
         return super().run(input_dir,
-                           track_logs=track_logs,
+                           resource_pool_id=resource_pool_id,
                            input_filename=sim_config_filename,
                            n_cores=n_cores,
                            output_dir=output_dir)
@@ -37,15 +38,17 @@ class SWASH(Simulator):
         self,
         input_dir: types.Path,
         sim_config_filename: str,
+        resource_pool_id: Optional[UUID] = None,
         n_cores: int = 1,
     ) -> str:
         """Run the simulation asynchronously.
-        
+
         Args:
             sim_config_filename: Name of the simulation configuration file.
             n_cores: Number of MPI cores to use for the simulation.
             """
 
         return super().run_async(input_dir,
+                                 resource_pool_id=resource_pool_id,
                                  n_cores=n_cores,
                                  input_filename=sim_config_filename)

--- a/inductiva/fluids/simulators/xbeach.py
+++ b/inductiva/fluids/simulators/xbeach.py
@@ -1,6 +1,7 @@
 """DualSPHysics module of the API."""
 import pathlib
 from typing import Optional
+from uuid import UUID
 
 from inductiva import types
 from inductiva.simulation import Simulator
@@ -18,8 +19,8 @@ class XBeach(Simulator):
         input_dir: types.Path,
         sim_config_filename: Optional[str] = "params.txt",
         output_dir: Optional[types.Path] = None,
+        resource_pool_id: Optional[UUID] = None,
         n_cores: int = 1,
-        track_logs: bool = False,
     ) -> pathlib.Path:
         """Run the simulation.
 
@@ -32,23 +33,25 @@ class XBeach(Simulator):
             input_dir,
             input_filename=sim_config_filename,
             n_cores=n_cores,
-            track_logs=track_logs,
             output_dir=output_dir,
+            resource_pool_id=resource_pool_id,
         )
 
     def run_async(
         self,
         input_dir: types.Path,
+        resource_pool_id: Optional[UUID] = None,
         sim_config_filename: Optional[str] = "params.txt",
         n_cores: int = 1,
     ) -> str:
         """Run the simulation asynchronously.
-        
+
         Args:
             sim_config_filename: Name of the simulation configuration file.
             n_cores: Number of MPI cores to use for the simulation.
             """
 
         return super().run_async(input_dir,
+                                 resource_pool_id=resource_pool_id,
                                  input_filename=sim_config_filename,
                                  n_cores=n_cores)

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -3,6 +3,7 @@ from functools import singledispatchmethod
 from typing import Optional, Literal
 import os
 import shutil
+from uuid import UUID
 
 from inductiva.types import Path
 from inductiva.molecules.simulators import GROMACS
@@ -25,11 +26,11 @@ class ProteinSolvation(Scenario):
         temperature: float = 300,
     ):
         """
-        Scenario constructor for protein solvation based on the GROMACS 
+        Scenario constructor for protein solvation based on the GROMACS
         simulator.
-        The three main steps of this scenario are solvation, energy minimization 
+        The three main steps of this scenario are solvation, energy minimization
         and simulation. The user can control the number of steps used to perform
-        the energy minimization step and the duration, temperature and 
+        the energy minimization step and the duration, temperature and
         integrator used to perform the simulation.
         Args:
             protein_pdb: The path to the protein pdb file.
@@ -44,6 +45,7 @@ class ProteinSolvation(Scenario):
             self,
             simulator: Simulator = GROMACS(),
             output_dir: Optional[Path] = None,
+            resource_pool_id: Optional[UUID] = None,
             simulation_time: float = 10,  # ns
             integrator: Literal["md", "sd", "bd"] = "md",
             nsteps_minim: int = 5000):
@@ -53,15 +55,15 @@ class ProteinSolvation(Scenario):
             output_dir: The output directory to save the simulation results.
             simulation_time: The simulation time in ns.
             integrator: The integrator to use for the simulation. Options:
-                - "md" (Molecular Dynamics): Accurate leap-frog algorithm for 
+                - "md" (Molecular Dynamics): Accurate leap-frog algorithm for
                 integrating Newton's equations of motion.
                 - "sd" (Steepest Descent): Stochastic dynamics integrator with
                 leap-frog scheme.
-                - "bd" (Brownian Dynamics): Euler integrator for Brownian or 
-                position Langevin dynamics. 
-                
-            For more details on the integrators, refer to the GROMACS 
-            documentation at 
+                - "bd" (Brownian Dynamics): Euler integrator for Brownian or
+                position Langevin dynamics.
+
+            For more details on the integrators, refer to the GROMACS
+            documentation at
             https://manual.gromacs.org/current/user-guide/mdp-options.html.
 
             nsteps_minim: Number of steps for energy minimization.
@@ -73,11 +75,15 @@ class ProteinSolvation(Scenario):
         self.nsteps_minim = nsteps_minim
         commands = self.read_commands_from_file(
             os.path.join(self.template_dir, "commands.json"))
-        return super().simulate(simulator, output_dir, commands=commands)
+        return super().simulate(simulator,
+                                output_dir,
+                                resource_pool_id=resource_pool_id,
+                                commands=commands)
 
     def simulate_async(
             self,
             simulator: Simulator = GROMACS(),
+            resource_pool_id: Optional[UUID] = None,
             simulation_time: float = 10,  # ns
             integrator: Literal["md", "sd", "bd"] = "md",
             nsteps_minim: int = 5000):
@@ -86,15 +92,15 @@ class ProteinSolvation(Scenario):
         Args:
             simulation_time: The simulation time in ns.
             integrator: The integrator to use for the simulation. Options:
-                - "md" (Molecular Dynamics): Accurate leap-frog algorithm for 
+                - "md" (Molecular Dynamics): Accurate leap-frog algorithm for
                 integrating Newton's equations of motion.
                 - "sd" (Steepest Descent): Stochastic dynamics integrator with
                 leap-frog scheme.
-                - "bd" (Brownian Dynamics): Euler integrator for Brownian or 
-                position Langevin dynamics. 
-                
-            For more details on the integrators, refer to the GROMACS 
-            documentation at 
+                - "bd" (Brownian Dynamics): Euler integrator for Brownian or
+                position Langevin dynamics.
+
+            For more details on the integrators, refer to the GROMACS
+            documentation at
             https://manual.gromacs.org/current/user-guide/mdp-options.html.
 
             nsteps_minim: Number of steps for energy minimization.
@@ -106,7 +112,9 @@ class ProteinSolvation(Scenario):
         self.nsteps_minim = nsteps_minim
         commands = self.read_commands_from_file(
             os.path.join(self.template_dir, "commands.json"))
-        return super().simulate_async(simulator, commands=commands)
+        return super().simulate_async(simulator,
+                                      resource_pool_id=resource_pool_id,
+                                      commands=commands)
 
     @singledispatchmethod
     def gen_config(self, simulator: Simulator):

--- a/inductiva/molecules/simulators/gromacs.py
+++ b/inductiva/molecules/simulators/gromacs.py
@@ -2,6 +2,7 @@
 
 import pathlib
 from typing import Optional, List
+from uuid import UUID
 
 from inductiva import types
 from inductiva.simulation import Simulator
@@ -18,28 +19,27 @@ class GROMACS(Simulator):
         self,
         input_dir: types.Path,
         commands: List[dict],
-        track_logs: bool = False,
         output_dir: Optional[types.Path] = None,
+        resource_pool_id: Optional[UUID] = None,
     ) -> pathlib.Path:
         """Run a list of GROMACS commands.
 
         Args:
             input_dir: Path to the directory containing the input files.
             commands: List of commands to run using the GROMACS simulator.
-            track_logs: If True, the logs of the remote execution will be
-            logged. 
             output_dir: Path to the directory where the output files will be
             stored. If not provided, a timestamped directory will be created.
         """
         return super().run(input_dir,
                            output_dir=output_dir,
-                           track_logs=track_logs,
+                           resource_pool_id=resource_pool_id,
                            commands=commands)
 
     def run_async(
         self,
         input_dir: types.Path,
         commands: List[dict],
+        resource_pool_id: Optional[UUID] = None,
     ) -> str:
         """Run a list of GROMACS commands asynchronously.
 
@@ -47,4 +47,6 @@ class GROMACS(Simulator):
             input_dir: Path to the directory containing the input files.
             commands: List of commands to run using the GROMACS simulator.
         """
-        return super().run_async(input_dir, commands=commands)
+        return super().run_async(input_dir,
+                                 resource_pool_id=resource_pool_id,
+                                 commands=commands)

--- a/inductiva/scenarios.py
+++ b/inductiva/scenarios.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 import tempfile
 from typing import Optional
+from uuid import UUID
 from inductiva.types import Path
 from inductiva.simulation import Simulator
 from inductiva.utils.files import resolve_path, get_timestamped_path
@@ -58,6 +59,7 @@ class Scenario(ABC):
         self,
         simulator: Simulator,
         output_dir: Optional[Path] = None,
+        resource_pool_id: Optional[UUID] = None,
         **kwargs,
     ) -> Path:
         """Simulates the scenario for a single simulator call."""
@@ -68,12 +70,14 @@ class Scenario(ABC):
                 input_dir,
                 *args,
                 output_dir=output_dir,
+                resource_pool_id=resource_pool_id,
                 **kwargs,
             )
 
     def simulate_async(
         self,
         simulator: Simulator,
+        resource_pool_id: Optional[UUID] = None,
         **kwargs,
     ) -> str:
         """Simulates the scenario asychronously."""
@@ -83,6 +87,7 @@ class Scenario(ABC):
             task_id = simulator.run_async(
                 input_dir,
                 *args,
+                resource_pool_id=resource_pool_id,
                 **kwargs,
             )
         return task_id

--- a/inductiva/simulation/simulator.py
+++ b/inductiva/simulation/simulator.py
@@ -1,6 +1,7 @@
 """Base class for low-level simulators."""
 from abc import ABC, abstractmethod
 from typing import Optional
+from uuid import UUID
 from inductiva import api
 from inductiva import types
 from inductiva.utils import files
@@ -35,7 +36,7 @@ class Simulator(ABC):
         input_dir: types.Path,
         *_args,
         output_dir: Optional[types.Path] = None,
-        track_logs: bool = False,
+        resource_pool_id: Optional[UUID] = None,
         **kwargs,
     ) -> types.Path:
         """Run the simulation.
@@ -48,8 +49,6 @@ class Simulator(ABC):
                 stored. If not provided, a timestamped directory will be
                 created with the same name as the input directory appended
                 with "-output".
-            track_logs: If True, the logs of the remote execution will be
-                streamed to the console.
             **kwargs: Additional keyword arguments to be passed to the
                 simulation API method.
         """
@@ -61,13 +60,14 @@ class Simulator(ABC):
             input_dir,
             output_dir,
             params=kwargs,
-            log_remote_execution=track_logs,
+            resource_pool_id=resource_pool_id,
         )
 
     def run_async(
         self,
         input_dir: types.Path,
         *_args,
+        resource_pool_id: Optional[UUID] = None,
         **kwargs,
     ) -> str:
         """Run the simulation asynchronously.
@@ -85,4 +85,5 @@ class Simulator(ABC):
             self.api_method_name,
             input_dir,
             params=kwargs,
+            resource_pool_id=resource_pool_id,
         )


### PR DESCRIPTION
This PR adds support for passing resource pool IDs when calling simulations with the API.
As there was already a "track_logs" parameter common for several API calls which is no longer supported, I ended up replacing that with the new one in some cases, so this PR also removes the support for tracking logs in the client, which is something that is also no longer supported by the backend. 