### PR TITLE
[Protein Solvation] Extract conformational changes metrics

### DIFF
--- a/inductiva/molecules/scenarios/md_water_box/post_processing.py
+++ b/inductiva/molecules/scenarios/md_water_box/post_processing.py
@@ -19,20 +19,18 @@ class MDWaterBoxOutput:
             sim_output_path: Path to the simulation output directory."""
 
         self.sim_output_dir = sim_output_path
-        self.topology = os.path.join(self.sim_output_dir, "eql.tpr")
 
     def render_interactive(self, use_compressed_trajectory: bool = False):
         """Render the simulation outputs in an interactive visualization.
         Args: 
             use_compressed_trajectory: Whether to use the compressed trajectory
             or the full precision trajectory."""
-
+        topology = os.path.join(self.sim_output_dir, "eql.tpr")
         if use_compressed_trajectory:
-            self.trajectory = os.path.join(self.sim_output_dir,
-                                           "trajectory.xtc")
+            trajectory = os.path.join(self.sim_output_dir, "trajectory.xtc")
         else:
-            self.trajectory = os.path.join(self.sim_output_dir, "eql.trr")
-        universe = unwrap_trajectory(self.topology, self.trajectory)
+            trajectory = os.path.join(self.sim_output_dir, "eql.trr")
+        universe = unwrap_trajectory(topology, trajectory)
         view = nv.show_mdanalysis(universe)
         view.add_ball_and_stick("all")
         print("System Information:")

--- a/inductiva/molecules/scenarios/md_water_box/post_processing.py
+++ b/inductiva/molecules/scenarios/md_water_box/post_processing.py
@@ -8,7 +8,8 @@ from ..utils import unwrap_trajectory
 class MDWaterBoxOutput:
     """Post process the simulation output of a MDWaterBox scenario."""
 
-    def __init__(self, sim_output_path: Path = None):
+    def __init__(self, sim_output_path: Path = None, 
+                 use_compressed_trajectory: bool = False):
         """Initializes a `MDWaterBoxOutput` object.
 
         Given a simulation output directory that contains the standard files
@@ -19,17 +20,16 @@ class MDWaterBoxOutput:
             sim_output_path: Path to the simulation output directory."""
 
         self.sim_output_dir = sim_output_path
+        self.topology = os.path.join(self.sim_output_dir, "eql.tpr")
+        if use_compressed_trajectory:
+            self.trajectory = os.path.join(self.sim_output_dir, "trajectory.xtc")
+        else:
+            self.trajectory = os.path.join(self.sim_output_dir, "eql.trr")
 
-    def render_interactive(self, use_compressed_trajectory: bool = False):
+    def render_interactive(self):
         """Render the simulation outputs in an interactive visualization."""
 
-        topology = os.path.join(self.sim_output_dir, "eql.tpr")
-        if use_compressed_trajectory:
-            trajectory = os.path.join(self.sim_output_dir, "trajectory.xtc")
-        else:
-            trajectory = os.path.join(self.sim_output_dir, "eql.trr")
-
-        universe = unwrap_trajectory(topology, trajectory)
+        universe = unwrap_trajectory(self.topology, self.trajectory)
         view = nv.show_mdanalysis(universe)
         view.add_ball_and_stick("all")
         print("System Information:")

--- a/inductiva/molecules/scenarios/md_water_box/post_processing.py
+++ b/inductiva/molecules/scenarios/md_water_box/post_processing.py
@@ -33,6 +33,7 @@ class MDWaterBoxOutput:
         universe = unwrap_trajectory(topology, trajectory)
         view = nv.show_mdanalysis(universe)
         view.add_ball_and_stick("all")
+        view.center()
         print("System Information:")
         print(f"Number of atoms in the system: {len(universe.atoms)}")
         print(f"Number of trajectory frames: {len(universe.trajectory)}")

--- a/inductiva/molecules/scenarios/md_water_box/post_processing.py
+++ b/inductiva/molecules/scenarios/md_water_box/post_processing.py
@@ -8,8 +8,7 @@ from ..utils import unwrap_trajectory
 class MDWaterBoxOutput:
     """Post process the simulation output of a MDWaterBox scenario."""
 
-    def __init__(self, sim_output_path: Path = None, 
-                 use_compressed_trajectory: bool = False):
+    def __init__(self, sim_output_path: Path = None):
         """Initializes a `MDWaterBoxOutput` object.
 
         Given a simulation output directory that contains the standard files
@@ -17,18 +16,20 @@ class MDWaterBoxOutput:
         visualize the simulation outputs in a notebook interactively.
 
         Args:
-            sim_output_path: Path to the simulation output directory."""
+            sim_output_path: Path to the simulation output directory.
+            use_compressed_trajectory: Whether to use the compressed trajectory
+            or the full precision trajectory."""
 
         self.sim_output_dir = sim_output_path
         self.topology = os.path.join(self.sim_output_dir, "eql.tpr")
+
+    def render_interactive(self, use_compressed_trajectory: bool = False):
+        """Render the simulation outputs in an interactive visualization."""
         if use_compressed_trajectory:
-            self.trajectory = os.path.join(self.sim_output_dir, "trajectory.xtc")
+            self.trajectory = os.path.join(self.sim_output_dir,
+                                           "trajectory.xtc")
         else:
             self.trajectory = os.path.join(self.sim_output_dir, "eql.trr")
-
-    def render_interactive(self):
-        """Render the simulation outputs in an interactive visualization."""
-
         universe = unwrap_trajectory(self.topology, self.trajectory)
         view = nv.show_mdanalysis(universe)
         view.add_ball_and_stick("all")

--- a/inductiva/molecules/scenarios/md_water_box/post_processing.py
+++ b/inductiva/molecules/scenarios/md_water_box/post_processing.py
@@ -16,15 +16,17 @@ class MDWaterBoxOutput:
         visualize the simulation outputs in a notebook interactively.
 
         Args:
-            sim_output_path: Path to the simulation output directory.
-            use_compressed_trajectory: Whether to use the compressed trajectory
-            or the full precision trajectory."""
+            sim_output_path: Path to the simulation output directory."""
 
         self.sim_output_dir = sim_output_path
         self.topology = os.path.join(self.sim_output_dir, "eql.tpr")
 
     def render_interactive(self, use_compressed_trajectory: bool = False):
-        """Render the simulation outputs in an interactive visualization."""
+        """Render the simulation outputs in an interactive visualization.
+        Args: 
+            use_compressed_trajectory: Whether to use the compressed trajectory
+            or the full precision trajectory."""
+
         if use_compressed_trajectory:
             self.trajectory = os.path.join(self.sim_output_dir,
                                            "trajectory.xtc")

--- a/inductiva/molecules/scenarios/protein_solvation/post_processing.py
+++ b/inductiva/molecules/scenarios/protein_solvation/post_processing.py
@@ -90,8 +90,7 @@ class ProteinSolvationOutput:
         })
 
         # Plot the data
-        plt.plot(df_rmsf_per_atom["residue_number"],
-                     df_rmsf_per_atom["rmsf"])
+        plt.plot(df_rmsf_per_atom["residue_number"], df_rmsf_per_atom["rmsf"])
         plt.xlabel("Residue Number")
         plt.ylabel("RMSF")
         plt.title("RMSF per residue")

--- a/inductiva/molecules/scenarios/protein_solvation/post_processing.py
+++ b/inductiva/molecules/scenarios/protein_solvation/post_processing.py
@@ -46,6 +46,7 @@ class ProteinSolvationOutput:
                                 selection="not water and not ion")
         if add_backbone:
             view.add_representation("cartoon", selection="protein")
+        view.center()
 
         print("System Information: ")
         print(f"Number of atoms in the system: {len(universe.atoms)}")
@@ -130,4 +131,5 @@ class ProteinSolvationOutput:
             residue.atoms.tempfactors = value
         view = nv.show_mdanalysis(universe)
         view.update_representation(color_scheme="bfactor")
+        view.center()
         return view

--- a/inductiva/molecules/scenarios/protein_solvation/post_processing.py
+++ b/inductiva/molecules/scenarios/protein_solvation/post_processing.py
@@ -80,9 +80,9 @@ class ProteinSolvationOutput:
         These atoms make the backbone of the protein.The RMSF is the square root 
         of the variance of the fluctuation around the average position:
         &rhoi = √⟨(xi - ⟨xi⟩)²⟩
-        It quantifies how much a structure diverges from a reference over time, 
-        the RSMF can reveal which areas of the system are the most mobile.
-        Check 
+        It quantifies how much a structure diverges from the average structure 
+        over time, the RSMF can reveal which areas of the system are the most 
+        mobile. Check 
         https://userguide.mdanalysis.org/stable/examples/analysis/alignment_and_rms/rmsf.html 
         for more details.
 

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -87,9 +87,9 @@ class ProteinSolvation(Scenario):
         self.nsteps_minim = nsteps_minim
         commands = self.get_commands()
         output_path = super().simulate(simulator,
-                                output_dir,
-                                resource_pool_id=resource_pool_id,
-                                commands=commands)
+                                       output_dir,
+                                       resource_pool_id=resource_pool_id,
+                                       commands=commands)
         return ProteinSolvationOutput(output_path)
 
     def simulate_async(

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -13,6 +13,7 @@ from inductiva.utils.templates import (TEMPLATES_PATH,
                                        batch_replace_params_in_template)
 from inductiva.scenarios import Scenario
 from inductiva.utils import files
+from .post_processing import ProteinSolvationOutput
 
 SCENARIO_TEMPLATE_DIR = os.path.join(TEMPLATES_PATH, "protein_solvation")
 GROMACS_TEMPLATE_INPUT_DIR = "gromacs"
@@ -85,10 +86,11 @@ class ProteinSolvation(Scenario):
         self.integrator = integrator
         self.nsteps_minim = nsteps_minim
         commands = self.get_commands()
-        return super().simulate(simulator,
+        output_path = super().simulate(simulator,
                                 output_dir,
                                 resource_pool_id=resource_pool_id,
                                 commands=commands)
+        return ProteinSolvationOutput(output_path)
 
     def simulate_async(
             self,

--- a/inductiva/molecules/scenarios/utils.py
+++ b/inductiva/molecules/scenarios/utils.py
@@ -24,12 +24,12 @@ def align_trajectory_to_average(universe, trajectory_output_path):
         trajectory_output_path: Path to the aligned trajectory file."""
     average = align.AverageStructure(universe,
                                      universe,
-                                     select='protein',
+                                     select="protein and name CA",
                                      ref_frame=0).run()
     average_trajectory = average.results.universe
 
     align.AlignTraj(universe,
                     average_trajectory,
-                    select='protein',
+                    select="protein and name CA",
                     filename=trajectory_output_path,
                     in_memory=False).run()

--- a/inductiva/molecules/scenarios/utils.py
+++ b/inductiva/molecules/scenarios/utils.py
@@ -1,6 +1,7 @@
 """Tools to analyze molecular dynamics simulations."""
 import MDAnalysis as mda
 from MDAnalysis import transformations
+from MDAnalysis.analysis import align
 
 
 def unwrap_trajectory(topology, trajectory):
@@ -14,3 +15,21 @@ def unwrap_trajectory(topology, trajectory):
     transformation = transformations.unwrap(atoms)
     universe.trajectory.add_transformations(transformation)
     return universe
+
+
+def align_trajectory_to_average(universe, trajectory_output_path):
+    """Align the trajectory to the average structure. 
+    Args:
+        universe: The universe MDAnalysis object.
+        trajectory_output_path: Path to the aligned trajectory file."""
+    average = align.AverageStructure(universe,
+                                     universe,
+                                     select='protein',
+                                     ref_frame=0).run()
+    average_trajectory = average.results.universe
+
+    align.AlignTraj(universe,
+                    average_trajectory,
+                    select='protein',
+                    filename=trajectory_output_path,
+                    in_memory=False).run()


### PR DESCRIPTION
In this PR, I implement the calculation of the root mean square fluctuation over a trajectory. The intent is to show how the ProteinSolvation Scenario can be used to study conformational changes.

This metric quantifies how much a structure diverges from a reference over time, the RSMF can reveal which areas of the system are the most mobile. An area of the structure with high RMSF values frequently diverges from the average, indicating high mobility. When RMSF analysis is carried out on proteins, it is typically restricted to backbone or alpha-carbon atoms; these are more characteristic of conformational changes than the more flexible side-chains. 
Here is an example output of the RMSF per residue: 
![image](https://github.com/inductiva/inductiva/assets/114397668/2d67a50f-6480-4e82-9993-fa756729bdd0)
The user can optionally render this information in a visualisation of the protein structure backbone. Where the darker areas show the most mobile residues. 
<img width="319" alt="image" src="https://github.com/inductiva/inductiva/assets/114397668/fb66bda5-501b-41b1-99a7-473bf7a999a1">

