### PR TITLE
Add MachineGroup to the Simulators

### DIFF
--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -24,7 +24,9 @@ output_dir = os.environ.get("INDUCTIVA_OUTPUT_DIR", "inductiva_output")
 api_key = os.environ.get("INDUCTIVA_API_KEY")
 working_dir = None
 
-absl.logging.set_verbosity(logging.INFO)
-
+# Disable urllib3 warnings.
+# TODO: Verify and fix the appearance of this warning.
 urllib3_logger = logging.getLogger("urllib3.connectionpool")
 urllib3_logger.setLevel(logging.CRITICAL)
+
+absl.logging.set_verbosity(absl.logging.INFO)

--- a/inductiva/fluids/scenarios/coastal_area/coastal_area.py
+++ b/inductiva/fluids/scenarios/coastal_area/coastal_area.py
@@ -101,7 +101,7 @@ class CoastalArea(Scenario):
 
         Args:
             simulator: Simulator to use. Supported simulators are: SWASH.
-            machine_group: The MachineGroup to use for the simulation.
+            machine_group: The machine group to use for the simulation.
             simulation_time: Total simulation time, in seconds.
             time_step: Time step, in seconds.
             output_time_step: Time step for the output, in seconds.

--- a/inductiva/fluids/scenarios/coastal_area/coastal_area.py
+++ b/inductiva/fluids/scenarios/coastal_area/coastal_area.py
@@ -5,9 +5,8 @@ import math
 import os
 import shutil
 from typing import Literal, Optional
-from uuid import UUID
 
-from inductiva import tasks
+from inductiva import tasks, resources
 from inductiva.scenarios import Scenario
 from inductiva.simulation import Simulator
 from inductiva.fluids.simulators import SWASH
@@ -91,7 +90,7 @@ class CoastalArea(Scenario):
     def simulate(
         self,
         simulator: Simulator = SWASH(),
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
         simulation_time: float = 100,
         time_step: float = 0.1,
@@ -102,7 +101,7 @@ class CoastalArea(Scenario):
 
         Args:
             simulator: Simulator to use. Supported simulators are: SWASH.
-            resource_pool_id: Resource pool to use for the simulation.
+            machine_group: The MachineGroup to use for the simulation.
             simulation_time: Total simulation time, in seconds.
             time_step: Time step, in seconds.
             output_time_step: Time step for the output, in seconds.
@@ -115,7 +114,7 @@ class CoastalArea(Scenario):
 
         task = super().simulate(
             simulator,
-            resource_pool_id=resource_pool_id,
+            machine_group=machine_group,
             run_async=run_async,
             sim_config_filename=SWASH_CONFIG_FILENAME,
             n_cores=n_cores,

--- a/inductiva/fluids/scenarios/dam_break/dam_break.py
+++ b/inductiva/fluids/scenarios/dam_break/dam_break.py
@@ -2,11 +2,10 @@
 from typing import List, Literal, Optional
 from enum import Enum
 from dataclasses import dataclass
-from uuid import UUID
 
-from inductiva import tasks
+from inductiva import tasks, resources
 from inductiva.simulation import Simulator
-from inductiva.fluids.simulators import DualSPHysics
+from inductiva.fluids.simulators import SPlisHSPlasH
 from inductiva.fluids.scenarios.fluid_block import FluidBlock
 from inductiva.fluids.fluid_types import FluidType
 from inductiva.fluids.fluid_types import WATER
@@ -52,9 +51,9 @@ class DamBreak(FluidBlock):
     # pylint: disable=arguments-renamed
     def simulate(
         self,
-        simulator: Simulator = DualSPHysics(),
-        resource_pool_id: Optional[UUID] = None,
-        device: Literal["cpu", "gpu"] = "gpu",
+        simulator: Simulator = SPlisHSPlasH(),
+        machine_group: Optional[resources.MachineGroup] = None,
+        device: Literal["cpu", "gpu"] = "cpu",
         resolution: Literal["high", "medium", "low"] = "medium",
         simulation_time: float = 1,
         run_async: bool = False,
@@ -63,6 +62,7 @@ class DamBreak(FluidBlock):
 
         Args:
             simulator: Simulator to use.
+            machine_group: The MachineGroup to use for the simulation.
             device: Device in which to run the simulation.
             resolution: Resolution of the simulation.
             simulation_time: Simulation time, in seconds.
@@ -72,7 +72,7 @@ class DamBreak(FluidBlock):
         particle_radius = ParticleRadius[resolution.upper()].value
 
         task = super().simulate(simulator=simulator,
-                                resource_pool_id=resource_pool_id,
+                                machine_group=machine_group,
                                 device=device,
                                 particle_radius=particle_radius,
                                 simulation_time=simulation_time,

--- a/inductiva/fluids/scenarios/dam_break/dam_break.py
+++ b/inductiva/fluids/scenarios/dam_break/dam_break.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from inductiva import tasks, resources
 from inductiva.simulation import Simulator
-from inductiva.fluids.simulators import SPlisHSPlasH
+from inductiva.fluids.simulators import DualSPHysics
 from inductiva.fluids.scenarios.fluid_block import FluidBlock
 from inductiva.fluids.fluid_types import FluidType
 from inductiva.fluids.fluid_types import WATER
@@ -51,9 +51,9 @@ class DamBreak(FluidBlock):
     # pylint: disable=arguments-renamed
     def simulate(
         self,
-        simulator: Simulator = SPlisHSPlasH(),
+        simulator: Simulator = DualSPHysics(),
         machine_group: Optional[resources.MachineGroup] = None,
-        device: Literal["cpu", "gpu"] = "cpu",
+        device: Literal["cpu", "gpu"] = "gpu",
         resolution: Literal["high", "medium", "low"] = "medium",
         simulation_time: float = 1,
         run_async: bool = False,
@@ -62,7 +62,7 @@ class DamBreak(FluidBlock):
 
         Args:
             simulator: Simulator to use.
-            machine_group: The MachineGroup to use for the simulation.
+            machine_group: The machine group to use for the simulation.
             device: Device in which to run the simulation.
             resolution: Resolution of the simulation.
             simulation_time: Simulation time, in seconds.

--- a/inductiva/fluids/scenarios/fluid_block/fluid_block.py
+++ b/inductiva/fluids/scenarios/fluid_block/fluid_block.py
@@ -103,7 +103,7 @@ class FluidBlock(Scenario):
         Args:
             simulator: The simulator to use for the simulation. Supported
               simulators are: SPlisHSPlasH, DualSPHysics.
-            machine_group: The MachineGroup to use for the simulation.
+            machine_group: The machine group to use for the simulation.
             device: Device in which to run the simulation. Available options are
               "cpu" and "gpu".
             particle_radius: Radius of the fluid particles, in meters.

--- a/inductiva/fluids/scenarios/fluid_block/fluid_block.py
+++ b/inductiva/fluids/scenarios/fluid_block/fluid_block.py
@@ -4,7 +4,6 @@ from functools import singledispatchmethod
 import os
 from typing import List, Literal, Optional
 import shutil
-from uuid import UUID
 
 from inductiva import tasks, resources
 from inductiva.scenarios import Scenario

--- a/inductiva/fluids/scenarios/fluid_block/fluid_block.py
+++ b/inductiva/fluids/scenarios/fluid_block/fluid_block.py
@@ -6,7 +6,7 @@ from typing import List, Literal, Optional
 import shutil
 from uuid import UUID
 
-from inductiva import tasks
+from inductiva import tasks, resources
 from inductiva.scenarios import Scenario
 from inductiva.simulation import Simulator
 from inductiva.fluids.fluid_types import FluidType
@@ -89,7 +89,7 @@ class FluidBlock(Scenario):
     def simulate(
         self,
         simulator: Simulator = DualSPHysics(),
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
         device: Literal["cpu", "gpu"] = "gpu",
         particle_radius: float = 0.02,
@@ -104,6 +104,7 @@ class FluidBlock(Scenario):
         Args:
             simulator: The simulator to use for the simulation. Supported
               simulators are: SPlisHSPlasH, DualSPHysics.
+            machine_group: The MachineGroup to use for the simulation.
             device: Device in which to run the simulation. Available options are
               "cpu" and "gpu".
             particle_radius: Radius of the fluid particles, in meters.
@@ -126,7 +127,7 @@ class FluidBlock(Scenario):
         self.output_time_step = output_time_step
 
         task = super().simulate(simulator=simulator,
-                                resource_pool_id=resource_pool_id,
+                                machine_group=machine_group,
                                 run_async=run_async,
                                 device=device)
 

--- a/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
+++ b/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
@@ -4,7 +4,6 @@ from enum import Enum
 from functools import singledispatchmethod
 import os
 from typing import List, Literal, Optional
-from uuid import UUID
 
 from inductiva import tasks, resources
 from inductiva.scenarios import Scenario

--- a/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
+++ b/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
@@ -193,7 +193,7 @@ class FluidTank(Scenario):
 
         Args:
             simulator: Simulator to use. Supported simulators are: SPlisHSPlasH.
-            machine_group: The MachineGroup to use for the simulation.
+            machine_group: The machine group to use for the simulation.
             simulation_time: Total simulation time, in seconds.
             output_time_step: Time step for the output, in seconds.
             resolution: Resolution of the simulation. Controls the particle

--- a/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
+++ b/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
@@ -6,7 +6,7 @@ import os
 from typing import List, Literal, Optional
 from uuid import UUID
 
-from inductiva import tasks
+from inductiva import tasks, resources
 from inductiva.scenarios import Scenario
 from inductiva.simulation import Simulator
 from inductiva.fluids.shapes import BaseShape
@@ -182,7 +182,7 @@ class FluidTank(Scenario):
     def simulate(
         self,
         simulator: Simulator = SPlisHSPlasH(),
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
         device: Literal["cpu", "gpu"] = "cpu",
         simulation_time: float = 5,
@@ -194,7 +194,7 @@ class FluidTank(Scenario):
 
         Args:
             simulator: Simulator to use. Supported simulators are: SPlisHSPlasH.
-            resource_pool_id: Resource pool to use for the simulation.
+            machine_group: The MachineGroup to use for the simulation.
             simulation_time: Total simulation time, in seconds.
             output_time_step: Time step for the output, in seconds.
             resolution: Resolution of the simulation. Controls the particle
@@ -212,7 +212,7 @@ class FluidTank(Scenario):
 
         task = super().simulate(
             simulator,
-            resource_pool_id=resource_pool_id,
+            machine_group=machine_group,
             run_async=run_async,
             device=device,
             sim_config_filename=self.get_config_filename(simulator),

--- a/inductiva/fluids/scenarios/heat_sink/heat_sink.py
+++ b/inductiva/fluids/scenarios/heat_sink/heat_sink.py
@@ -112,7 +112,7 @@ class HeatSink(Scenario):
             simulation_time: The simulation time, in seconds.
             output_time_step: The time step to save the simulation results, in
               seconds.
-            machine_group: The MachineGroup to use for the simulation.
+            machine_group: The machine group to use for the simulation.
             run_async: Whether to run the simulation asynchronously.
         """
         self.simulation_time = simulation_time

--- a/inductiva/fluids/scenarios/heat_sink/heat_sink.py
+++ b/inductiva/fluids/scenarios/heat_sink/heat_sink.py
@@ -3,10 +3,10 @@ from functools import singledispatchmethod
 import os
 import shutil
 from typing import Optional
-from uuid import UUID
+
 from inductiva.fluids.scenarios.heat_sink.output import HeatSinkOutput
 
-from inductiva import tasks
+from inductiva import tasks, resources
 from inductiva.fluids.simulators import OpenFOAM
 from inductiva.simulation import Simulator
 from inductiva.scenarios import Scenario
@@ -100,7 +100,7 @@ class HeatSink(Scenario):
     def simulate(
         self,
         simulator: Simulator = OpenFOAM(),
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
         simulation_time=300,
         output_time_step=10,
@@ -112,7 +112,7 @@ class HeatSink(Scenario):
             simulation_time: The simulation time, in seconds.
             output_time_step: The time step to save the simulation results, in
               seconds.
-            resource_pool_id: The resource pool to use for the simulation.
+            machine_group: The MachineGroup to use for the simulation.
             run_async: Whether to run the simulation asynchronously.
         """
         self.simulation_time = simulation_time
@@ -121,7 +121,7 @@ class HeatSink(Scenario):
         commands = self.get_commands()
 
         task = super().simulate(simulator,
-                                resource_pool_id=resource_pool_id,
+                                machine_group=machine_group,
                                 run_async=run_async,
                                 commands=commands)
 

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -128,7 +128,7 @@ class WindTunnel(Scenario):
             n_cores: Number of cores to use for the simulation.
             resolution: Level of detail of the mesh used for the simulation.
                 Options: "high", "medium" or "low".
-            machine_group: The MachineGroup to use for the simulation.
+            machine_group: The machine group to use for the simulation.
         """
 
         if object_path:

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 from absl import logging
 
-from inductiva import tasks
+from inductiva import tasks, resources
 from inductiva.types import Path
 from inductiva.scenarios import Scenario
 from inductiva.simulation import Simulator
@@ -111,7 +111,7 @@ class WindTunnel(Scenario):
 
     def simulate(self,
                  simulator: Simulator = OpenFOAM("windtunnel"),
-                 resource_pool_id: Optional[UUID] = None,
+                 machine_group: Optional[resources.MachineGroup] = None,
                  run_async: bool = False,
                  object_path: Optional[Path] = None,
                  num_iterations: float = 100,
@@ -129,7 +129,7 @@ class WindTunnel(Scenario):
             n_cores: Number of cores to use for the simulation.
             resolution: Level of detail of the mesh used for the simulation.
                 Options: "high", "medium" or "low".
-            resource_pool_id: Id of the resource pool to use for the simulation.
+            machine_group: The MachineGroup to use for the simulation.
         """
 
         if object_path:
@@ -144,7 +144,7 @@ class WindTunnel(Scenario):
         commands = self.get_commands()
 
         task = super().simulate(simulator,
-                                resource_pool_id=resource_pool_id,
+                                machine_group=machine_group,
                                 run_async=run_async,
                                 n_cores=n_cores,
                                 commands=commands)

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -7,7 +7,6 @@ import os
 import shutil
 import tempfile
 from typing import Optional, List, Literal
-from uuid import UUID
 
 from absl import logging
 

--- a/inductiva/fluids/simulators/dualsphysics.py
+++ b/inductiva/fluids/simulators/dualsphysics.py
@@ -1,9 +1,8 @@
 """DualSPHysics module of the API."""
 
 from typing import Literal, Optional
-from uuid import UUID
 
-from inductiva import types, tasks
+from inductiva import types, tasks, resources
 from inductiva.simulation import Simulator
 
 
@@ -19,7 +18,7 @@ class DualSPHysics(Simulator):
         input_dir: types.Path,
         sim_config_filename: str,
         device: Literal["gpu", "cpu"] = "cpu",
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
     ) -> tasks.Task:
         """Run the simulation.
@@ -30,7 +29,7 @@ class DualSPHysics(Simulator):
             other arguments: See the documentation of the base class.
         """
         return super().run(input_dir,
-                           resource_pool_id=resource_pool_id,
+                           machine_group=machine_group,
                            device=device,
                            input_filename=sim_config_filename,
                            run_async=run_async)

--- a/inductiva/fluids/simulators/openfoam.py
+++ b/inductiva/fluids/simulators/openfoam.py
@@ -1,6 +1,5 @@
 """OpenFOAM module of the API for fluid dynamics."""
 from typing import Optional, List
-from uuid import UUID
 
 from inductiva import types, tasks, resources
 from inductiva.simulation import Simulator

--- a/inductiva/fluids/simulators/openfoam.py
+++ b/inductiva/fluids/simulators/openfoam.py
@@ -2,7 +2,7 @@
 from typing import Optional, List
 from uuid import UUID
 
-from inductiva import types, tasks
+from inductiva import types, tasks, resources
 from inductiva.simulation import Simulator
 
 
@@ -21,7 +21,7 @@ class OpenFOAM(Simulator):
         self,
         input_dir: types.Path,
         commands: List[dict],
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: Optional[resources.MachineGroup] = None,
         n_cores: int = 1,
         run_async: bool = False,
     ) -> tasks.Task:
@@ -33,7 +33,7 @@ class OpenFOAM(Simulator):
             other arguments: See the documentation of the base class.
         """
         return super().run(input_dir,
-                           resource_pool_id=resource_pool_id,
+                           machine_group=machine_group,
                            n_cores=n_cores,
                            commands=commands,
                            run_async=run_async)

--- a/inductiva/fluids/simulators/splishsplash.py
+++ b/inductiva/fluids/simulators/splishsplash.py
@@ -1,8 +1,7 @@
 """DualSPHysics module of the API."""
 from typing import Literal, Optional
-from uuid import UUID
 
-from inductiva import types, tasks
+from inductiva import types, tasks, resources
 from inductiva.simulation import Simulator
 
 
@@ -17,7 +16,7 @@ class SPlisHSPlasH(Simulator):
         self,
         input_dir: types.Path,
         sim_config_filename: str,
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: Optional[resources.MachineGroup] = None,
         device: Literal["gpu", "cpu"] = "cpu",
         run_async: bool = False,
     ) -> tasks.Task:
@@ -30,7 +29,7 @@ class SPlisHSPlasH(Simulator):
         """
         return super().run(
             input_dir,
-            resource_pool_id=resource_pool_id,
+            machine_group=machine_group,
             device=device,
             input_filename=sim_config_filename,
             run_async=run_async,

--- a/inductiva/fluids/simulators/swash.py
+++ b/inductiva/fluids/simulators/swash.py
@@ -1,8 +1,8 @@
 """SWASH module of the API."""
 from typing import Optional
-from uuid import UUID
+
 from inductiva.simulation import Simulator
-from inductiva import types, tasks
+from inductiva import types, tasks, resources
 
 
 class SWASH(Simulator):
@@ -16,7 +16,7 @@ class SWASH(Simulator):
         self,
         input_dir: types.Path,
         sim_config_filename: str,
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: Optional[resources.MachineGroup] = None,
         n_cores: int = 1,
         run_async: bool = False,
     ) -> tasks.Task:
@@ -28,7 +28,7 @@ class SWASH(Simulator):
             other arguments: See the documentation of the base class.
         """
         return super().run(input_dir,
-                           resource_pool_id=resource_pool_id,
+                           machine_group=machine_group,
                            input_filename=sim_config_filename,
                            n_cores=n_cores,
                            run_async=run_async)

--- a/inductiva/fluids/simulators/xbeach.py
+++ b/inductiva/fluids/simulators/xbeach.py
@@ -1,8 +1,7 @@
 """DualSPHysics module of the API."""
 from typing import Optional
-from uuid import UUID
 
-from inductiva import types, tasks
+from inductiva import types, tasks, resources
 from inductiva.simulation import Simulator
 
 
@@ -17,7 +16,7 @@ class XBeach(Simulator):
         self,
         input_dir: types.Path,
         sim_config_filename: Optional[str] = "params.txt",
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: Optional[resources.MachineGroup] = None,
         n_cores: int = 1,
         run_async: bool = False,
     ) -> tasks.Task:
@@ -32,6 +31,6 @@ class XBeach(Simulator):
             input_dir,
             input_filename=sim_config_filename,
             n_cores=n_cores,
-            resource_pool_id=resource_pool_id,
+            machine_group=machine_group,
             run_async=run_async,
         )

--- a/inductiva/molecules/scenarios/md_water_box/md_water_box.py
+++ b/inductiva/molecules/scenarios/md_water_box/md_water_box.py
@@ -4,9 +4,8 @@ from typing import Optional, Literal
 import os
 import shutil
 import tempfile
-from uuid import UUID
 
-from inductiva import tasks
+from inductiva import tasks, resources
 from inductiva.molecules.simulators import GROMACS
 from inductiva.simulation import Simulator
 from inductiva.utils.templates import (TEMPLATES_PATH,
@@ -49,7 +48,7 @@ class MDWaterBox(Scenario):
     def simulate(
             self,
             simulator: Simulator = GROMACS(),
-            resource_pool_id: Optional[UUID] = None,
+            machine_group: Optional[resources.MachineGroup] = None,
             run_async: bool = False,
             simulation_time_ns: float = 10,  # ns
             integrator: Literal["md", "sd", "bd"] = "md",
@@ -57,6 +56,7 @@ class MDWaterBox(Scenario):
         """Simulate the water box scenario using molecular dynamics.
 
         Args:
+            machine_group: The MachineGroup to use for the simulation.
             simulation_time_ns: The simulation time in ns.
             integrator: The integrator to use for the simulation. Options:
                 - "md" (Molecular Dynamics): Accurate leap-frog algorithm for
@@ -70,8 +70,7 @@ class MDWaterBox(Scenario):
             documentation at
             https://manual.gromacs.org/current/user-guide/mdp-options.html.
 
-            resource_pool_id: The ID of the resource pool to use for the
-              simulation.
+            machine_group: The machine group to use for the simulation.
             n_steps_min: Number of steps for energy minimization.
             run_async: Whether to run the simulation asynchronously.
         """
@@ -83,7 +82,7 @@ class MDWaterBox(Scenario):
 
         commands = self.get_commands()
         task = super().simulate(simulator,
-                                resource_pool_id=resource_pool_id,
+                                machine_group=machine_group,
                                 commands=commands,
                                 run_async=run_async)
 

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -4,9 +4,8 @@ from functools import singledispatchmethod
 from typing import Optional, Literal
 import os
 import shutil
-from uuid import UUID
 
-from inductiva import tasks
+from inductiva import tasks, resources
 from inductiva.molecules.simulators import GROMACS
 from inductiva.simulation import Simulator
 from inductiva.utils.templates import (TEMPLATES_PATH,
@@ -47,7 +46,7 @@ class ProteinSolvation(Scenario):
     def simulate(
             self,
             simulator: Simulator = GROMACS(),
-            resource_pool_id: Optional[UUID] = None,
+            machine_group: Optional[resources.MachineGroup] = None,
             run_async: bool = False,
             simulation_time_ns: float = 10,  # ns
             output_timestep_ps: float = 1,  # ps
@@ -56,6 +55,7 @@ class ProteinSolvation(Scenario):
         """Simulate the solvation of a protein.
 
         Args:
+            machine_group: The MachineGroup to use for the simulation.
             simulation_time_ns: The simulation time in ns.
             output_timestep_ps: The output timestep in ps.
             integrator: The integrator to use for the simulation. Options:
@@ -85,7 +85,7 @@ class ProteinSolvation(Scenario):
         self.n_steps_min = n_steps_min
         commands = self.get_commands()
         task = super().simulate(simulator,
-                                resource_pool_id=resource_pool_id,
+                                machine_group=machine_group,
                                 commands=commands,
                                 run_async=run_async)
 

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -55,7 +55,7 @@ class ProteinSolvation(Scenario):
         """Simulate the solvation of a protein.
 
         Args:
-            machine_group: The MachineGroup to use for the simulation.
+            machine_group: The machine group to use for the simulation.
             simulation_time_ns: The simulation time in ns.
             output_timestep_ps: The output timestep in ps.
             integrator: The integrator to use for the simulation. Options:

--- a/inductiva/molecules/simulators/gromacs.py
+++ b/inductiva/molecules/simulators/gromacs.py
@@ -25,7 +25,7 @@ class GROMACS(Simulator):
         Args:
             input_dir: Path to the directory containing the input files.
             commands: List of commands to run using the GROMACS simulator.
-            machine_group: The MachineGroup to use for the simulation.
+            machine_group: The machine group to use for the simulation.
             run_async: Whether to run the simulation asynchronously.
         """
         return super().run(input_dir,

--- a/inductiva/molecules/simulators/gromacs.py
+++ b/inductiva/molecules/simulators/gromacs.py
@@ -1,9 +1,8 @@
 """GROMACS module of the API"""
 
 from typing import Optional, List
-from uuid import UUID
 
-from inductiva import types, tasks
+from inductiva import types, tasks, resources
 from inductiva.simulation import Simulator
 
 
@@ -18,7 +17,7 @@ class GROMACS(Simulator):
         self,
         input_dir: types.Path,
         commands: List[dict],
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
     ) -> tasks.Task:
         """Run a list of GROMACS commands.
@@ -26,11 +25,10 @@ class GROMACS(Simulator):
         Args:
             input_dir: Path to the directory containing the input files.
             commands: List of commands to run using the GROMACS simulator.
-            resource_pool_id: UUID of the resource pool to use for the
-              simulation.
+            machine_group: The MachineGroup to use for the simulation.
             run_async: Whether to run the simulation asynchronously.
         """
         return super().run(input_dir,
-                           resource_pool_id=resource_pool_id,
+                           machine_group=machine_group,
                            commands=commands,
                            run_async=run_async)

--- a/inductiva/resources/machines.py
+++ b/inductiva/resources/machines.py
@@ -60,11 +60,11 @@ class MachineGroup():
                 )
             try:
                 logging.info("Creating a machine group."
-                             "This may take a few minutes.")
+                             "This may take a few seconds.")
                 start_time = time.time()
                 instance_group = api_instance.create_instance_group(
                     body=instance_group_config)
-                creation_time_mins = time.time() - start_time
+                creation_time_secs = time.time() - start_time
 
                 self.id = instance_group.body["id"]
                 self.name = instance_group.body["name"]
@@ -72,7 +72,7 @@ class MachineGroup():
                 #    api_instance)
 
                 logging.info("Machine group successfully created in %.2f s.",
-                             creation_time_mins)
+                             creation_time_secs)
                 self._log_machine_group_info()
 
             except inductiva.client.ApiException as api_exception:
@@ -99,10 +99,10 @@ class MachineGroup():
                              "This may take a few minutes.")
                 start_time = time.time()
                 api_instance.delete_instance_group(body=instance_group_config)
-                termination_time_mins = time.time() - start_time
+                termination_time_mins = (time.time() - start_time) / 60
                 logging.info(
                     "Machine group of %s machines successfully "
-                    "terminated in %.2f s.", self.num_machines,
+                    "terminated in %.2f mins.", self.num_machines,
                     termination_time_mins)
 
             except inductiva.client.ApiException as api_exception:

--- a/inductiva/resources/machines.py
+++ b/inductiva/resources/machines.py
@@ -98,8 +98,7 @@ class MachineGroup():
                 logging.info("Terminating machine group."
                              "This may take a few minutes.")
                 start_time = time.time()
-                api_instance.delete_instance_group(
-                    body=instance_group_config)
+                api_instance.delete_instance_group(body=instance_group_config)
                 termination_time_mins = time.time() - start_time
                 logging.info(
                     "Machine group of %s machines successfully "

--- a/inductiva/resources/machines.py
+++ b/inductiva/resources/machines.py
@@ -64,13 +64,14 @@ class MachineGroup():
                 start_time = time.time()
                 instance_group = api_instance.create_instance_group(
                     body=instance_group_config)
-                creation_time_mins = (time.time() - start_time) / 60
+                creation_time_mins = time.time() - start_time
 
                 self.id = instance_group.body["id"]
+                self.name = instance_group.body["name"]
                 #self.estimated_price = self._compute_estimated_price(
                 #    api_instance)
 
-                logging.info("Machine group successfully created in %.2f mins.",
+                logging.info("Machine group successfully created in %.2f s.",
                              creation_time_mins)
                 self._log_machine_group_info()
 
@@ -84,17 +85,25 @@ class MachineGroup():
             api_instance = inductiva.client.apis.tags.instance_api.InstanceApi(
                 client)
 
+            instance_group_config = \
+                inductiva.client.model.instance_group.InstanceGroup(
+                    name=self.name,
+                    machine_type=self.machine_type,
+                    num_instances=self.num_machines,
+                    spot=self.spot,
+                    disk_size_gb=self.disk_size_gb,
+                    zone=self.zone,
+                )
             try:
                 logging.info("Terminating machine group."
                              "This may take a few minutes.")
                 start_time = time.time()
                 api_instance.delete_instance_group(
-                    body=inductiva.client.model.instance.Instance(
-                        id=self.id, zone=self.zone))
-                termination_time_mins = (time.time() - start_time) / 60
+                    body=instance_group_config)
+                termination_time_mins = time.time() - start_time
                 logging.info(
-                    "Machine group of %s machines successfully"
-                    "terminated in %.2f mins.", self.num_machines,
+                    "Machine group of %s machines successfully "
+                    "terminated in %.2f s.", self.num_machines,
                     termination_time_mins)
 
             except inductiva.client.ApiException as api_exception:
@@ -124,4 +133,6 @@ class MachineGroup():
         logging.info("Number of machines: %s", self.num_machines)
         logging.info("Spot: %s", self.spot)
         logging.info("Disk size: %s GB", self.disk_size_gb)
-        logging.info("Estimated cost per hour: %s $/h", self.estimated_price)
+        # We won't offer price values just yet, due to a bug.
+        # TODO: Fix the price computation.
+        # logging.info("Estimated cost per hour: %s $/h", self.estimated_price)

--- a/inductiva/scenarios.py
+++ b/inductiva/scenarios.py
@@ -3,7 +3,8 @@
 from abc import ABC, abstractmethod
 import tempfile
 from typing import Optional
-from uuid import UUID
+
+from inductiva import resources
 from inductiva.types import Path
 from inductiva.simulation import Simulator
 import json
@@ -34,7 +35,7 @@ class Scenario(ABC):
     def simulate(
         self,
         simulator: Simulator,
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
         **kwargs,
     ):
@@ -46,7 +47,7 @@ class Scenario(ABC):
 
             return simulator.run(
                 input_dir,
-                resource_pool_id=resource_pool_id,
+                machine_group=machine_group,
                 run_async=run_async,
                 **kwargs,
             )

--- a/inductiva/simulation/simulator.py
+++ b/inductiva/simulation/simulator.py
@@ -1,4 +1,5 @@
 """Base class for low-level simulators."""
+from typing import Optional
 from abc import ABC, abstractmethod
 
 from inductiva import types, tasks, resources
@@ -25,7 +26,7 @@ class Simulator(ABC):
         self,
         input_dir: types.Path,
         *_args,
-        machine_group: resources.MachineGroup = None,
+        machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
         **kwargs,
     ) -> tasks.Task:

--- a/inductiva/simulation/simulator.py
+++ b/inductiva/simulation/simulator.py
@@ -1,12 +1,8 @@
 """Base class for low-level simulators."""
 from abc import ABC, abstractmethod
 
-from typing import Optional
-from uuid import UUID
-
-from inductiva import types
+from inductiva import types, tasks, resources
 from inductiva.utils import files
-from inductiva import tasks
 
 
 class Simulator(ABC):
@@ -29,7 +25,7 @@ class Simulator(ABC):
         self,
         input_dir: types.Path,
         *_args,
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: resources.MachineGroup = None,
         run_async: bool = False,
         **kwargs,
     ) -> tasks.Task:
@@ -48,6 +44,6 @@ class Simulator(ABC):
             self.api_method_name,
             input_dir,
             run_async=run_async,
-            resource_pool_id=resource_pool_id,
+            machine_group=machine_group,
             **kwargs,
         )

--- a/inductiva/stellarators/scenarios/coils/coils.py
+++ b/inductiva/stellarators/scenarios/coils/coils.py
@@ -4,14 +4,14 @@ import os
 import random
 import shutil
 import typing
-import uuid
 
 from absl import logging
 from functools import singledispatchmethod
 
 import numpy as np
 
-from inductiva import scenarios, simulation, stellarators, tasks, types, utils
+from inductiva import (scenarios, simulation, stellarators,
+                       tasks, types, utils, resources)
 
 SIMSOPT_COIL_COEFFICIENTS_FILENAME = 'coil_coefficients.npz'
 SIMSOPT_COIL_CURRENTS_FILENAME = 'coil_currents.npz'
@@ -227,7 +227,7 @@ class StellaratorCoils(scenarios.Scenario):
     def simulate(
         self,
         simulator: simulation.Simulator = stellarators.simulators.Simsopt(),
-        resource_pool_id: typing.Optional[uuid.UUID] = None,
+        machine_group: typing.Optional[resources.MachineGroup] = None,
         run_async: bool = False,
         plasma_surface_filepath: typing.Optional[types.Path] = None,
         num_iterations: int = 1,
@@ -256,7 +256,7 @@ class StellaratorCoils(scenarios.Scenario):
 
         Args:
             simulator: The simulator to use for the simulation.
-            resource_pool_id: The resource pool to use for the simulation.
+            machine_group: The MachineGroup to use for the simulation.
             run_async: Whether to run the simulation asynchronously.
             plasma_surface_filepath: Path to the file with the description of
               the plasma surface on which the magnetic field will be calculated.
@@ -284,7 +284,7 @@ class StellaratorCoils(scenarios.Scenario):
 
         task = super().simulate(
             simulator,
-            resource_pool_id=resource_pool_id,
+            machine_group=machine_group,
             run_async=run_async,
             coil_coefficients_filename=SIMSOPT_COIL_COEFFICIENTS_FILENAME,
             coil_currents_filename=SIMSOPT_COIL_CURRENTS_FILENAME,

--- a/inductiva/stellarators/scenarios/coils/coils.py
+++ b/inductiva/stellarators/scenarios/coils/coils.py
@@ -10,8 +10,8 @@ from functools import singledispatchmethod
 
 import numpy as np
 
-from inductiva import (scenarios, simulation, stellarators,
-                       tasks, types, utils, resources)
+from inductiva import (scenarios, simulation, stellarators, tasks, types, utils,
+                       resources)
 
 SIMSOPT_COIL_COEFFICIENTS_FILENAME = 'coil_coefficients.npz'
 SIMSOPT_COIL_CURRENTS_FILENAME = 'coil_currents.npz'

--- a/inductiva/stellarators/scenarios/coils/coils.py
+++ b/inductiva/stellarators/scenarios/coils/coils.py
@@ -256,7 +256,7 @@ class StellaratorCoils(scenarios.Scenario):
 
         Args:
             simulator: The simulator to use for the simulation.
-            machine_group: The MachineGroup to use for the simulation.
+            machine_group: The machine group to use for the simulation.
             run_async: Whether to run the simulation asynchronously.
             plasma_surface_filepath: Path to the file with the description of
               the plasma surface on which the magnetic field will be calculated.

--- a/inductiva/stellarators/simulators/simsopt.py
+++ b/inductiva/stellarators/simulators/simsopt.py
@@ -1,8 +1,7 @@
 """Simsopt module of the API."""
 from typing import Optional
-from uuid import UUID
 
-from inductiva import simulation, tasks, types
+from inductiva import simulation, tasks, types, resources
 
 
 class Simsopt(simulation.Simulator):
@@ -22,7 +21,7 @@ class Simsopt(simulation.Simulator):
         num_iterations: int,
         num_samples: int,
         sigma_scaling_factor: float,
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
     ) -> tasks.Task:
         """Run the simulation.
@@ -53,7 +52,7 @@ class Simsopt(simulation.Simulator):
         """
         return super().run(
             input_dir,
-            resource_pool_id=resource_pool_id,
+            machine_group=machine_group,
             run_async=run_async,
             coil_coefficients_filename=coil_coefficients_filename,
             coil_currents_filename=coil_currents_filename,

--- a/inductiva/structures/scenarios/plate_linear_elastic/plate_linear_elastic.py
+++ b/inductiva/structures/scenarios/plate_linear_elastic/plate_linear_elastic.py
@@ -5,9 +5,8 @@ import os
 from typing import List, Optional
 
 from functools import singledispatchmethod
-from uuid import UUID
 
-from inductiva import tasks
+from inductiva import tasks, resources
 from inductiva.scenarios import Scenario
 from inductiva.simulation import Simulator
 from inductiva.structures.simulators import FEniCSx
@@ -64,20 +63,20 @@ class DeformablePlate(Scenario):
 
     def simulate(self,
                  simulator: Simulator = FEniCSx(),
-                 resource_pool_id: Optional[UUID] = None,
+                 machine_group: Optional[resources.MachineGroup] = None,
                  run_async: bool = False) -> tasks.Task:
         """Simulates the scenario.
 
         Args:
             simulator: The simulator to use for the simulation.
-            resource_pool_id: The resource pool to use for the simulation.
+            machine_group: The machine group to use for the simulation.
             run_async: Whether to run the simulation asynchronously.
             mesh_filename: Mesh filename.
             bcs_filename: Boundary conditions filename.
             material_filename: Material filename.
         """
         task = super().simulate(simulator,
-                                resource_pool_id=resource_pool_id,
+                                machine_group=machine_group,
                                 run_async=run_async,
                                 mesh_filename=MESH_FILENAME,
                                 bcs_filename=BCS_FILENAME,

--- a/inductiva/structures/simulators/fenicsx.py
+++ b/inductiva/structures/simulators/fenicsx.py
@@ -1,7 +1,6 @@
 """FEniCSx module of the API for Finite Element Analysis."""
 
 from typing import Optional
-from uuid import UUID
 
 import inductiva
 
@@ -23,7 +22,7 @@ class FEniCSx(inductiva.simulation.Simulator):
         mesh_filename: str,
         bcs_filename: str,
         material_filename: str,
-        resource_pool_id: Optional[UUID] = None,
+        machine_group: Optional[inductiva.resources.MachineGroup] = None,
         run_async: bool = False,
     ) -> inductiva.tasks.Task:
         """Run the simulation.
@@ -32,12 +31,12 @@ class FEniCSx(inductiva.simulation.Simulator):
             mesh_filename: Mesh filename.
             bcs_filename: Boundary conditions filename.
             material_filename: Material filename.
-            resource_pool_id: Optional UUID of the resource pool to use.
+            machine_group: The MachineGroup to use for the simulation.
             run_async: Whether to run the simulation asynchronously.
             other arguments: See the documentation of the base class.
         """
         return super().run(input_dir,
-                           resource_pool_id=resource_pool_id,
+                           machine_group=machine_group,
                            run_async=run_async,
                            mesh_filename=mesh_filename,
                            bcs_filename=bcs_filename,

--- a/inductiva/structures/simulators/fenicsx.py
+++ b/inductiva/structures/simulators/fenicsx.py
@@ -31,7 +31,7 @@ class FEniCSx(inductiva.simulation.Simulator):
             mesh_filename: Mesh filename.
             bcs_filename: Boundary conditions filename.
             material_filename: Material filename.
-            machine_group: The MachineGroup to use for the simulation.
+            machine_group: The machine group to use for the simulation.
             run_async: Whether to run the simulation asynchronously.
             other arguments: See the documentation of the base class.
         """

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -1,6 +1,6 @@
 """Functions for running simulations via Inductiva Web API."""
 import pathlib
-from typing import Any
+from typing import Any, Optional
 
 from inductiva import tasks, resources
 from inductiva.api import methods
@@ -9,7 +9,7 @@ from inductiva.api import methods
 def run_simulation(
     api_method_name: str,
     input_dir: pathlib.Path,
-    machine_group: resources.MachineGroup = None,
+    machine_group: Optional[resources.MachineGroup] = None,
     run_async: bool = False,
     **kwargs: Any,
 ) -> tasks.Task:

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -1,16 +1,15 @@
 """Functions for running simulations via Inductiva Web API."""
 import pathlib
-from typing import Any, Optional
-from uuid import UUID
+from typing import Any
 
-from inductiva import tasks
+from inductiva import tasks, resources
 from inductiva.api import methods
 
 
 def run_simulation(
     api_method_name: str,
     input_dir: pathlib.Path,
-    resource_pool_id: Optional[UUID] = None,
+    machine_group: resources.MachineGroup = None,
     run_async: bool = False,
     **kwargs: Any,
 ) -> tasks.Task:
@@ -27,7 +26,7 @@ def run_simulation(
     task_id = methods.invoke_async_api(api_method_name,
                                        params,
                                        type_annotations,
-                                       resource_pool_id=resource_pool_id)
+                                       resource_pool_id=machine_group.id)
     task = tasks.Task(task_id)
     if not isinstance(task_id, str):
         raise RuntimeError(


### PR DESCRIPTION
This PR serves to remove the resource_pool_id from all types of simulators and substitute by the MachineGroup that is already deployed to the Cloud.

The changes descends the inheritance ladder up until the function run_simulation in tasks/run_simulation.py. Here, we keep the concept of resource_pool_id to still identify to the which machines the simulation should go.

Current deployment is under testing to find inconsistencies and bugs!

E.g. of usage now:

```python
machine_group = inductiva.resources.MachineGroup(
    machine_type="c2-standard-16",
    num_machines=2,
    disk_size_gb=30,
    zone="europe-west1-b")

machine_group.start()

scenario = inductiva.molecules.scenarios.ProteinSolvation(protein_pdb = "protein.pdb") 
task = scenario.simulate(simulation_time_ns=0.1,
                                           run_async=False,
                                           machine_group=machine_group)

task.download_outputs()
```

Verify if the scenarios and simulators you own work as expected.