### PR TITLE
Change order of the parameters of plate class + typos

### DIFF
--- a/inductiva/structures/plates.py
+++ b/inductiva/structures/plates.py
@@ -35,15 +35,15 @@ class RectangularPlate(Plate):
 
     Attributes:
         plate_type (str): Plate type.
-        length (float): Plate length.
         width (float): Plate width.
+        length (float): Plate length.
     """
 
-    def __init__(self, length: float, width: float) -> None:
+    def __init__(self, width: float, length: float) -> None:
         """Initializes a RectangularPlate object."""
         self.plate_type = "rectangular"
-        self.length = length
         self.width = width
+        self.length = length
 
     def perimeter(self) -> float:
         """Calculate the perimeter of the plate.

--- a/inductiva/structures/scenarios/plate_linear_elastic/geometry_utils.py
+++ b/inductiva/structures/scenarios/plate_linear_elastic/geometry_utils.py
@@ -75,7 +75,7 @@ class GeometricCase:
         holes_mesh_offset = []
         holes_predefined_element_size = []
 
-        for hole in self.holes:
+        for hole in self.holes_list:
             mesh_offset, predefined_element_size = hole.get_hole_mesh_params()
 
             holes_mesh_offset.append(mesh_offset)
@@ -98,7 +98,7 @@ class GeometricCase:
         holes_gmsh = []
         holes_boundary_ids = []
 
-        for hole in self.holes:
+        for hole in self.holes_list:
             hole_gmsh = hole.to_occ()
             gmsh.model.occ.synchronize()
 


### PR DESCRIPTION
This PR includes two changes:
1. `Reordered the parameters of the plate class`, so that the width comes first and then the length. This change is intended to enhance intuitiveness, aligning with the convention of specifying width before length (similar to x before y).
2. `Corrected typos`: Renamed the parameter 'holes' to 'list_holes'.