### PR TITLE
Bug fix: resource_pool utilization in proteinSolvation now works

### DIFF
--- a/inductiva/molecules/__init__.py
+++ b/inductiva/molecules/__init__.py
@@ -1,3 +1,3 @@
 #pylint: disable=missing-module-docstring
 from .simulators import GROMACS
-from .scenarios import protein_solvation
+from .scenarios import protein_solvation, _post_processing

--- a/inductiva/molecules/__init__.py
+++ b/inductiva/molecules/__init__.py
@@ -1,3 +1,3 @@
 #pylint: disable=missing-module-docstring
 from .simulators import GROMACS
-from .scenarios import protein_solvation#, _post_processing
+from .scenarios import protein_solvation  #, _post_processing

--- a/inductiva/molecules/__init__.py
+++ b/inductiva/molecules/__init__.py
@@ -1,3 +1,3 @@
 #pylint: disable=missing-module-docstring
 from .simulators import GROMACS
-from .scenarios import protein_solvation, _post_processing
+from .scenarios import protein_solvation#, _post_processing

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -77,13 +77,13 @@ class ProteinSolvation(Scenario):
 
         #Compute charge if it is not provided
         if self.charged is None:
-            self.charged = self.compute_charge()
+            self.charged = self.compute_charge(resource_pool_id = resource_pool_id)
 
         #Edit commands.json according to the charge of the protein
         commands_path = os.path.join(self.template_dir, "commands.json")
 
         replace_params_in_template(self.template_dir, "commands.json.jinja",
-                                   {"charged": self.charged}, commands_path)
+                                   {"pdb_file": self.protein_pdb, "charged": self.charged}, commands_path)
 
         commands = self.read_commands_from_file(commands_path)
         self.nsteps = int(
@@ -124,13 +124,13 @@ class ProteinSolvation(Scenario):
 
         #Compute charge if it is not provided
         if self.charged is None:
-            self.charged = self.compute_charge()
+            self.charged = self.compute_charge(resource_pool_id=resource_pool_id)
 
         #Edit commands.json according to the charge of the protein
         commands_path = os.path.join(self.template_dir, "commands.json")
 
         replace_params_in_template(self.template_dir, "commands.json.jinja",
-                                   {"charged": self.charged}, commands_path)
+                                   {"pdb_file": self.protein_pdb, "charged": self.charged}, commands_path)
 
         commands = self.read_commands_from_file(commands_path)
 
@@ -144,18 +144,25 @@ class ProteinSolvation(Scenario):
                                       resource_pool_id=resource_pool_id,
                                       commands=commands)
 
-    def compute_charge(self, simulator: Simulator = GROMACS()):
+    def compute_charge(self, simulator: Simulator = GROMACS(),
+                       resource_pool_id: Optional[UUID] = None):
         """Check if the protein is charged."""
 
         logging.info("Computing the charge of the protein")
 
         protein_directory = os.path.dirname(self.protein_pdb)
-        commands = self.read_commands_from_file(
-            os.path.join(self.template_dir, "charge_computation.json"))
 
+        commands_path = os.path.join(self.template_dir, "charge_computation.json")
+        protein_pdb = os.path.basename(self.protein_pdb)
+        replace_params_in_template(self.template_dir, "charge_computation.json.jinja",
+                                   {"pdb_file": protein_pdb}, commands_path)
+
+        commands = self.read_commands_from_file(commands_path)
+        
         simulator.run(protein_directory,
                       commands=commands,
-                      output_dir=protein_directory)
+                      output_dir=protein_directory,
+                      resource_pool_id=resource_pool_id)
 
         topology_file = os.path.join(protein_directory, "topol.top")
 
@@ -163,7 +170,7 @@ class ProteinSolvation(Scenario):
         #file in the lines starting with "; residue". Summing the charges of
         #all residues gives the total charge of the protein.
 
-        with open(topology_file, "r", encoding="UFT-8") as file:
+        with open(topology_file, "r", encoding="utf-8") as file:
             charge = np.sum([
                 float(line.split()[-1])
                 for line in file

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -77,13 +77,16 @@ class ProteinSolvation(Scenario):
 
         #Compute charge if it is not provided
         if self.charged is None:
-            self.charged = self.compute_charge(resource_pool_id = resource_pool_id)
+            self.charged = self.compute_charge(
+                resource_pool_id=resource_pool_id)
 
         #Edit commands.json according to the charge of the protein
         commands_path = os.path.join(self.template_dir, "commands.json")
 
-        replace_params_in_template(self.template_dir, "commands.json.jinja",
-                                   {"pdb_file": self.protein_pdb, "charged": self.charged}, commands_path)
+        replace_params_in_template(self.template_dir, "commands.json.jinja", {
+            "pdb_file": self.protein_pdb,
+            "charged": self.charged
+        }, commands_path)
 
         commands = self.read_commands_from_file(commands_path)
         self.nsteps = int(
@@ -124,13 +127,16 @@ class ProteinSolvation(Scenario):
 
         #Compute charge if it is not provided
         if self.charged is None:
-            self.charged = self.compute_charge(resource_pool_id=resource_pool_id)
+            self.charged = self.compute_charge(
+                resource_pool_id=resource_pool_id)
 
         #Edit commands.json according to the charge of the protein
         commands_path = os.path.join(self.template_dir, "commands.json")
 
-        replace_params_in_template(self.template_dir, "commands.json.jinja",
-                                   {"pdb_file": self.protein_pdb, "charged": self.charged}, commands_path)
+        replace_params_in_template(self.template_dir, "commands.json.jinja", {
+            "pdb_file": self.protein_pdb,
+            "charged": self.charged
+        }, commands_path)
 
         commands = self.read_commands_from_file(commands_path)
 
@@ -144,7 +150,8 @@ class ProteinSolvation(Scenario):
                                       resource_pool_id=resource_pool_id,
                                       commands=commands)
 
-    def compute_charge(self, simulator: Simulator = GROMACS(),
+    def compute_charge(self,
+                       simulator: Simulator = GROMACS(),
                        resource_pool_id: Optional[UUID] = None):
         """Check if the protein is charged."""
 
@@ -152,13 +159,15 @@ class ProteinSolvation(Scenario):
 
         protein_directory = os.path.dirname(self.protein_pdb)
 
-        commands_path = os.path.join(self.template_dir, "charge_computation.json")
+        commands_path = os.path.join(self.template_dir,
+                                     "charge_computation.json")
         protein_pdb = os.path.basename(self.protein_pdb)
-        replace_params_in_template(self.template_dir, "charge_computation.json.jinja",
+        replace_params_in_template(self.template_dir,
+                                   "charge_computation.json.jinja",
                                    {"pdb_file": protein_pdb}, commands_path)
 
         commands = self.read_commands_from_file(commands_path)
-        
+
         simulator.run(protein_directory,
                       commands=commands,
                       output_dir=protein_directory,

--- a/inductiva/templates/protein_solvation/gromacs/charge_computation.json
+++ b/inductiva/templates/protein_solvation/gromacs/charge_computation.json
@@ -1,5 +1,5 @@
 [{
     "cmd":
-        "gmx pdb2gmx -f protein.pdb -o protein.gro -water tip3p -ff amber99sb-ildn",
+        "gmx pdb2gmx -f 1AKI_clean.pdb -o protein.gro -water tip3p -ff amber99sb-ildn",
     "prompts": []
 }]

--- a/inductiva/templates/protein_solvation/gromacs/charge_computation.json
+++ b/inductiva/templates/protein_solvation/gromacs/charge_computation.json
@@ -1,5 +1,0 @@
-[{
-    "cmd":
-        "gmx pdb2gmx -f 1AKI_clean.pdb -o protein.gro -water tip3p -ff amber99sb-ildn",
-    "prompts": []
-}]

--- a/inductiva/templates/protein_solvation/gromacs/charge_computation.json.jinja
+++ b/inductiva/templates/protein_solvation/gromacs/charge_computation.json.jinja
@@ -1,0 +1,5 @@
+[{
+    "cmd":
+        "gmx pdb2gmx -f {{pdb_file}} -o protein.gro -water tip3p -ff amber99sb-ildn",
+    "prompts": []
+}]

--- a/inductiva/templates/protein_solvation/gromacs/commands.json
+++ b/inductiva/templates/protein_solvation/gromacs/commands.json
@@ -1,0 +1,11 @@
+[
+    {"cmd": "gmx pdb2gmx -f protein.pdb -o protein.gro -water tip3p -ff amber99sb-ildn", "prompts":[]},
+    {"cmd": "gmx editconf -f protein.gro -o protein_box.gro -c yes -d 1.0 -bt cubic", "prompts":[]},
+    {"cmd": "gmx solvate -cp protein_box.gro -o protein_solv.gro -p topol.top", "prompts":[]},
+    {"cmd": "gmx grompp -f ions.mdp -c protein_solv.gro -p topol.top -o ions.tpr  -maxwarn 1 ", "prompts":[]},
+    {"cmd": "gmx genion -s ions.tpr -o protein_solv_ions.gro -p topol.top -pname NA -nname CL -neutral yes", "prompts":[ "SOL" ]},
+    {"cmd": "gmx grompp -f energy_minimization.mdp -c protein_solv_ions.gro -p topol.top -o em.tpr", "prompts":[]},
+    {"cmd": "gmx mdrun -deffnm em -v yes", "prompts":[]},
+    {"cmd": "gmx grompp -f simulation.mdp -c em.gro -r em.gro -p topol.top -o solvated_protein.tpr", "prompts":[]},
+    {"cmd": "gmx mdrun -deffnm solvated_protein -v yes", "prompts":[]}
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ imageio-ffmpeg
 ipython
 websockets
 typing-extensions
+MDAnalysis
+nglview


### PR DESCRIPTION
- Corrected an issue with the charge_computation command;
- If the user specified a resour_pool_id the code wouldn't work, since it wasn't passing the resource_pool_id to the super.simulate methods.

There are some things (change in requirements and __init__ file) that do not relate to this bug fix; it's something that will be used in the next PR (I splitted the changes to have a more manageable PR, but some things were ill divided)