### PR TITLE
[ProteinSolvation]Remove option to plot with full precision trajectory 

### DIFF
--- a/inductiva/molecules/scenarios/protein_solvation/post_processing.py
+++ b/inductiva/molecules/scenarios/protein_solvation/post_processing.py
@@ -2,7 +2,7 @@
 import os
 import pathlib
 import time
-import typing
+from typing import Literal
 
 import matplotlib.pyplot as plt
 import MDAnalysis as mda
@@ -11,8 +11,10 @@ import numpy as np
 
 import inductiva
 
+FULL_TRAJECTORY_FILE = "full_trajectory.trr"
 COMPRESSED_TRAJECTORY_FILE = "compressed_trajectory.xtc"
-TOPOLOGY_FILE = "protein.gro"
+PROTEIN_TOPOLOGY_FILE = "protein.gro"
+SYSTEM_TOPOLOGY_FILE = "solvated_protein.tpr"
 
 
 class ProteinSolvationOutput():
@@ -29,19 +31,18 @@ class ProteinSolvationOutput():
             sim_output_path: Path to the simulation output directory."""
 
         self.sim_output_dir = sim_output_path
-        topology_path = os.path.join(self.sim_output_dir, TOPOLOGY_FILE)
+        topology_path = os.path.join(self.sim_output_dir, PROTEIN_TOPOLOGY_FILE)
         trajectory_path = os.path.join(self.sim_output_dir,
                                        COMPRESSED_TRAJECTORY_FILE)
         self.universe = inductiva.molecules.scenarios.utils.unwrap_trajectory(
             topology_path, trajectory_path)
 
-    def render_interactive(
-            self,
-            representation: typing.Literal["cartoon", "ball+stick", "line",
-                                           "point", "surface",
-                                           "ribbon"] = "ball+stick",
-            selection: str = "protein",
-            add_backbone: bool = True):
+    def render_interactive(self,
+                           representation: Literal["cartoon", "ball+stick",
+                                                   "line", "point", "surface",
+                                                   "ribbon"] = "ball+stick",
+                           selection: str = "protein",
+                           add_backbone: bool = True):
         """
         Render the simulation outputs in an interactive visualization.
         Args: 
@@ -60,11 +61,9 @@ class ProteinSolvationOutput():
         view.center()
 
         print("System Information: ")
-        print(f"Number of atoms in the system: {len(self.universe.atoms)}")
+        print(f"Number of protein atoms: {len(self.universe.atoms)}")
         print(f"Number of amino acids: "
               f"{self.universe.select_atoms('protein').n_residues}")
-        print(f"Number of solvent molecules:"
-              f"{self.universe.select_atoms('not protein').n_residues}")
         print(f"Number of trajectory frames: {len(self.universe.trajectory)}")
         return view
 
@@ -85,10 +84,9 @@ class ProteinSolvationOutput():
             nglview_visualization: Whether to return visualization of the 
             RMSF using nglview or not."""
         start_time = time.time()
-        topology_path = os.path.join(self.sim_output_dir,
-                                     "solvated_protein.tpr")
+        topology_path = os.path.join(self.sim_output_dir, SYSTEM_TOPOLOGY_FILE)
         full_trajectory_path = os.path.join(self.sim_output_dir,
-                                            "full_trajectory.trr")
+                                            FULL_TRAJECTORY_FILE)
         full_precision_universe = mda.Universe(topology_path,
                                                full_trajectory_path)
 
@@ -120,8 +118,8 @@ class ProteinSolvationOutput():
     def render_attribute_per_residue(
         self,
         residue_attributes: np.ndarray,
-        representation: typing.Literal["cartoon", "ball+stick", "line", "point",
-                                       "surface", "ribbon"] = "cartoon"):
+        representation: Literal["cartoon", "ball+stick", "line", "point",
+                                "surface", "ribbon"] = "cartoon"):
         """Render a specific protein attribute in an interactive visualization.
         Args: 
             residue_attributes: The per residue values of the attribute you want 

--- a/inductiva/molecules/scenarios/protein_solvation/post_processing.py
+++ b/inductiva/molecules/scenarios/protein_solvation/post_processing.py
@@ -17,7 +17,7 @@ PROTEIN_TOPOLOGY_FILE = "protein.gro"
 SYSTEM_TOPOLOGY_FILE = "solvated_protein.tpr"
 
 
-class ProteinSolvationOutput():
+class ProteinSolvationOutput:
     """Post process the simulation output of a ProteinSolvation scenario."""
 
     def __init__(self, sim_output_path: pathlib.Path = None):

--- a/inductiva/molecules/scenarios/protein_solvation/post_processing.py
+++ b/inductiva/molecules/scenarios/protein_solvation/post_processing.py
@@ -68,7 +68,6 @@ class ProteinSolvationOutput():
         print(f"Number of trajectory frames: {len(self.universe.trajectory)}")
         return view
 
-
     def calculate_rmsf_trajectory(self,
                                   use_compressed_trajectory: bool = False):
         """Calculate the root mean square fluctuation (RMSF) over a trajectory.  
@@ -115,11 +114,10 @@ class ProteinSolvationOutput():
         plt.show()
 
     def render_attribute_per_residue(
-            self,
-            residue_attributes: np.ndarray,
-            representation: typing.Literal["cartoon", "ball+stick", "line",
-                                           "point", "surface",
-                                           "ribbon"] = "cartoon"):
+        self,
+        residue_attributes: np.ndarray,
+        representation: typing.Literal["cartoon", "ball+stick", "line", "point",
+                                       "surface", "ribbon"] = "cartoon"):
         """Render a specific protein attribute in an interactive visualization.
         Args: 
             residue_attributes: The per residue values of the attribute you want 

--- a/inductiva/molecules/scenarios/protein_solvation/post_processing.py
+++ b/inductiva/molecules/scenarios/protein_solvation/post_processing.py
@@ -12,7 +12,7 @@ import numpy as np
 import inductiva
 
 COMPRESSED_TRAJECTORY_FILE = "compressed_trajectory.xtc"
-TOPOLOGY_FILE = "solvated_protein.tpr"
+TOPOLOGY_FILE = "protein.gro"
 
 
 class ProteinSolvationOutput():
@@ -68,8 +68,7 @@ class ProteinSolvationOutput():
         print(f"Number of trajectory frames: {len(self.universe.trajectory)}")
         return view
 
-    def calculate_rmsf_trajectory(self,
-                                  use_compressed_trajectory: bool = False):
+    def calculate_rmsf_trajectory(self):
         """Calculate the root mean square fluctuation (RMSF) over a trajectory.  
 
         It is typically calculated for the alpha carbon atom of each residue. 
@@ -86,12 +85,14 @@ class ProteinSolvationOutput():
             nglview_visualization: Whether to return visualization of the 
             RMSF using nglview or not."""
         start_time = time.time()
-        topology_path = os.path.join(self.sim_output_dir, TOPOLOGY_FILE)
+        topology_path = os.path.join(self.sim_output_dir, "solvated_protein.tpr")
+        full_trajectory_path = os.path.join(self.sim_output_dir, "full_trajectory.trr")
+        full_precision_universe = mda.Universe(topology_path, full_trajectory_path)
 
         aligned_trajectory_path = os.path.join(self.sim_output_dir,
                                                "aligned_traj.dcd")
         inductiva.molecules.scenarios.utils.align_trajectory_to_average(
-            self.universe, aligned_trajectory_path)
+            full_precision_universe, aligned_trajectory_path)
         align_universe = mda.Universe(topology_path, aligned_trajectory_path)
 
         # Calculate RMSF for carbon alpha atoms

--- a/inductiva/molecules/scenarios/protein_solvation/post_processing.py
+++ b/inductiva/molecules/scenarios/protein_solvation/post_processing.py
@@ -85,9 +85,12 @@ class ProteinSolvationOutput():
             nglview_visualization: Whether to return visualization of the 
             RMSF using nglview or not."""
         start_time = time.time()
-        topology_path = os.path.join(self.sim_output_dir, "solvated_protein.tpr")
-        full_trajectory_path = os.path.join(self.sim_output_dir, "full_trajectory.trr")
-        full_precision_universe = mda.Universe(topology_path, full_trajectory_path)
+        topology_path = os.path.join(self.sim_output_dir,
+                                     "solvated_protein.tpr")
+        full_trajectory_path = os.path.join(self.sim_output_dir,
+                                            "full_trajectory.trr")
+        full_precision_universe = mda.Universe(topology_path,
+                                               full_trajectory_path)
 
         aligned_trajectory_path = os.path.join(self.sim_output_dir,
                                                "aligned_traj.dcd")

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -57,6 +57,7 @@ class ProteinSolvation(Scenario):
 
         Args:
             simulation_time_ns: The simulation time in ns.
+            output_timestep_ps: The output timestep in ps.
             integrator: The integrator to use for the simulation. Options:
                 - "md" (Molecular Dynamics): Accurate leap-frog algorithm for
                 integrating Newton's equations of motion.
@@ -76,7 +77,10 @@ class ProteinSolvation(Scenario):
         self.nsteps = int(
             simulation_time_ns * 1e6 / 2
         )  # convert to fs and divide by the time step of the simulation (2 fs)
-        self.output_frequency = output_timestep_ps * 1000 / 2  # convert to fs and divide by the time step of the simulation (2 fs)
+        self.output_frequency = (
+            output_timestep_ps
+        ) * 1000 / 2  # convert to fs and divide by the time step
+        # of the simulation (2 fs)
         self.integrator = integrator
         self.n_steps_min = n_steps_min
         commands = self.get_commands()
@@ -127,6 +131,7 @@ def _(self, simulator: GROMACS, input_dir):  # pylint: disable=unused-argument
             "nsteps": self.nsteps,
             "ref_temp": self.temperature,
             "nsteps_minim": self.n_steps_min,
+            "output_frequency": self.output_frequency,
         },
         output_filename_paths=[
             os.path.join(input_dir, "simulation.mdp"),

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -77,9 +77,9 @@ class ProteinSolvation(Scenario):
         self.nsteps = int(
             simulation_time_ns * 1e6 / 2
         )  # convert to fs and divide by the time step of the simulation (2 fs)
-        self.output_frequency = (
-            output_timestep_ps
-        ) * 1000 / 2  # convert to fs and divide by the time step
+        self.output_frequency = int(
+            output_timestep_ps * 1000 /
+            2)  # convert to fs and divide by the time step
         # of the simulation (2 fs)
         self.integrator = integrator
         self.n_steps_min = n_steps_min

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -50,6 +50,7 @@ class ProteinSolvation(Scenario):
             resource_pool_id: Optional[UUID] = None,
             run_async: bool = False,
             simulation_time_ns: float = 10,  # ns
+            output_timestep_ps: float = 1,  # ps
             integrator: Literal["md", "sd", "bd"] = "md",
             n_steps_min: int = 5000) -> tasks.Task:
         """Simulate the solvation of a protein.
@@ -75,6 +76,7 @@ class ProteinSolvation(Scenario):
         self.nsteps = int(
             simulation_time_ns * 1e6 / 2
         )  # convert to fs and divide by the time step of the simulation (2 fs)
+        self.output_frequency = output_timestep_ps * 1000 / 2  # convert to fs and divide by the time step of the simulation (2 fs)
         self.integrator = integrator
         self.n_steps_min = n_steps_min
         commands = self.get_commands()

--- a/inductiva/molecules/scenarios/utils.py
+++ b/inductiva/molecules/scenarios/utils.py
@@ -10,7 +10,7 @@ def unwrap_trajectory(topology, trajectory):
     Args:
         topology: Path to the topology file.
         trajectory: Path to the trajectory file."""
-    universe = mda.Universe(topology, trajectory, all_coordinates=True)
+    universe = mda.Universe(topology, trajectory, guess_bonds=True)
     atoms = universe.atoms
     transformation = transformations.unwrap(atoms)
     universe.trajectory.add_transformations(transformation)

--- a/inductiva/templates/protein_solvation/gromacs/simulation.mdp.jinja
+++ b/inductiva/templates/protein_solvation/gromacs/simulation.mdp.jinja
@@ -4,12 +4,12 @@ nsteps                  = {{ nsteps }}       ; number of steps in simulation
 dt                      = 0.002              ; 2 fs
 
 ; Output control
-nstxout                 = 500                ; save coordinates every 1.0 ps
-nstvout                 = 500                ; save velocities every 1.0 ps
-nstenergy               = 500                ; save energies every 1.0 ps
-nstlog                  = 500                ; update log file every 1.0 ps
-nstxout-compressed      = 500                ; save coordinates every 1.0 ps in the compressed trajectory file
-compressed-x-grps       = protein            ; save only protein coordinates in the compressed trajectory file 
+nstxout                 = {{ output_frequency }}                ; save coordinates every 1.0 ps
+nstvout                 = {{ output_frequency }}                ; save velocities every 1.0 ps
+nstenergy               = {{ output_frequency }}                ; save energies every 1.0 ps
+nstlog                  = {{ output_frequency }}                ; update log file every 1.0 ps
+nstxout-compressed      = {{ output_frequency }}                ; save coordinates every 1.0 ps in the compressed trajectory file
+compressed-x-grps       = protein                               ; save only protein coordinates in the compressed trajectory file 
 
 ; Temperature coupling is on
 tc-grps                 = system             ; single coupling group

--- a/inductiva/templates/protein_solvation/gromacs/simulation.mdp.jinja
+++ b/inductiva/templates/protein_solvation/gromacs/simulation.mdp.jinja
@@ -4,11 +4,12 @@ nsteps                  = {{ nsteps }}       ; number of steps in simulation
 dt                      = 0.002              ; 2 fs
 
 ; Output control
-nstxtcout               = 1                   ; generate .xtc file 
-nstxout                 = 500                ; save coordinates every 500 iter
+nstxout                 = 500                ; save coordinates every 1.0 ps
 nstvout                 = 500                ; save velocities every 1.0 ps
 nstenergy               = 500                ; save energies every 1.0 ps
 nstlog                  = 500                ; update log file every 1.0 ps
+nstxout-compressed      = 500                ; save coordinates every 1.0 ps in the compressed trajectory file
+compressed-x-grps       = protein            ; save only protein coordinates in the compressed trajectory file 
 
 ; Temperature coupling is on
 tc-grps                 = system             ; single coupling group


### PR DESCRIPTION
In this pull request, I have removed the option to render the trajectory with the full precision file. After testing, I saw that plotting with either the full precision file or the compressed one does not yield significant differences in the visualization quality.
The full precision file contains velocity, coordinates, and forces data, so to do more in depth analysis is better to use this one. In this file everything is saved with full precision. 
The compressed file contains only the coordinates and saves them with only 3 decimal places by default. The size of it is much smaller (around 200 times smaller). 
I have chosen to use only the xtc format to render the trajectory. While for the computation of the RMSF uses the full precision file to have a more accurate measure. 
Finally, I have made adjustments to the mdp files. I was saving every timestep of the simulation, resulting in a unnecessarily large xtc file. Now I am saving coordinates every 1 ps. I also chose to only save the protein coordinates and discard the water molecules positions. These changes make the  resulting file smaller. 