### PR TITLE
Stellarators redefined simulate method

### DIFF
--- a/inductiva/stellarators/scenarios/coils/coils.py
+++ b/inductiva/stellarators/scenarios/coils/coils.py
@@ -236,18 +236,7 @@ class StellaratorCoils(scenarios.Scenario):
     ) -> tasks.Task:
         """Simulates the scenario.
 
-        A simulation can be performed in two ways simply by adding some more
-        arguments. 
-        
-        If `num_iterations`, `num_samples` and `sigma_scaling_factor`
-        are all not provided, the simulation merely uses the created device and 
-        performs the computation of the magnetic field produced by its coils
-        on the given plasma surface. Additionally, it produces an output of
-        the objective functions that assess the quality of the device.
-
-        Alternatively, if the arguments are provided (with `num_iterations` and 
-        `num_samples` both greater than 1), the simulation process
-        is different. It also uses the create device, but as a beginning step.
+        The simulation process uses the created device, but as a beginning step.
         Using this initial device, the simulation adds noise to the coefficients
         that describe the coils using a normal distribution function, generating
         `num_samples` configurations. After this, the configuration with the
@@ -255,9 +244,10 @@ class StellaratorCoils(scenarios.Scenario):
         the next iteration. This process is repeated `num_iterations` times. 
         All the generated configurations (their Fourier Series coefficients) 
         and their corresponding objective functions are an output of this 
-        process.
+        process, as well as the magnetic field vector and strength on each 
+        point of the plasma surface.
 
-        This second process is designed to find the best stellarator 
+        This process is designed to find the best stellarator 
         configuration out of all configurations in a particular range
         of parameters (a hyper-sphere of Fourier Series coefficients that
         define the stellarator coils). This way, this search process performed

--- a/inductiva/stellarators/scenarios/coils/coils.py
+++ b/inductiva/stellarators/scenarios/coils/coils.py
@@ -236,23 +236,23 @@ class StellaratorCoils(scenarios.Scenario):
     ) -> tasks.Task:
         """Simulates the scenario.
 
-        The simulation process uses the created device, but as a beginning step.
-        Using this initial device, the simulation adds noise to the coefficients
-        that describe the coils using a normal distribution function, generating
-        `num_samples` configurations. After this, the configuration with the
-        lowest value of the objective functions is used as an initial step for
-        the next iteration. This process is repeated `num_iterations` times. 
-        All the generated configurations (their Fourier Series coefficients) 
-        and their corresponding objective functions are an output of this 
-        process, as well as the magnetic field vector and strength on each 
-        point of the plasma surface.
+        The magnetic field produced on the plasma surface and a set of objective
+        functions are computed for a collection of stellarator coil 
+        configurations with the goal of optimizing a stellarator design.
 
-        This process is designed to find the best stellarator 
-        configuration out of all configurations in a particular range
-        of parameters (a hyper-sphere of Fourier Series coefficients that
-        define the stellarator coils). This way, this search process performed
-        by merely adding noise to an initial stellarator acts as a sort of 
-        optimization, allowing the objective functions to be lowered.
+        The optimization is performed as follows:
+        1. The scenario's coil configuration is used as an initial 
+          configuration.
+        2. Gaussian noise is added to each coil parameter to produce 
+          `num_sample` configurations.
+        3. From these configurations, the one with the lowest value of the
+          objective functions is selected.
+        4. This configuration is then used as an initial configuration for
+          the next iteration.
+        5. The process is repeated `num_iteration` times.
+
+        The simulation also outputs the Fourier Series coefficients describing
+        the coils for each of the configurations obtained during the process.
 
         Args:
             simulator: The simulator to use for the simulation.

--- a/inductiva/stellarators/simulators/simsopt.py
+++ b/inductiva/stellarators/simulators/simsopt.py
@@ -19,6 +19,9 @@ class Simsopt(simulation.Simulator):
         coil_coefficients_filename: str,
         coil_currents_filename: str,
         num_field_periods: int,
+        num_iterations: int,
+        num_samples: int,
+        sigma_scaling_factor: float,
         resource_pool_id: Optional[UUID] = None,
         run_async: bool = False,
     ) -> tasks.Task:
@@ -35,6 +38,17 @@ class Simsopt(simulation.Simulator):
               Refers to the number of complete magnetic field repetitions 
               within a stellarator. Represents how many times the magnetic
               field pattern repeats itself along the toroidal direction.
+            num_iterations: Number of iterations to run for the searching 
+              process.
+            num_samples: Number of different stellarator samples generated per 
+              iteration from a configuration. The samples are generated using
+              normal distribution noise for each coefficient of the Fourier 
+              Series that describes the coils.
+            sigma_scaling_factor: Scaling factor for the sigma value used in 
+              the random generation of noise. This argument makes sure that 
+              the noise is generated proportionally to each coefficient. It 
+              also determines the range of search for new values of the
+              coefficients.
             other arguments: See the documentation of the base class.
         """
         return super().run(
@@ -44,4 +58,7 @@ class Simsopt(simulation.Simulator):
             coil_coefficients_filename=coil_coefficients_filename,
             coil_currents_filename=coil_currents_filename,
             plasma_surface_filename=plasma_surface_filename,
-            num_field_periods=num_field_periods)
+            num_field_periods=num_field_periods,
+            num_iterations=num_iterations,
+            num_samples=num_samples,
+            sigma_scaling_factor=sigma_scaling_factor)


### PR DESCRIPTION
This PR aims to include new arguments to the `simulate` method that will decide (when evaluated the API side) what is the simulation that will be performed. 

For the moment, I only included two cases, one where the user provides all the additional arguments and another where the user provides none of them. 

This seemed better for now rather than to check if every argument is None or not and then apply a default value to those that were, but it is easily extendible to that case, it would just make the code look a bit different with a lot of 'if' statements.