### PR TITLE
Fix WindTunnel typo and Molecules __init__

### DIFF
--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -61,7 +61,7 @@ class WindTunnel(Scenario):
             logging.info("Using a default domain: `{\"x\":"
                          "[-5, 15], \"y\": [-4, 4], \"z\": [0, 8]}`.")
             self.domain = {"x": [-5, 15], "y": [-4, 4], "z": [0, 8]}
-        elif isinstance(domain, dict):
+        elif not isinstance(domain, dict):
             raise ValueError(
                 "`domain` must be a dictionary of the type `{\"x\":"
                 "[-5, 15], \"y\": [-4, 4], \"z\": [0, 8]}`.")

--- a/inductiva/molecules/__init__.py
+++ b/inductiva/molecules/__init__.py
@@ -1,3 +1,4 @@
 #pylint: disable=missing-module-docstring
 from .simulators import GROMACS
-from .scenarios import protein_solvation
+from .scenarios import ProteinSolvation
+from .scenarios import MDWaterBox

--- a/inductiva/molecules/scenarios/__init__.py
+++ b/inductiva/molecules/scenarios/__init__.py
@@ -1,2 +1,3 @@
 #pylint: disable=missing-module-docstring
 from .protein_solvation import ProteinSolvation
+from .md_water_box import MDWaterBox


### PR DESCRIPTION
Fix a typo in the WindTunnel and correct the `__init__` of molecules to appropriately use the scenarios of `MDWaterBox` and `ProteinSolvation`. 

I think this will fix #319, since on my side I can use the package outside the parent directory.