### PR TITLE
[Fluid tank scenario] Add output class

### DIFF
--- a/inductiva/fluids/scenarios/fluid_tank/__init__.py
+++ b/inductiva/fluids/scenarios/fluid_tank/__init__.py
@@ -6,3 +6,4 @@ from .fluid_tank import (
     RectangularTankInlet,
     CircularTankInlet,
 )
+from .output import FluidTankOutput

--- a/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
+++ b/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
@@ -18,7 +18,6 @@ from inductiva.fluids.shapes import Cylinder
 from inductiva.fluids.fluid_types import FluidType
 from inductiva.fluids.fluid_types import WATER
 from inductiva.fluids.simulators import SPlisHSPlasH
-from inductiva.fluids.post_processing.splishsplash import convert_vtk_data_dir_to_netcdf
 from inductiva.utils.templates import replace_params_in_template
 from inductiva.fluids.scenarios.fluid_tank.output import FluidTankOutput
 
@@ -186,13 +185,7 @@ class FluidTank(Scenario):
             sim_config_filename=self.get_config_filename(simulator),
         )
 
-        # TODO: Add any kind of post-processing here, e.g. convert files?
-        convert_vtk_data_dir_to_netcdf(
-            data_dir=os.path.join(output_path, "vtk"),
-            output_time_step=self.output_time_step,
-            netcdf_data_dir=os.path.join(output_path, "netcdf"))
-
-        return FluidTankOutput(output_path)
+        return FluidTankOutput(output_path, self.output_time_step)
 
     def simulate_async(
         self,

--- a/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
+++ b/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
@@ -128,7 +128,7 @@ class FluidTank(Scenario):
         self,
         shape: BaseShape = Cylinder(radius=0.5, height=1),
         fluid: FluidType = WATER,
-        fluid_level: float = 0,
+        fluid_level: float = 0.5,
         inlet: Optional[BaseTankInlet] = CircularTankInlet(radius=0.1),
         outlet: Optional[BaseTankOutlet] = CylindricalTankOutlet(radius=0.1,
                                                                  height=0.1),

--- a/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
+++ b/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
@@ -182,7 +182,7 @@ class FluidTank(Scenario):
             output_dir=output_dir,
             resource_pool_id=resource_pool_id,
             device=device,
-            input_filename=self.get_config_filename(simulator),
+            sim_config_filename=self.get_config_filename(simulator),
         )
 
         # TODO: Add any kind of post-processing here, e.g. convert files?

--- a/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
+++ b/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
@@ -194,6 +194,41 @@ class FluidTank(Scenario):
 
         return FluidTankOutput(output_path)
 
+    def simulate_async(
+        self,
+        simulator: Simulator = SPlisHSPlasH(),
+        resource_pool_id: Optional[UUID] = None,
+        device: Literal["cpu", "gpu"] = "cpu",
+        simulation_time: float = 5,
+        resolution: Literal["low", "medium", "high"] = "low",
+        output_time_step: float = 0.1,
+        particle_sorting: bool = False,
+    ):
+        """Simulates the scenario.
+
+        Args:
+            simulator: Simulator to use.
+            device: Device in which to run the simulation.
+            simulation_time: Simulation time, in seconds.
+            output_time_step: Time step between output files, in seconds.
+            resolution: Resolution of the simulation. Controls the particle
+                radius and time step.
+            particle_sorting: Whether to use particle sorting.
+        """
+
+        self.simulation_time = simulation_time
+        self.particle_radius = ParticleRadius[resolution.upper()].value
+        self.time_step = TimeStep[resolution.upper()].value
+        self.output_time_step = output_time_step
+        self.particle_sorting = particle_sorting
+
+        return super().simulate_async(
+            simulator,
+            resource_pool_id=resource_pool_id,
+            device=device,
+            sim_config_filename=self.get_config_filename(simulator),
+        )
+
     def get_bounding_box(self):
         """Gets the bounding box of the tank.
 

--- a/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
+++ b/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
@@ -20,6 +20,7 @@ from inductiva.fluids.fluid_types import WATER
 from inductiva.fluids.simulators import SPlisHSPlasH
 from inductiva.fluids.post_processing.splishsplash import convert_vtk_data_dir_to_netcdf
 from inductiva.utils.templates import replace_params_in_template
+from inductiva.fluids.scenarios.fluid_tank.output import FluidTankOutput
 
 from . import mesh_file_utils
 
@@ -191,7 +192,7 @@ class FluidTank(Scenario):
             output_time_step=self.output_time_step,
             netcdf_data_dir=os.path.join(output_path, "netcdf"))
 
-        return output_path
+        return FluidTankOutput(output_path)
 
     def get_bounding_box(self):
         """Gets the bounding box of the tank.

--- a/inductiva/fluids/scenarios/fluid_tank/output.py
+++ b/inductiva/fluids/scenarios/fluid_tank/output.py
@@ -1,0 +1,61 @@
+"""Post-processing and visualization utilities of the fluid tank scenario."""
+
+import os
+from typing import Optional
+
+import xarray as xr
+
+from inductiva.types import Path
+from inductiva.utils import files, visualization
+
+
+class FluidTankOutput:
+    """Fluid tank simulation output."""
+
+    def __init__(self, sim_output_path: Path):
+        """Initializes a `FluidTankOutput` object.
+
+        Args:
+            sim_output_path: Path to simulation output files.
+        """
+
+        self.sim_output_path = sim_output_path
+
+    def render(
+        self,
+        movie_path: Path = "movie.mp4",
+        fps: int = 10,
+        color: Optional[str] = None,
+    ):
+        """Renders temporal evolution of the fluid particle positions.
+        
+        A movie is produced representing the temporal evolution of the positions
+        of the particles representing the fluid in the tank. Each frame of the
+        movie is a scatter plot of the particle positions at a given time.
+         
+        The movie is saved in the `movie_path` location.
+
+        Args:
+            movie_path: Path to the movie file.
+            fps: Number of frames per second to use in the movie.
+            color: Color used to represent the particles.
+        """
+
+        particle_data = xr.open_mfdataset(
+            os.path.join(self.sim_output_path, "netcdf", "*.nc"))
+
+        movie_path = files.resolve_path(movie_path)
+
+        visualization.create_3d_scatter_plot_movie(
+            particle_data,
+            iter_var="time",
+            x_var="x",
+            y_var="y",
+            z_var="z",
+            x_limits=[-0.5, 0.5],
+            y_limits=[-0.5, 0.5],
+            z_limits=[-0.1, 1],
+            color=color,
+            movie_path=movie_path,
+            movie_fps=fps,
+        )

--- a/inductiva/fluids/scenarios/fluid_tank/output.py
+++ b/inductiva/fluids/scenarios/fluid_tank/output.py
@@ -6,13 +6,14 @@ from typing import Optional
 import xarray as xr
 
 from inductiva.types import Path
+from inductiva.fluids.post_processing.splishsplash import convert_vtk_data_dir_to_netcdf
 from inductiva.utils import files, visualization
 
 
 class FluidTankOutput:
     """Fluid tank simulation output."""
 
-    def __init__(self, sim_output_path: Path):
+    def __init__(self, sim_output_path: Path, output_time_step: float = 1):
         """Initializes a `FluidTankOutput` object.
 
         Args:
@@ -20,6 +21,7 @@ class FluidTankOutput:
         """
 
         self.sim_output_path = sim_output_path
+        self.output_time_step = output_time_step
 
     def render(
         self,
@@ -40,6 +42,11 @@ class FluidTankOutput:
             fps: Number of frames per second to use in the movie.
             color: Color used to represent the particles.
         """
+
+        convert_vtk_data_dir_to_netcdf(
+            data_dir=os.path.join(self.sim_output_path, "vtk"),
+            output_time_step=self.output_time_step,
+            netcdf_data_dir=os.path.join(self.sim_output_path, "netcdf"))
 
         particle_data = xr.open_mfdataset(
             os.path.join(self.sim_output_path, "netcdf", "*.nc"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ gmsh
 meshio
 vtk
 xarray
+dask
 matplotlib
 imageio
 pyvista


### PR DESCRIPTION
This PR adds a class to represent the output of a fluid tank simulation. The output produced by the `render` method looks as follows:

https://github.com/inductiva/inductiva/assets/11545632/e2c4852c-386f-427b-a4de-e370728d7283

This PR also adds the method `simulate_async` to the scenario class, which was previously missing.