### PR TITLE
Add visualization to heat sink scenario

### DIFF
--- a/inductiva/fluids/scenarios/heat_sink/__init__.py
+++ b/inductiva/fluids/scenarios/heat_sink/__init__.py
@@ -1,2 +1,3 @@
 #pylint: disable=missing-module-docstring
 from .heat_sink import HeatSink
+from .output import HeatSinkOutput

--- a/inductiva/fluids/scenarios/heat_sink/output.py
+++ b/inductiva/fluids/scenarios/heat_sink/output.py
@@ -1,0 +1,94 @@
+"""TODO
+"""
+import os
+from IPython.display import HTML
+
+import pyvista as pv
+
+from inductiva.types import Path
+from inductiva.utils import files
+
+
+class HeatSinkOutput:
+    """Post-Process WindTunnel simulation outputs.
+
+    Current Support:
+        OpenFOAM
+    """
+
+    def __init__(self, sim_output_path: Path):
+        """Initializes a `WindTunnelSimulationOutput` object.
+
+        Args:
+            sim_output_path: Path to simulation output files.
+            time_step: Time step where we read the data.
+        """
+
+        self.sim_output_path = sim_output_path
+
+    def render(
+        self,
+        movie_path: Path = "movie.mp4",
+        fps: int = 10,
+        cmap: str = "viridis",
+        clim: list = [280, 300],
+    ):
+        """Render flow property over the object in the WindTunnel."""
+
+        movie_path = files.resolve_path(movie_path)
+
+        foam_file_path = os.path.join(self.sim_output_path, "foam.foam")
+
+        # Create reading file
+        with open(foam_file_path, "w", encoding="utf-8"):
+            reader = pv.OpenFOAMReader(foam_file_path)
+
+        plotter = pv.Plotter(off_screen=True)
+
+        # Set camera position to a nice view.
+        plotter.view_vector([-0.67, 0.49, -0.58], viewup=[0.31, 0.90, 0.29])
+        plotter.camera.zoom(1.4)
+
+        plotter.open_movie(movie_path, framerate=fps)
+
+        for i in range(1, reader.number_time_points):
+            reader.set_active_time_point(i)
+
+            mesh = reader.read()
+
+            fins_data = mesh["fins"]["boundary"]
+            fluid_data = mesh["fluid"]["internalMesh"]
+
+            fluid_data_slice = fluid_data.slice(normal=(-1, 0, 0))
+
+            plotter.add_mesh(fins_data,
+                             scalars="T",
+                             cmap=cmap,
+                             clim=clim,
+                             show_scalar_bar=False)
+
+            plotter.add_mesh(fluid_data_slice,
+                             scalars="T",
+                             cmap=cmap,
+                             clim=clim,
+                             show_scalar_bar=False)
+
+            plotter.add_scalar_bar(
+                "Temperature [K]",
+                position_x=0.45,
+                width=0.5,
+                title_font_size=18,
+                label_font_size=18,
+                n_labels=5,
+                fmt="%.0f",
+                font_family="arial",
+            )
+
+            plotter.add_title(f"Time = {reader.active_time_value} [s]",
+                              font_size=12)
+
+            plotter.show_axes()
+
+            plotter.write_frame()
+
+        plotter.close()

--- a/inductiva/fluids/scenarios/heat_sink/output.py
+++ b/inductiva/fluids/scenarios/heat_sink/output.py
@@ -2,6 +2,7 @@
 
 import os
 import pathlib
+from typing import Sequence
 
 import pyvista as pv
 
@@ -22,11 +23,11 @@ class HeatSinkOutput:
         self.sim_output_path = sim_output_path
 
     def render(
-        self,
-        movie_path: Path = "movie.mp4",
-        fps: int = 10,
-        cmap: str = "viridis",
-        clim: list = [280, 300],
+            self,
+            movie_path: Path = "movie.mp4",
+            fps: int = 10,
+            cmap: str = "viridis",
+            clim: Sequence[float] = (280, 300),
     ):
         """Renders temporal evolution of the temperature.
         

--- a/inductiva/fluids/scenarios/heat_sink/output.py
+++ b/inductiva/fluids/scenarios/heat_sink/output.py
@@ -89,7 +89,6 @@ class HeatSinkOutput:
                 width=0.5,
                 title_font_size=18,
                 label_font_size=18,
-                n_labels=5,
                 fmt="%.0f",
                 font_family="arial",
             )

--- a/inductiva/fluids/scenarios/heat_sink/output.py
+++ b/inductiva/fluids/scenarios/heat_sink/output.py
@@ -43,6 +43,7 @@ class HeatSinkOutput:
             fps: Number of frames per second to use in the movie.
             cmap: Colormap used to represent temperature.
             clim: Colorbar limits.
+            view: View to use in the movie.
         """
 
         movie_path = files.resolve_path(movie_path)

--- a/inductiva/fluids/scenarios/heat_sink/output.py
+++ b/inductiva/fluids/scenarios/heat_sink/output.py
@@ -79,7 +79,7 @@ class HeatSinkOutput:
             zoom_factor = 1.2
             slice_normal = (-1, 0, 0)
         else:
-            raise ValueError(f"Invalid view.")
+            raise ValueError("Invalid view.")
 
         plotter.camera.zoom(zoom_factor)
 


### PR DESCRIPTION
Fixes #342.

This PR introduces a `HeatSinkOutput` class with a `render` method. This method produces a video with the temporal evolution of temperature in a simulation of the `HeatSink` scenario.

The temperature is shown on the surface of the heat sink itself, and on (a slice cutting through the center of the heat sink of) the surrounding air.

Here is an example movie obtained with the new class and method.


https://github.com/inductiva/inductiva/assets/11545632/6fa20561-a54e-4e7c-92d4-d7698f25c6c1

