### PR TITLE
Add virtual_display to SPH renders

### DIFF
--- a/inductiva/fluids/scenarios/_post_processing.py
+++ b/inductiva/fluids/scenarios/_post_processing.py
@@ -17,6 +17,7 @@ class SPHSimulationOutput:
         self.sim_output_dir = sim_output_path
 
     def render(self,
+               virtual_display: bool = False,
                movie_path: str = "movie.mp4",
                fps: int = 10,
                color: str = "blue"):
@@ -34,7 +35,7 @@ class SPHSimulationOutput:
 
         create_movie_from_vtk(vtk_dir,
                               movie_path,
-                              virtual_display=True,
+                              virtual_display=virtual_display,
                               camera=[(3., 3., 2.), (0., 0., 0.), (1., 1., 2.)],
                               fps=fps,
                               color=color)


### PR DESCRIPTION
This just adds the parameter `virtual_display` has an argument to the function, to render in colabs and servers.