### PR TITLE
Fix default values workflow in tasks module

### DIFF
--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -23,10 +23,14 @@ def run_simulation(
         "sim_dir": pathlib.Path,
     }
 
+    resource_pool_id = None
+    if machine_group is not None:
+        resource_pool_id = machine_group.id
+
     task_id = methods.invoke_async_api(api_method_name,
                                        params,
                                        type_annotations,
-                                       resource_pool_id=machine_group.id)
+                                       resource_pool_id=resource_pool_id)
     task = tasks.Task(task_id)
     if not isinstance(task_id, str):
         raise RuntimeError(

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -38,6 +38,7 @@ class Task:
         self.id = task_id
         self._api = tasks_api.TasksApi(api.get_client())
         self._output_class = None
+        self._default_files_list = None
 
     def __enter__(self):
         """Enter context manager for managing a blocking execution.


### PR DESCRIPTION
This PR fixes two issues that were occurring in the tasks module:

- The attribute self._default_files_list was not being initialised to None, hence when using self.get_output() from a task initiliased with just an id, it would fail!
- The resource_pool_id that serves to identify the machines in run_simulation.py was not being correct when machine_group was not provided.