### PR TITLE
Fix some scenarions not running on Windows: replace NamedTemporaryFile with StringIO

### DIFF
--- a/inductiva/fluids/scenarios/coastal_area/coastal_area.py
+++ b/inductiva/fluids/scenarios/coastal_area/coastal_area.py
@@ -196,7 +196,7 @@ def _(self, simulator: SWASH, input_dir):  # pylint: disable=unused-argument
             "time_step": self.time_step,
             "output_time_step": self.output_time_step,
         },
-        output_file_path=config_file_path,
+        output_file=config_file_path,
         remove_template=True,
     )
 

--- a/inductiva/fluids/scenarios/fluid_block/fluid_block.py
+++ b/inductiva/fluids/scenarios/fluid_block/fluid_block.py
@@ -26,7 +26,7 @@ DUALSPHYSICS_CONFIG_FILENAME = "dam_break.xml"
 
 class FluidBlock(Scenario):
     """Fluid block scenario.
-    
+
     This is a simulation scenario for a fluid block moving in a cubic tank under
     the action of gravity. The tank is a cube of dimensions 1 x 1 x 1 m. The
     fluid block is also cubic, but has configurable dimensions and initial
@@ -188,7 +188,7 @@ def _(self, simulator: SPlisHSPlasH, input_dir):  # pylint: disable=unused-argum
             "particle_sorting": self.particle_sorting,
             "adaptive_time_step": self.adaptive_time_step,
         },
-        output_file_path=os.path.join(input_dir, SPLISHSPLASH_CONFIG_FILENAME),
+        output_file=os.path.join(input_dir, SPLISHSPLASH_CONFIG_FILENAME),
     )
 
 
@@ -216,5 +216,5 @@ def _(self, simulator: DualSPHysics, input_dir):  # pylint: disable=unused-argum
             "fluid": self.fluid,
             "adaptive_time_step": self.adaptive_time_step,
         },
-        output_file_path=os.path.join(input_dir, DUALSPHYSICS_CONFIG_FILENAME),
+        output_file=os.path.join(input_dir, DUALSPHYSICS_CONFIG_FILENAME),
     )

--- a/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
+++ b/inductiva/fluids/scenarios/fluid_tank/fluid_tank.py
@@ -118,7 +118,7 @@ class CylindricalTankOutlet(BaseTankOutlet):
 
 class FluidTank(Scenario):
     """Fluid tank scenario.
-    
+
     This is a simulation scenario for a fluid tank. The tank has a 3D shape that
     may be cubic or cylindrical. Fluid is injected in the tank via an inlet
     located at the top of the tank, and flows out of the tank via an outlet
@@ -133,8 +133,8 @@ class FluidTank(Scenario):
 
     Schematic representation of the simulation scenario: e.g. x/y points right,
     z points up.
-    
-       inlet        
+
+       inlet
     _____________________
     |    |              |
     |    v              |
@@ -147,8 +147,8 @@ class FluidTank(Scenario):
     |                   |
     |___________________|
                     |
-                    v  outlet    
-    
+                    v  outlet
+
     The scenario can be simulated with SPlisHSPlasH.
     """
 
@@ -299,5 +299,5 @@ def _(self, simulator: SPlisHSPlasH, input_dir):  # pylint: disable=unused-argum
             "bounding_box_min": bounding_box_min,
             "bounding_box_max": bounding_box_max,
         },
-        output_file_path=os.path.join(input_dir, SPLISHSPLASH_CONFIG_FILENAME),
+        output_file=os.path.join(input_dir, SPLISHSPLASH_CONFIG_FILENAME),
     )

--- a/inductiva/fluids/scenarios/heat_sink/heat_sink.py
+++ b/inductiva/fluids/scenarios/heat_sink/heat_sink.py
@@ -170,6 +170,6 @@ def _(self, simulator: OpenFOAM, input_dir):  # pylint: disable=unused-argument
             "air_temperature": self.air_temperature,
             "heater_power": self.heater_power
         },
-        output_file_path=params_file_path,
+        output_file=params_file_path,
         remove_template=True,
     )

--- a/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/scenarios/wind_tunnel/wind_tunnel.py
@@ -5,7 +5,7 @@ import enum
 from functools import singledispatchmethod
 import os
 import shutil
-import tempfile
+import io
 from typing import Optional, List, Literal
 
 from absl import logging
@@ -35,7 +35,7 @@ class WindTunnel(scenarios.Scenario):
     effects of air moving past solid objects. Here, the tunnel consists
     of a box object in 3D space (x, y, z) space, where air flows in the
     positive x-direction with a certain velocity.
-            
+
     An arbitrary object is placed within the tunnel, sucht that air flows
     around it, as illustrated in the schematic below:
     |--------------------------------|
@@ -44,7 +44,7 @@ class WindTunnel(scenarios.Scenario):
     |->_______|_o___O_|______________|
 
     This scenario solves steady-state continuity and momentum equations
-    (time-independent) with incompressible flow. 
+    (time-independent) with incompressible flow.
     The simulation solves the time-independent equations for several
     time steps, based on the state of the previous one. The end goal is
     to determine the steady-state of the system, i.e., where the flow
@@ -153,14 +153,13 @@ class WindTunnel(scenarios.Scenario):
                                               OPENFOAM_TEMPLATE_INPUT_DIR,
                                               COMMANDS_TEMPLATE_FILE_NAME)
 
-        with tempfile.NamedTemporaryFile() as commands_file:
-            templates.replace_params_in_template(
-                template_path=commands_template_path,
-                params={"n_cores": self.n_cores},
-                output_file_path=commands_file.name,
-            )
-
-            commands = self.read_commands_from_file(commands_file.name)
+        inmemory_file = io.StringIO()
+        templates.replace_params_in_template(
+            template_path=commands_template_path,
+            params={"n_cores": self.n_cores},
+            output_file=inmemory_file,
+        )
+        commands = self.read_commands_from_file(inmemory_file)
 
         return commands
 

--- a/inductiva/scenarios.py
+++ b/inductiva/scenarios.py
@@ -1,8 +1,9 @@
 """Base class for scenarios."""
 
 from abc import ABC, abstractmethod
+import io
 import tempfile
-from typing import Optional
+from typing import Optional, Union
 
 from inductiva import resources
 from inductiva.types import Path
@@ -19,11 +20,15 @@ class Scenario(ABC):
         """To be implemented in subclasses."""
         pass
 
-    def read_commands_from_file(self, commands_path: str):
+    def read_commands_from_file(self, commands_file: Union[str, io.StringIO]):
         "Read list of commands from commands.json file"
-        with open(commands_path, "r", encoding="utf-8") as f:
-            commands = json.load(f)
-        return commands
+        if isinstance(commands_file, str):
+            with open(commands_file, "r", encoding="utf-8") as f:
+                return json.load(f)
+
+        # Make sure already opened file is read from the beginning
+        commands_file.seek(0)
+        return json.load(commands_file)
 
     def validate_simulator(self, simulator: Simulator):
         """Checks if the scenario can be simulated with the given simulator."""

--- a/inductiva/utils/templates.py
+++ b/inductiva/utils/templates.py
@@ -1,7 +1,8 @@
 """Utils related to template files."""
 
 import os
-from typing import Dict, List
+import io
+from typing import Dict, List, Union
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
@@ -14,7 +15,7 @@ TEMPLATES_PATH = find_path_to_package("templates")
 def replace_params_in_template(
     template_path: str,
     params: Dict,
-    output_file_path: str,
+    output_file: Union[str, io.StringIO],
     remove_template: bool = False,
 ) -> None:
     """Replaces parameters in a template file."""
@@ -27,7 +28,7 @@ def replace_params_in_template(
     environment = Environment(loader=FileSystemLoader(template_dir))
     template = environment.get_template(template_filename)
     stream = template.stream(**params)
-    stream.dump(output_file_path)
+    stream.dump(output_file)
 
     if remove_template:
         os.remove(template_path)
@@ -62,6 +63,6 @@ def batch_replace_params_in_template(
         replace_params_in_template(
             template_path=template_path,
             params=params,
-            output_file_path=output_filename_paths[index],
+            output_file=output_filename_paths[index],
             remove_template=remove_templates,
         )


### PR DESCRIPTION
This fixes the problem described in #507. The problem however wasn't related to permissions to access the filesystem but actually, it was related to differences in behavior of the `NamedTemporaryFile` class in Windows vs. Unix platforms. Quoted from [here](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile):

> Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows). 

My approach to fix this rather than directly using the file-like object provided when creating a `NamedTemporaryFile` was to use `StringIO` to create an "in memory file" to be used when using the templates to create the commands file.


