### PR TITLE
[Coastal area scenario] Plot bathymetries on uniform grid

### DIFF
--- a/inductiva/fluids/scenarios/coastal_area/bathymetry.py
+++ b/inductiva/fluids/scenarios/coastal_area/bathymetry.py
@@ -285,8 +285,13 @@ class Bathymetry:
 
         # Filter out points that are far from bathymetry locations.
         tree = scipy.spatial.KDTree(np.c_[self.x, self.y])
+
+        # Obtain distance between each point on the uniform grid and the
+        # closest bathymetry location.
         distance, _ = tree.query(np.c_[x_grid.ravel(), y_grid.ravel()], k=1)
         distance = distance.reshape(x_grid.shape)
+
+        # Set depths to NaN for points that are far from bathymetry locations.
         depths_grid[distance > max_distance] = np.nan
 
         # Plot the bathymetry.

--- a/inductiva/fluids/scenarios/coastal_area/bathymetry.py
+++ b/inductiva/fluids/scenarios/coastal_area/bathymetry.py
@@ -264,6 +264,11 @@ class Bathymetry:
               the minimum or maximum colors, respectively.
             path: Path to save the plot. If `None`, the plot is not saved, and
               the matplotlib `Axes` object is returned instead.
+            grid_size: Size of the uniform grid to which the bathymetry is
+              interpolated before being plotted.
+            max_distance: Threshold distance to filter out points on the
+              uniform grid that are far from points where the bathymetry is
+              defined.
         """
 
         # Create uniform grid for interpolation.

--- a/inductiva/fluids/scenarios/coastal_area/bathymetry.py
+++ b/inductiva/fluids/scenarios/coastal_area/bathymetry.py
@@ -250,9 +250,9 @@ class Bathymetry:
         The data is interpolated from the points where the bathymetry is defined
         to the uniform grid using linear interpolation.
 
-        Points on the uniform grid at a distance to points where the bathymetry
-        is defined larger than a threshold distance `max_distance` are not
-        plotted.
+        Points on the uniform grid at a distance larger than a threshold
+        distance `max_distance` from points where the bathymetry is defined are
+        omitted.
     
         The plot is produced with matplotlib.
 


### PR DESCRIPTION
While the plotting method introduced in #489 works for bathymetries defined over regions with an approximately rectangular overall shape, it failed to accurately represent bathymetries defined over complex regions, e.g. defined over regions with concave borders (or hulls).

In this PR I introduce changes to the plotting method to circumvent this difficulty.

Below I use an example bathymetry (from the region of Algarve, taken from [here](https://sextant.ifremer.fr/record/SDN_CPRD_590_HR_Lidar_Algarve/)) to illustrate the problem and the solution I found to it.

Here is a representation of the x, y coordinates where the bathymetry is defined:

![bathymetry_demo_scatter](https://github.com/inductiva/inductiva/assets/11545632/e7e60f05-3c87-443f-a314-572b98b28d71)

As you can see, there is a lot of white space in the center of the figure.

When plotting this with the previous implementation, we would get something similar to the figure below:

![bathymetry_demo_hull](https://github.com/inductiva/inductiva/assets/11545632/cb670667-bd97-4d6e-a1b2-978b12dcb591)

I overlayed here a red scatter marking the locations where the bathymetry is defined (as shown in the previous figure) and a black line marking the [convex hull](https://en.wikipedia.org/wiki/Convex_hull) containing all those locations.

The problem is that matplotlib plotting methods such as [`tripcolor`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.tripcolor.html) determines the area to color using the convex hull that contains all the points.

The solution I implement interpolates the bathymetry data to a uniform grid and filters out of that grid any point that is at a distance from the locations where the bathymetry is defined larger than a given threshold.

![bathymetry_demo_imshow](https://github.com/inductiva/inductiva/assets/11545632/a2e17a88-50c1-476d-8882-e2a519ff973e)

The size of the grid to which depths are interpolated and the threshold distance are parameters (with reasonable defaults, but which may require tuning in the future) in the plot method.

This allows the user to get a more accurate representation of the bathymetry data they are reading/exploring.