### PR TITLE
Add temp paths to current directory

### DIFF
--- a/inductiva/fluids/scenarios/wind_terrain/wind_terrain.py
+++ b/inductiva/fluids/scenarios/wind_terrain/wind_terrain.py
@@ -137,7 +137,8 @@ class WindOverTerrain(scenarios.Scenario):
                                               OPENFOAM_TEMPLATE_INPUT_DIR,
                                               COMMANDS_TEMPLATE_FILE_NAME)
 
-        with tempfile.NamedTemporaryFile() as commands_file:
+        commands_path = inductiva.utils.files.resolve_path()
+        with tempfile.NamedTemporaryFile(dir=commands_path) as commands_file:
             inductiva.utils.templates.replace_params_in_template(
                 template_path=commands_template_path,
                 params={"n_cores": self.n_cores},

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -153,7 +153,8 @@ class WindTunnel(scenarios.Scenario):
                                               OPENFOAM_TEMPLATE_INPUT_DIR,
                                               COMMANDS_TEMPLATE_FILE_NAME)
 
-        with tempfile.NamedTemporaryFile() as commands_file:
+        commands_path = files.resolve_path()
+        with tempfile.NamedTemporaryFile(dir=commands_path) as commands_file:
             templates.replace_params_in_template(
                 template_path=commands_template_path,
                 params={"n_cores": self.n_cores},

--- a/inductiva/molecules/scenarios/md_water_box/md_water_box.py
+++ b/inductiva/molecules/scenarios/md_water_box/md_water_box.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import tempfile
 
-from inductiva import tasks, resources
+from inductiva import tasks, resources, utils
 from inductiva.molecules.simulators import GROMACS
 from inductiva.simulation import Simulator
 from inductiva.utils.templates import (TEMPLATES_PATH,
@@ -97,7 +97,8 @@ class MDWaterBox(Scenario):
                                               GROMACS_TEMPLATE_INPUT_DIR,
                                               COMMANDS_TEMPLATE_FILE_NAME)
 
-        with tempfile.NamedTemporaryFile() as commands_file:
+        commands_path = utils.files.resolve_path()
+        with tempfile.NamedTemporaryFile(dir=commands_path) as commands_file:
             replace_params_in_template(
                 template_path=commands_template_path,
                 params={"box_size": self.box_size},

--- a/inductiva/scenarios.py
+++ b/inductiva/scenarios.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 import tempfile
 from typing import Optional
 
-from inductiva import resources
+from inductiva import resources, utils
 from inductiva.types import Path
 from inductiva.simulation import Simulator
 import json
@@ -42,7 +42,9 @@ class Scenario(ABC):
         """Simulates the scenario synchronously."""
         self.validate_simulator(simulator)
 
-        with tempfile.TemporaryDirectory() as input_dir:
+        input_path = utils.files.resolve_path()
+
+        with tempfile.TemporaryDirectory(dir=input_path) as input_dir:
             self.create_input_files(simulator, input_dir)
 
             return simulator.run(

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -34,7 +34,7 @@ def get_timestamped_path(path: types.Path, sep: str = "-") -> pathlib.Path:
     return path.with_name(name + path.suffix)
 
 
-def resolve_path(path: types.Path) -> pathlib.Path:
+def resolve_path(path: types.Path = None) -> pathlib.Path:
     """Resolve a path relative to the Inductiva package working directory.
 
     Args:
@@ -44,6 +44,9 @@ def resolve_path(path: types.Path) -> pathlib.Path:
 
     if inductiva.working_dir:
         root = pathlib.Path(inductiva.working_dir)
+
+    if path is None:
+        return root
 
     return pathlib.Path(root, path)
 


### PR DESCRIPTION
This PR adds a path to where the temporary directories of the commands and scenario input files are prepared to send to the backend. The reason for this change is concerned with the Windows framework, where temporary files are created on:
`C:\Users\username\AppData\Local\Temp` and this folder may have weird access permissions for us to read and write files.

Hence, to fix this issue and simplify this approach, we write the files in the current working directory and they are removed automatically with the context manager when passed to the backend.