### PR TITLE
Tasks.delete_machine=True now deletes machine after task is finished

### DIFF
--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -52,7 +52,6 @@ class ProteinSolvation(Scenario):
             simulation_time_ns: float = 10,  # ns
             integrator: Literal["md", "sd", "bd"] = "md",
             n_steps_min: int = 5000,
-            visualized_section: str = "Protein-H",
             delete_machine: bool = False) -> tasks.Task:
         """Simulate the solvation of a protein.
 
@@ -80,8 +79,6 @@ class ProteinSolvation(Scenario):
             delete_machine: Whether to delete the machine after the simulation
             is finished.
         """
-
-        self.visualized_section = visualized_section
 
         self.nsteps = int(
             simulation_time_ns * 1e6 / 2

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -52,7 +52,8 @@ class ProteinSolvation(Scenario):
             simulation_time_ns: float = 10,  # ns
             integrator: Literal["md", "sd", "bd"] = "md",
             n_steps_min: int = 5000,
-            visualized_section: str = "Protein-H") -> tasks.Task:
+            visualized_section: str = "Protein-H",
+            delete_machine: bool = False) -> tasks.Task:
         """Simulate the solvation of a protein.
 
         Args:
@@ -76,6 +77,8 @@ class ProteinSolvation(Scenario):
                 - "Protein-H": The protein with hydrogens. This is the default.
                 - "System": The whole system (Protein + Water).
             run_async: Whether to run the simulation asynchronously.
+            delete_machine: Whether to delete the machine after the simulation
+            is finished.
         """
 
         self.visualized_section = visualized_section
@@ -89,7 +92,8 @@ class ProteinSolvation(Scenario):
         task = super().simulate(simulator,
                                 resource_pool_id=resource_pool_id,
                                 commands=commands,
-                                run_async=run_async)
+                                run_async=run_async,
+                                delete_machine=delete_machine)
 
         task.set_output_class(ProteinSolvationOutput)
 

--- a/inductiva/molecules/simulators/gromacs.py
+++ b/inductiva/molecules/simulators/gromacs.py
@@ -14,13 +14,12 @@ class GROMACS(Simulator):
     def api_method_name(self) -> str:
         return "md.gromacs.run_simulation"
 
-    def run(
-        self,
-        input_dir: types.Path,
-        commands: List[dict],
-        resource_pool_id: Optional[UUID] = None,
-        run_async: bool = False,
-    ) -> tasks.Task:
+    def run(self,
+            input_dir: types.Path,
+            commands: List[dict],
+            resource_pool_id: Optional[UUID] = None,
+            run_async: bool = False,
+            delete_machine: bool = False) -> tasks.Task:
         """Run a list of GROMACS commands.
 
         Args:
@@ -33,4 +32,5 @@ class GROMACS(Simulator):
         return super().run(input_dir,
                            resource_pool_id=resource_pool_id,
                            commands=commands,
-                           run_async=run_async)
+                           run_async=run_async,
+                           delete_machine=delete_machine)

--- a/inductiva/scenarios.py
+++ b/inductiva/scenarios.py
@@ -36,6 +36,7 @@ class Scenario(ABC):
         simulator: Simulator,
         resource_pool_id: Optional[UUID] = None,
         run_async: bool = False,
+        delete_machine: bool = False,
         **kwargs,
     ):
         """Simulates the scenario synchronously."""
@@ -48,5 +49,6 @@ class Scenario(ABC):
                 input_dir,
                 resource_pool_id=resource_pool_id,
                 run_async=run_async,
+                delete_machine=delete_machine,
                 **kwargs,
             )

--- a/inductiva/simulation/simulator.py
+++ b/inductiva/simulation/simulator.py
@@ -31,6 +31,7 @@ class Simulator(ABC):
         *_args,
         resource_pool_id: Optional[UUID] = None,
         run_async: bool = False,
+        delete_machine: bool = False,
         **kwargs,
     ) -> tasks.Task:
         """Run the simulation.
@@ -49,5 +50,6 @@ class Simulator(ABC):
             input_dir,
             run_async=run_async,
             resource_pool_id=resource_pool_id,
+            delete_machine=delete_machine,
             **kwargs,
         )

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -12,6 +12,7 @@ def run_simulation(
     input_dir: pathlib.Path,
     resource_pool_id: Optional[UUID] = None,
     run_async: bool = False,
+    delete_machine: bool = False,
     **kwargs: Any,
 ) -> tasks.Task:
     """Run a simulation via Inductiva Web API."""
@@ -28,7 +29,7 @@ def run_simulation(
                                        params,
                                        type_annotations,
                                        resource_pool_id=resource_pool_id)
-    task = tasks.Task(task_id)
+    task = tasks.Task(task_id, delete_machine)
     if not isinstance(task_id, str):
         raise RuntimeError(
             f"Expected result to be a string with task_id, got {type(task_id)}")


### PR DESCRIPTION
Task now have a new attribute, task.delete_machine. If task.delete_machine is true, the method task.wait() deletes the machine in which the task ran if task is in a terminal status. The value for this attribute is False by default, but can be specified by the user (which leads to some minor changes in a bunch of files)
Also added a get_machine method to get the name of the machine in which the task is running/ran

The method only works rn for ProteinSolvation. After feedback in this PR I will implement the necessary changes for the other scenarios.