### PR TITLE
Disable urllib3 warnings

### DIFF
--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -1,5 +1,6 @@
 """Client for Inductiva's web API."""
 import os
+import urllib3
 
 from . import fluids
 from . import core
@@ -15,3 +16,4 @@ api_key = os.environ.get("INDUCTIVA_API_KEY")
 working_dir = None
 
 logging.set_verbosity(logging.INFO)
+urllib3.disable_warnings()


### PR DESCRIPTION
This disables the urllib3 retry warning. As it seems to not affect the behavior, I'll suppress the warning but not close the issue while we don't fix the root cause of the warning.

Issue #412.