### PR TITLE
Refactor Openfoam Scenarios Post-Processing

### DIFF
--- a/inductiva/fluids/__init__.py
+++ b/inductiva/fluids/__init__.py
@@ -12,7 +12,6 @@ from .fluid_types import (
 from .scenarios import DamBreak
 from .scenarios import FluidBlock
 from .scenarios import WindTunnel
-from .scenarios import WindTunnelOutput
 from .scenarios import (
     FluidTank,
     CubicTankOutlet,
@@ -23,6 +22,7 @@ from .scenarios import (
 from . import scenarios
 from . import shapes
 from . import post_processing
+from .post_processing import SteadyStateOutput
 from .scenarios._post_processing import SPHSimulationOutput
 from .simulators import (
     SWASH,

--- a/inductiva/fluids/__init__.py
+++ b/inductiva/fluids/__init__.py
@@ -22,6 +22,7 @@ from .scenarios import (
 )
 from . import scenarios
 from . import shapes
+from . import post_processing
 from .scenarios._post_processing import SPHSimulationOutput
 from .simulators import (
     SWASH,

--- a/inductiva/fluids/post_processing/__init__.py
+++ b/inductiva/fluids/post_processing/__init__.py
@@ -1,0 +1,2 @@
+#pylint: disable=missing-module-docstring
+from .openfoam import SteadyStateOutput

--- a/inductiva/fluids/post_processing/openfoam.py
+++ b/inductiva/fluids/post_processing/openfoam.py
@@ -66,8 +66,7 @@ class SteadyStateOutput:
 
         return domain_mesh, object_mesh
 
-    def get_object_pressure_field(self,
-                                  save_path: types.Path = None):
+    def get_object_pressure_field(self, save_path: types.Path = None):
         """Get a pressure scalar field over mesh points of the object.
 
         Returns:

--- a/inductiva/fluids/post_processing/openfoam.py
+++ b/inductiva/fluids/post_processing/openfoam.py
@@ -1,7 +1,7 @@
 """Post-processing tools of fluid dynamics steady-state simulations.
 
 This class implements various post-processing capabilities for
-the visuals associated. Namely:
+the visualizations associated. Namely:
     - Pressure over object;
     - Cutting plane;
     - Stream lines.
@@ -23,11 +23,11 @@ class SteadyStateOutput:
     """Post-Process steady-state simulation outputs.
 
     This class contains several methods to post-process the output 
-    and visualize the results of a steady-state simulations where
+    and visualize the results of a steady-state simulation where
     time-independent results are obtained.
 
-    To be general we assume that a simulation is performed inside a
-    regular box and a certain object is placed inside the box.
+    To be general we assume that a simulation is performed over a
+    regular box - the domain - and a certain object placed inside.
     The object is either a small object inside the domain or a more
     general object that spreads all through the domain.
     """
@@ -40,13 +40,16 @@ class SteadyStateOutput:
         
         Attributes:
             sim_output_path: Path to simulation output files.
-            last_time_step: Last time step of the simulation.
+            last_iteration: Last iteration of the simulation.
                 Obtained through the output folders.
         """
 
         self.sim_output_path = sim_output_path
+        # Sort all output folders and files by alphabetical order.
         outputs_dir_list = sorted(os.listdir(sim_output_path))
-        self.last_time_step = float(outputs_dir_list[1])
+        # The second folder is the folder containing the output of
+        # the last iteration.
+        self.last_iteration = float(outputs_dir_list[1])
 
     def get_output_mesh(self):  # pylint: disable=unused-argument
         """Get domain and object mesh info at the steady-state."""
@@ -58,7 +61,7 @@ class SteadyStateOutput:
         pathlib.Path(foam_file_path).touch(exist_ok=True)
 
         reader = pv.OpenFOAMReader(foam_file_path)
-        reader.set_active_time_value(self.last_time_step)
+        reader.set_active_time_value(self.last_iteration)
 
         full_mesh = reader.read()
         domain_mesh = full_mesh["internalMesh"]
@@ -74,7 +77,7 @@ class SteadyStateOutput:
             and to render it.
         """
 
-        _, object_mesh = self.get_mesh_at_time(self.last_time_step)
+        _, object_mesh = self.get_output_mesh(self.last_iteration)
 
         field_notation = OpenFOAMPhysicalField["PRESSURE"].value
         physical_field = MeshData(object_mesh, field_notation)
@@ -107,7 +110,7 @@ class SteadyStateOutput:
                 Types of files permitted: .vtk, .ply, .stl
         """
 
-        mesh, object_mesh = self.get_mesh_at_time(self.last_time_step)
+        mesh, object_mesh = self.get_output_mesh(self.last_iteration)
 
         inlet_position = (mesh.bounds[0], 0, 1)
 
@@ -138,7 +141,7 @@ class SteadyStateOutput:
                 Types of files permitted: .vtk, .ply, .stl
         """
 
-        mesh, object_mesh = self.get_mesh_at_time(self.last_time_step)
+        mesh, object_mesh = self.get_output_mesh(self.last_iteration)
 
         if plane == "xy":
             normal = (0, 0, 1)

--- a/inductiva/fluids/post_processing/openfoam.py
+++ b/inductiva/fluids/post_processing/openfoam.py
@@ -77,7 +77,7 @@ class SteadyStateOutput:
             and to render it.
         """
 
-        _, object_mesh = self.get_output_mesh(self.last_iteration)
+        _, object_mesh = self.get_output_mesh()
 
         field_notation = OpenFOAMPhysicalField["PRESSURE"].value
         physical_field = MeshData(object_mesh, field_notation)
@@ -110,7 +110,7 @@ class SteadyStateOutput:
                 Types of files permitted: .vtk, .ply, .stl
         """
 
-        mesh, object_mesh = self.get_output_mesh(self.last_iteration)
+        mesh, object_mesh = self.get_output_mesh()
 
         inlet_position = (mesh.bounds[0], 0, 1)
 
@@ -141,7 +141,7 @@ class SteadyStateOutput:
                 Types of files permitted: .vtk, .ply, .stl
         """
 
-        mesh, object_mesh = self.get_output_mesh(self.last_iteration)
+        mesh, object_mesh = self.get_output_mesh()
 
         if plane == "xy":
             normal = (0, 0, 1)

--- a/inductiva/fluids/scenarios/__init__.py
+++ b/inductiva/fluids/scenarios/__init__.py
@@ -3,6 +3,7 @@ from .dam_break import DamBreak
 from .fluid_block import FluidBlock
 from .wind_tunnel import WindTunnel
 from .wind_tunnel import WindTunnelOutput
+from .wind_terrain import WindOverTerrain
 from .fluid_tank import (
     FluidTank,
     CubicTankOutlet,

--- a/inductiva/fluids/scenarios/__init__.py
+++ b/inductiva/fluids/scenarios/__init__.py
@@ -2,7 +2,6 @@
 from .dam_break import DamBreak
 from .fluid_block import FluidBlock
 from .wind_tunnel import WindTunnel
-from .wind_tunnel import WindTunnelOutput
 from .wind_terrain import WindOverTerrain
 from .fluid_tank import (
     FluidTank,

--- a/inductiva/fluids/scenarios/wind_terrain/__init__.py
+++ b/inductiva/fluids/scenarios/wind_terrain/__init__.py
@@ -1,0 +1,2 @@
+#pylint: disable=missing-module-docstring
+from .wind_terrain import WindOverTerrain

--- a/inductiva/fluids/scenarios/wind_terrain/wind_terrain.py
+++ b/inductiva/fluids/scenarios/wind_terrain/wind_terrain.py
@@ -126,8 +126,7 @@ class WindOverTerrain(scenarios.Scenario):
                                 n_cores=n_cores,
                                 commands=commands)
 
-        task.set_output_class(
-            fluids.post_processing.SteadyStateOutput)
+        task.set_output_class(fluids.post_processing.SteadyStateOutput)
 
         return task
 

--- a/inductiva/fluids/scenarios/wind_terrain/wind_terrain.py
+++ b/inductiva/fluids/scenarios/wind_terrain/wind_terrain.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 import numpy as np
 
 import inductiva
-from inductiva import fluids, simulation, resources, scenarios
+from inductiva import fluids, simulation, resources, scenarios, world
 
 SCENARIO_TEMPLATE_DIR = os.path.join(inductiva.utils.templates.TEMPLATES_PATH,
                                      "wind_terrain")
@@ -56,7 +56,7 @@ class WindOverTerrain(scenarios.Scenario):
     valid_simulators = [fluids.simulators.OpenFOAM]
 
     def __init__(self,
-                 terrain: inductiva.world.Terrain,
+                 terrain: world.Terrain,
                  wind_velocity: List[float],
                  wind_position: Optional[List[float]] = None,
                  atmosphere_height: float = 300):
@@ -98,8 +98,7 @@ class WindOverTerrain(scenarios.Scenario):
 
     def simulate(
         self,
-        simulator: simulation.Simulator = fluids.simulators.OpenFOAM(
-        ),
+        simulator: simulation.Simulator = fluids.simulators.OpenFOAM(),
         machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
         n_cores: int = 1,
@@ -128,7 +127,7 @@ class WindOverTerrain(scenarios.Scenario):
                                 commands=commands)
 
         task.set_output_class(
-            inductiva.fluids.post_processing.SteadyStateOutput)
+            fluids.post_processing.SteadyStateOutput)
 
         return task
 

--- a/inductiva/fluids/scenarios/wind_terrain/wind_terrain.py
+++ b/inductiva/fluids/scenarios/wind_terrain/wind_terrain.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 import numpy as np
 
 import inductiva
-from inductiva import fluids, resources
+from inductiva import fluids, simulation, resources, scenarios
 
 SCENARIO_TEMPLATE_DIR = os.path.join(inductiva.utils.templates.TEMPLATES_PATH,
                                      "wind_terrain")
@@ -19,7 +19,7 @@ COMMANDS_TEMPLATE_FILE_NAME = "commands.json.jinja"
 TERRAIN_FILENAME = "terrain.stl"
 
 
-class WindOverTerrain(inductiva.scenarios.Scenario):
+class WindOverTerrain(scenarios.Scenario):
     """Wind flowing over complex terrain scenario.
 
     This simulation scenario models the steady-state conditions of
@@ -98,7 +98,7 @@ class WindOverTerrain(inductiva.scenarios.Scenario):
 
     def simulate(
         self,
-        simulator: inductiva.simulation.Simulator = fluids.simulators.OpenFOAM(
+        simulator: simulation.Simulator = fluids.simulators.OpenFOAM(
         ),
         machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
@@ -151,7 +151,7 @@ class WindOverTerrain(inductiva.scenarios.Scenario):
         return commands
 
     @singledispatchmethod
-    def create_input_files(self, simulator: inductiva.simulation.Simulator):
+    def create_input_files(self, simulator: simulation.Simulator):
         pass
 
 

--- a/inductiva/fluids/scenarios/wind_terrain/wind_terrain.py
+++ b/inductiva/fluids/scenarios/wind_terrain/wind_terrain.py
@@ -127,6 +127,9 @@ class WindOverTerrain(inductiva.scenarios.Scenario):
                                 n_cores=n_cores,
                                 commands=commands)
 
+        task.set_output_class(
+            inductiva.fluids.post_processing.SteadyStateOutput)
+
         return task
 
     def get_commands(self):

--- a/inductiva/fluids/scenarios/wind_tunnel/__init__.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/__init__.py
@@ -1,3 +1,3 @@
 #pylint: disable=missing-module-docstring
 from .wind_tunnel import WindTunnel
-from .post_processing import WindTunnelOutput
+from .output import WindTunnelOutput

--- a/inductiva/fluids/scenarios/wind_tunnel/output.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/output.py
@@ -23,8 +23,7 @@ class WindTunnelOutput(inductiva.fluids.post_processing.SteadyStateOutput):
         OpenFOAM.
     """
 
-    def get_force_coefficients(self,
-                               save_path: inductiva.types.Path = None):
+    def get_force_coefficients(self, save_path: inductiva.types.Path = None):
         """Get the force coefficients of the object in the WindTunnel.
         
         The force coefficients are provided in a .dat file during the

--- a/inductiva/fluids/scenarios/wind_tunnel/output.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/output.py
@@ -11,11 +11,10 @@ from inductiva import types
 class WindTunnelOutput(post_processing.SteadyStateOutput):
     """Post-Process WindTunnel simulation outputs.
     This class is based on a more general class for post-processing the
-    outputs of steady-state simulations. It inherits the following processing
-    methods:
+    outputs of steady-state simulations. It inherits the following tools:
         - Pressure over object;
         - Cutting plane;
-        - StreamLines;
+        - Stream lines;
 
     Additionally, it provides the following methods:
         - Force coefficients (added here only for this scenario).
@@ -51,7 +50,7 @@ class WindTunnelOutput(post_processing.SteadyStateOutput):
                 if index == num_header_lines:
                     force_coefficients.append(line.split()[1:])
                 # Add the force coefficients for the simulation time chosen
-                elif index == num_header_lines + self.last_time_step + 1:
+                elif index == num_header_lines + self.last_iteration + 1:
                     force_coefficients.append(line.split())
 
         if save_path:

--- a/inductiva/fluids/scenarios/wind_tunnel/output.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/output.py
@@ -4,10 +4,11 @@ Currently, we only support the OpenFOAM simulator.
 import os
 import csv
 
-import inductiva
+from inductiva.fluids import post_processing
+from inductiva import fluids, types
 
 
-class WindTunnelOutput(inductiva.fluids.post_processing.SteadyStateOutput):
+class WindTunnelOutput(post_processing.SteadyStateOutput):
     """Post-Process WindTunnel simulation outputs.
     This class is based on a more general class for post-processing the
     outputs of steady-state simulations. It inherits the following processing
@@ -23,7 +24,7 @@ class WindTunnelOutput(inductiva.fluids.post_processing.SteadyStateOutput):
         OpenFOAM.
     """
 
-    def get_force_coefficients(self, save_path: inductiva.types.Path = None):
+    def get_force_coefficients(self, save_path: types.Path = None):
         """Get the force coefficients of the object in the WindTunnel.
         
         The force coefficients are provided in a .dat file during the

--- a/inductiva/fluids/scenarios/wind_tunnel/output.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/output.py
@@ -1,0 +1,62 @@
+"""Visualization processing of WindTunnel scenario.
+Currently, we only support the OpenFOAM simulator.
+"""
+import os
+import csv
+
+import inductiva
+
+
+class WindTunnelOutput(inductiva.fluids.post_processing.SteadyStateOutput):
+    """Post-Process WindTunnel simulation outputs.
+    This class is based on a more general class for post-processing the
+    outputs of steady-state simulations. It inherits the following processing
+    methods:
+        - Pressure over object;
+        - Cutting plane;
+        - StreamLines;
+
+    Additionally, it provides the following methods:
+        - Force coefficients (added here only for this scenario).
+
+    Current Support:
+        OpenFOAM.
+    """
+
+    def get_force_coefficients(self,
+                               save_path: inductiva.types.Path = None):
+        """Get the force coefficients of the object in the WindTunnel.
+        
+        The force coefficients are provided in a .dat file during the
+        simulation run-time. This file contains 8 lines that are provide
+        the general input information. In this function, we read the file,
+        ignore the first 8 lines and read the force coefficients for the 
+        simulation_time chosen.
+
+        Args:
+            save_path: Path to save the force coefficients in a .csv file.
+        """
+
+        num_header_lines = 8
+        force_coefficients_path = os.path.join(self.sim_output_path,
+                                               "postProcessing", "forceCoeffs1",
+                                               "0", "forceCoeffs.dat")
+        force_coefficients = []
+
+        with open(force_coefficients_path, "r",
+                  encoding="utf-8") as forces_file:
+            for index, line in enumerate(forces_file.readlines()):
+                # Pick the line 8 of the file:
+                # [#, Time, Cm, Cd, Cl, Cl(f), Cl(r)] and remove the # column
+                if index == num_header_lines:
+                    force_coefficients.append(line.split()[1:])
+                # Add the force coefficients for the simulation time chosen
+                elif index == num_header_lines + self.last_time_step + 1:
+                    force_coefficients.append(line.split())
+
+        if save_path:
+            with open(save_path, "w", encoding="utf-8") as csv_file:
+                csv_writer = csv.writer(csv_file)
+                csv_writer.writerows(force_coefficients)
+
+        return force_coefficients

--- a/inductiva/fluids/scenarios/wind_tunnel/output.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/output.py
@@ -5,7 +5,7 @@ import os
 import csv
 
 from inductiva.fluids import post_processing
-from inductiva import fluids, types
+from inductiva import types
 
 
 class WindTunnelOutput(post_processing.SteadyStateOutput):

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -141,7 +141,7 @@ class WindTunnel(scenarios.Scenario):
                                 n_cores=n_cores,
                                 commands=commands)
 
-        task.set_output_class(fluids.scenarios.WindTunnelOutput)
+        task.set_output_class(fluids.scenarios.wind_tunnel.WindTunnelOutput)
         task.set_default_output_files(self.set_default_output_files())
 
         return task

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -1,7 +1,7 @@
 """Wind tunnel scenario to run an object over an air flow."""
 
 from dataclasses import dataclass
-from enum import Enum
+import enum
 from functools import singledispatchmethod
 import os
 import shutil
@@ -10,25 +10,18 @@ from typing import Optional, List, Literal
 
 from absl import logging
 
-from inductiva import tasks, resources
-from inductiva.types import Path
-from inductiva.scenarios import Scenario
-from inductiva.simulation import Simulator
-from inductiva.fluids.simulators import OpenFOAM
-from inductiva.utils.templates import (TEMPLATES_PATH,
-                                       batch_replace_params_in_template,
-                                       replace_params_in_template)
-from inductiva.utils import files
-from inductiva.fluids.scenarios.wind_tunnel.post_processing import WindTunnelOutput
+import inductiva
+from inductiva import tasks, resources, fluids, types
+from inductiva.utils import templates, files
 
-SCENARIO_TEMPLATE_DIR = os.path.join(TEMPLATES_PATH, "wind_tunnel")
+SCENARIO_TEMPLATE_DIR = os.path.join(templates.TEMPLATES_PATH, "wind_tunnel")
 OPENFOAM_TEMPLATE_INPUT_DIR = "openfoam"
 FILES_SUBDIR = "files"
 COMMANDS_TEMPLATE_FILE_NAME = "commands.json.jinja"
 
 
 @dataclass
-class MeshResolution(Enum):
+class MeshResolution(enum.Enum):
     """Sets particle radius according to resolution."""
     HIGH = [5, 6]
     MEDIUM = [4, 5]
@@ -36,7 +29,7 @@ class MeshResolution(Enum):
     VERY_LOW = [2, 3]
 
 
-class WindTunnel(Scenario):
+class WindTunnel(inductiva.scenarios.Scenario):
     """Physical scenario of a configurable wind tunnel simulation.
 
     A wind tunnel is a tool used in aerodynamic research to study the
@@ -66,7 +59,7 @@ class WindTunnel(Scenario):
     pressure_field, cutting planes and force coefficients.
     """
 
-    valid_simulators = [OpenFOAM]
+    valid_simulators = [fluids.simulators.OpenFOAM]
 
     def __init__(self,
                  flow_velocity: List[float] = None,
@@ -109,10 +102,11 @@ class WindTunnel(Scenario):
         ]
 
     def simulate(self,
-                 simulator: Simulator = OpenFOAM("windtunnel"),
+                 simulator: inductiva.Simulator = fluids.simulators.OpenFOAM(
+                     "windtunnel"),
                  machine_group: Optional[resources.MachineGroup] = None,
                  run_async: bool = False,
-                 object_path: Optional[Path] = None,
+                 object_path: Optional[types.Path] = None,
                  num_iterations: float = 100,
                  resolution: Literal["high", "medium", "low"] = "medium",
                  n_cores: int = 1) -> tasks.Task:
@@ -148,7 +142,7 @@ class WindTunnel(Scenario):
                                 n_cores=n_cores,
                                 commands=commands)
 
-        task.set_output_class(WindTunnelOutput)
+        task.set_output_class(fluids.scenarios.WindTunnelOutput)
         task.set_default_output_files(self.set_default_output_files())
 
         return task
@@ -161,7 +155,7 @@ class WindTunnel(Scenario):
                                               COMMANDS_TEMPLATE_FILE_NAME)
 
         with tempfile.NamedTemporaryFile() as commands_file:
-            replace_params_in_template(
+            templates.replace_params_in_template(
                 template_path=commands_template_path,
                 params={"n_cores": self.n_cores},
                 output_file_path=commands_file.name,
@@ -172,12 +166,12 @@ class WindTunnel(Scenario):
         return commands
 
     @singledispatchmethod
-    def create_input_files(self, simulator: Simulator):
+    def create_input_files(self, simulator: inductiva.Simulator):
         pass
 
 
 @WindTunnel.create_input_files.register
-def _(self, simulator: OpenFOAM, input_dir):  # pylint: disable=unused-argument
+def _(self, simulator: fluids.simulators.OpenFOAM, input_dir):  # pylint: disable=unused-argument
     """Creates OpenFOAM simulation input files."""
 
     # The WindTunnel with OpenFOAM requires changing multiple files
@@ -190,7 +184,7 @@ def _(self, simulator: OpenFOAM, input_dir):  # pylint: disable=unused-argument
                     dirs_exist_ok=True,
                     symlinks=True)
 
-    batch_replace_params_in_template(
+    templates.batch_replace_params_in_template(
         templates_dir=input_dir,
         template_filenames=[
             os.path.join("0", "include",

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -10,8 +10,7 @@ from typing import Optional, List, Literal
 
 from absl import logging
 
-import inductiva
-from inductiva import tasks, resources, fluids, types
+from inductiva import tasks, resources, fluids, types, simulation, scenarios
 from inductiva.utils import templates, files
 
 SCENARIO_TEMPLATE_DIR = os.path.join(templates.TEMPLATES_PATH, "wind_tunnel")
@@ -29,7 +28,7 @@ class MeshResolution(enum.Enum):
     VERY_LOW = [2, 3]
 
 
-class WindTunnel(inductiva.scenarios.Scenario):
+class WindTunnel(scenarios.Scenario):
     """Physical scenario of a configurable wind tunnel simulation.
 
     A wind tunnel is a tool used in aerodynamic research to study the
@@ -102,7 +101,7 @@ class WindTunnel(inductiva.scenarios.Scenario):
         ]
 
     def simulate(self,
-                 simulator: inductiva.Simulator = fluids.simulators.OpenFOAM(
+                 simulator: simulation.Simulator = fluids.simulators.OpenFOAM(
                      "windtunnel"),
                  machine_group: Optional[resources.MachineGroup] = None,
                  run_async: bool = False,
@@ -166,7 +165,7 @@ class WindTunnel(inductiva.scenarios.Scenario):
         return commands
 
     @singledispatchmethod
-    def create_input_files(self, simulator: inductiva.Simulator):
+    def create_input_files(self, simulator: simulation.Simulator):
         pass
 
 

--- a/inductiva/utils/visualization.py
+++ b/inductiva/utils/visualization.py
@@ -21,7 +21,6 @@ from tqdm import tqdm
 import xarray as xr
 
 from inductiva.utils import files
-from inductiva.types import Path
 import threading
 
 MPL_CONFIG_PARAMS = {
@@ -491,65 +490,3 @@ def create_color_plot_movie(
         create_movie_from_frames(frames_dir=tmp_dir,
                                  movie_path=movie_path,
                                  fps=movie_fps)
-
-
-class MeshData:
-    """MeshData class that allows for mesh data manipulation and render.
-
-    Process outputs of simulation over meshes. We assume that scalar
-    fields are defined over the points of the mesh. In this way, we have
-    a general method to manipulate the data and render the specification
-    data. As of now, this serves a niche, but the goal
-    is to integrate this more generally later on.
-
-    Example:
-    Imagine we run a WindTunnel simulation with an object inside
-    for which a mesh was generated. A possible output of the simulation is
-    a mesh of the object with scalar fields over the points defining a certain
-    physical property, e.g., pressure.
-
-    Assume this output mesh is `object_mesh`. To process the pressure field over
-    the data, we can do `pressure_field = MeshData(object_mesh, "p")`
-
-    `pressure_field.mesh` contains a mesh structure with the pressure field over
-    the mesh.
-
-    `pressure_field.render()` renders the pressure field property over the mesh.
-    """
-
-    def __init__(self, mesh_data, scalar_name: str = None):
-        """Initialize a `MeshData` type object.
-
-        Args:
-            mesh_data: pyvista mesh (PolyData or Unstructured) which
-                contains all of the simulated outputs over the mesh.
-            scalar_name: string that defines the scalar we want to
-                manipulate and render. This names depends on the mesh_data
-                array names and on the specific simulator used.
-
-        Attributes:
-            mesh: mesh over the object obtained from
-        """
-        self.mesh = pv.PolyData(mesh_data.points, faces=mesh_data.faces)
-        self.scalar_name = scalar_name
-        self.mesh.point_data[scalar_name] = mesh_data.point_data[scalar_name]
-        self.mesh.cell_data[scalar_name] = mesh_data.cell_data[scalar_name]
-
-    def render(self,
-               off_screen: bool = False,
-               background_color: str = "black",
-               scalars_cmap: str = "viridis",
-               virtual_display: bool = False,
-               save_path: Path = None):
-        """Render scalar field data over the mesh."""
-        if save_path is not None:
-            save_path = files.resolve_path(save_path)
-
-        if virtual_display:
-            pv.start_xvfb()
-
-        plotter = pv.Plotter(off_screen=off_screen)
-        pv.global_theme.background = background_color
-        plotter.add_mesh(self.mesh, scalars=self.scalar_name, cmap=scalars_cmap)
-        plotter.show(screenshot=save_path)
-        plotter.close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     ipython
     nglview
     MDAnalysis
+    utm
 
 [options.package_data]
 # Include .obj and .jinja files:


### PR DESCRIPTION
This PR serves to refactor the post-processing capabilities for some of the OpenFOAM scenarios. 

**Motive:** The post-processing tools for the new WindOverTerrain scenario are analogous to those of the WindTunnel scenario. Hence, to remove code duplication the latter tools need to be available for both.

In general, these tools will be good enough for steady state simulations.

**Approach:** Create a SteadyStateOutput class that manages all post-processing tools that fit both scenarios above.
-> For the WindTunnel we need an extra tool, which obtains the force coefficients from simulation outputs. With this in mind, the `WindTunnelOutput` class is now a child of `SteadyStateOutput` which implements this specific function.

Later on, we can further generalize things. 
This finishes the implementation of the WindOverTerrain scenario. To conclude its deployment still need to document it and run further tests.