### PR TITLE
[Bug] Fix output type in task class

### DIFF
--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -14,6 +14,7 @@ from inductiva.client.apis.tags.tasks_api import TasksApi
 from inductiva.utils import files
 from inductiva.utils import data
 from inductiva.utils import output_contents
+from inductiva import types
 
 
 class Task:
@@ -160,7 +161,7 @@ class Task:
             The output of the task.
         """
         self.wait()
-        output_dir = self.download_outputs(output_dir)
+        output_dir = self.download_outputs(output_dir=output_dir)
 
         if self._output_class:
             return self._output_class(output_dir)
@@ -198,7 +199,7 @@ class Task:
     def download_outputs(
         self,
         filenames: Optional[List[str]] = None,
-        output_dir: Optional[pathlib.Path] = None,
+        output_dir: Optional[types.Path] = None,
         uncompress: bool = True,
         rm_archive: bool = True,
     ) -> pathlib.Path:
@@ -226,11 +227,10 @@ class Task:
         # implement our own download logic (with progress bar, first checking
         # the size of the file, etc.)
         response = api_response.response
-
+        output_dir = files.resolve_path(output_dir)
         if output_dir is None:
             output_dir = files.resolve_path(inductiva.output_dir).joinpath(
                 self.id)
-
         if output_dir.exists():
             shutil.rmtree(output_dir)
 

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -15,6 +15,7 @@ from inductiva.utils import files
 from inductiva.utils import data
 from inductiva.utils import output_contents
 from inductiva import types
+import warnings
 
 
 class Task:
@@ -228,14 +229,14 @@ class Task:
         # the size of the file, etc.)
         response = api_response.response
 
-        output_dir = files.resolve_path(output_dir)
         if output_dir is None:
             output_dir = files.resolve_path(inductiva.output_dir).joinpath(
                 self.id)
-        if output_dir.exists():
-            shutil.rmtree(output_dir)
+        output_dir = files.resolve_path(output_dir)
 
-        output_dir.mkdir(parents=True)
+        if output_dir.exists():
+            warnings.warn("Path already exists, files may be overwritten.")
+        output_dir.mkdir(parents=True, exist_ok=True)
 
         zip_path = output_dir.joinpath("output.zip")
 

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -55,7 +55,7 @@ class Task:
         """
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback) -> bool:
         """Exit context manager killing the task if an exception was raised."""
         del traceback  # unused
         del exc_type  # unused
@@ -154,7 +154,8 @@ class Task:
         """Set the output class of the task."""
         self._output_class = output_class
 
-    def get_output(self, output_dir: Optional[types.Path] = None):
+    def get_output(self,
+                   output_dir: Optional[types.Path] = None) -> pathlib.Path:
         """Get the output files produced by the task. If the task 
         is not finished the function will wait until it is to download
         the output folder contents. 
@@ -174,7 +175,7 @@ class Task:
 
         return output_dir
 
-    def get_output_files_info(self):
+    def get_output_files_info(self) -> output_contents.OutputContents:
         """Get information of the output files of the task.
 
         Returns:

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -155,11 +155,12 @@ class Task:
         self._output_class = output_class
 
     def get_output(self, output_dir: Optional[types.Path] = None):
-        """Get the output files produced by the task.
+        """Get the output files produced by the task. If the task 
+        is not finished the function will wait until it is to download
+        the output folder contents. 
         Returns:
             The output path of the task.
         Example:
-            Usage of the get_output function:
             task = Task("task_id") 
             output_path = task.get_output()  
             # prints:

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -155,10 +155,15 @@ class Task:
         self._output_class = output_class
 
     def get_output(self, output_dir: Optional[types.Path] = None):
-        """Get the output of the task.
-
+        """Get the output files produced by the task.
         Returns:
-            The output of the task.
+            The output path of the task.
+        Example:
+            Usage of the get_output function:
+            task = Task("task_id") 
+            output_path = task.get_output()  
+            # prints:
+            100%|██████████| 1.64G/1.64G [00:32<00:00, 55.1MiB/s]   
         """
         self.wait()
         output_dir = self.download_outputs(output_dir=output_dir)

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -154,7 +154,7 @@ class Task:
         """Set the output class of the task."""
         self._output_class = output_class
 
-    def get_output(self, output_dir=None):
+    def get_output(self, output_dir: Optional[types.Path] = None):
         """Get the output of the task.
 
         Returns:

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -227,6 +227,7 @@ class Task:
         # implement our own download logic (with progress bar, first checking
         # the size of the file, etc.)
         response = api_response.response
+
         output_dir = files.resolve_path(output_dir)
         if output_dir is None:
             output_dir = files.resolve_path(inductiva.output_dir).joinpath(

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -208,7 +208,7 @@ class Task:
         filenames: Optional[List[str]] = None,
         output_dir: Optional[types.Path] = None,
         uncompress: bool = True,
-        rm_archive: bool = True,
+        rm_downloaded_zip_archive: bool = True,
     ) -> pathlib.Path:
         """Download output files of the task.
 
@@ -219,7 +219,7 @@ class Task:
                 files are downloaded to the default directory. The default is
                 {inductiva.working_dir}/{inductiva.output_dir}/{task_id}.
             uncompress: Whether to uncompress the archive after downloading it.
-            rm_archive: Whether to remove the archive after uncompressing it.
+            rm_downloaded_zip_archive: Whether to remove the archive after uncompressing it.
                 If uncompress is False, this argument is ignored.
         """
         api_response = self._api.download_task_output(
@@ -250,7 +250,7 @@ class Task:
 
         if uncompress:
             data.uncompress_task_outputs(zip_path, output_dir)
-            if rm_archive:
+            if rm_downloaded_zip_archive:
                 zip_path.unlink()
 
         return output_dir

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -219,8 +219,8 @@ class Task:
                 files are downloaded to the default directory. The default is
                 {inductiva.working_dir}/{inductiva.output_dir}/{task_id}.
             uncompress: Whether to uncompress the archive after downloading it.
-            rm_downloaded_zip_archive: Whether to remove the archive after uncompressing it.
-                If uncompress is False, this argument is ignored.
+            rm_downloaded_zip_archive: Whether to remove the archive after 
+            uncompressing it. If uncompress is False, this argument is ignored.
         """
         api_response = self._api.download_task_output(
             path_params=self._get_path_params(),


### PR DESCRIPTION
The task class was only working when the output_dir variable was from type pathlib.Path. In this PR, I fixed it, now output_dir can be a str or a path like object. 