### PR TITLE
[Coastal area scenario] Add support to read XYZ ASCII bathymetry files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ imageio-ffmpeg
 ipython
 MDAnalysis
 nglview
+utm


### PR DESCRIPTION
This PR adds a classmethod to the `Bathymetry` class that allows reading XYZ ASCII bathymetry files. See #478 for context.

Example code to read some bathymetry from the Sines area available [here](https://sextant.ifremer.fr/record/SDN_CPRD_590_HR_Sines/):
```python
import inductiva

bathymetry = inductiva.fluids.scenarios.coastal_area.Bathymetry.from_ascii_xyz_file("590_HR_Sines.emo")
bathymetry.plot(output_path)
```

![bathymetry_demo](https://github.com/inductiva/inductiva/assets/11545632/37c5162a-aaf7-431b-9b83-853ab12e3782)
