### PR TITLE
[Coastal area scenario] Update method to write bathymetry to file format required by SWASH

### DIFF
--- a/inductiva/fluids/scenarios/coastal_area/bathymetry.py
+++ b/inductiva/fluids/scenarios/coastal_area/bathymetry.py
@@ -50,12 +50,12 @@ class Bathymetry:
         x_range: Sequence[float],
         y_range: Sequence[float],
     ):
-        """Creates a `Bathymetry` object from a text file.
+        """Creates a `Bathymetry` object from a bot file.
         
-        The depth values are read from a text file. The text file must contain
-        a 2D array with the depths, in meters. The first and second dimensions
-        of the array in the text file (i.e. rows and columns) correspond to the
-        x and y directions, respectively.
+        The depth values are read from a bot file, i.e. a text file with a 2D
+        array with the depths, in meters. The first and second dimensions of the
+        array in the text file (i.e. rows and columns) correspond to the x and y
+        directions, respectively.
 
         Args:
             text_file_path: Path to the text file.
@@ -180,14 +180,27 @@ class Bathymetry:
 
         return cls(depths.flatten(), x.flatten(), y.flatten())
 
-    def to_text_file(self, text_file_path: str):
-        """Writes the bathymetry to a text file.
+    def to_bot_file(self, bot_file_path: str):
+        """Writes the bathymetry to a bot file.
 
         Args:
             text_file_path: Path to the text file.
         """
 
-        np.savetxt(text_file_path, self.depths)
+        x_grid, y_grid = inductiva.utils.grids.get_meshgrid(
+            x_range=self.x_range,
+            y_range=self.y_range,
+            x_num=len(self.x_uniques()),
+            y_num=len(self.y_uniques()),
+        )
+
+        depths_grid = inductiva.utils.interpolation.interpolate_to_uniform_grid(
+            x=(self.x, self.y),
+            values=self.depths,
+            x_grid=(x_grid, y_grid),
+        )
+
+        np.savetxt(bot_file_path, depths_grid)
 
     @property
     def x_range(self) -> Tuple[float]:

--- a/inductiva/fluids/scenarios/coastal_area/bathymetry.py
+++ b/inductiva/fluids/scenarios/coastal_area/bathymetry.py
@@ -180,7 +180,10 @@ class Bathymetry:
 
         return cls(depths.flatten(), x.flatten(), y.flatten())
 
-    def to_bot_file(self, bot_file_path: str):
+    def to_bot_file(
+        self,
+        bot_file_path: str,
+    ):
         """Writes the bathymetry to a bot file.
 
         Args:
@@ -199,6 +202,12 @@ class Bathymetry:
             values=self.depths,
             x_grid=(x_grid, y_grid),
         )
+
+        if np.sum(np.isnan(depths_grid)) > 0:
+            raise ValueError(
+                "The bathymetry cannot be converted to a uniform grid because "
+                "depths are not defined in one or more edge regions of the "
+                "domain.")
 
         np.savetxt(bot_file_path, depths_grid)
 
@@ -363,7 +372,11 @@ class Bathymetry:
         else:
             return ax
 
-    def to_uniform_grid(self, x_resolution: float = 2, y_resolution: float = 2):
+    def to_uniform_grid(
+        self,
+        x_resolution: float = 2,
+        y_resolution: float = 2,
+    ):
         """Converts the bathymetry to a uniform grid.
 
         The bathymetry is interpolated to a grid with uniform spacing in the x

--- a/inductiva/fluids/scenarios/coastal_area/bathymetry.py
+++ b/inductiva/fluids/scenarios/coastal_area/bathymetry.py
@@ -186,6 +186,10 @@ class Bathymetry:
     ):
         """Writes the bathymetry to a bot file.
 
+        The depth values are interpolated to a regular grid and written to a bot
+        file. The grid size is determined automatically from the range and the
+        number of unique x and y values.
+
         Args:
             text_file_path: Path to the text file.
         """

--- a/inductiva/fluids/scenarios/coastal_area/coastal_area.py
+++ b/inductiva/fluids/scenarios/coastal_area/coastal_area.py
@@ -199,7 +199,7 @@ def _(self, simulator: SWASH, input_dir):  # pylint: disable=unused-argument
     )
 
     bathymetry_file_path = os.path.join(input_dir, SWASH_BATHYMETRY_FILENAME)
-    self.bathymetry.to_text_file(bathymetry_file_path)
+    self.bathymetry.to_bot_file(bathymetry_file_path)
 
 
 def _convert_time_to_hmsms(time: float) -> str:

--- a/inductiva/fluids/scenarios/coastal_area/coastal_area.py
+++ b/inductiva/fluids/scenarios/coastal_area/coastal_area.py
@@ -162,10 +162,8 @@ def _(self, simulator: SWASH, input_dir):  # pylint: disable=unused-argument
     bathymetry_x_num = len(self.bathymetry.x_uniques())
     bathymetry_y_num = len(self.bathymetry.y_uniques())
 
-    bathymetry_x_delta = (self.bathymetry.x_range[1] -
-                          self.bathymetry.x_range[0]) / bathymetry_x_num
-    bathymetry_y_delta = (self.bathymetry.y_range[1] -
-                          self.bathymetry.y_range[0]) / bathymetry_y_num
+    bathymetry_x_delta = (self.bathymetry.x_ptp()) / bathymetry_x_num
+    bathymetry_y_delta = (self.bathymetry.y_ptp()) / bathymetry_y_num
 
     # SWASH requires the simulation time to be formatted as HHMMSS.sss.
     simulation_time_hmsms = _convert_time_to_hmsms(self.simulation_time)


### PR DESCRIPTION
This PR introduces a method to write a bathymetry to a bot file, the format required by SWASH. For context, see #478.

It converts the bathymetry to a uniform grid, and writes that grid to the file.

Here is an example snippet:

```python
import inductiva

bathymetry = inductiva.fluids.scenarios.coastal_area.Bathymetry.from_random_depths(
    x_range=(0, 1000),
    y_range=(0, 1000),
    x_num=250,
    y_num=250,
    max_depth=30,
    initial_roughness=0,
)

# To write the bathymetry to a bot file...
# bathymetry.to_bot_file(path)

# Create the scenario.
scenario = inductiva.fluids.scenarios.CoastalArea(bathymetry=bathymetry, ...)

# Run simulation.
# This calls .to_bot_file() internally and generates a bathymetry file compatible with SWASH.
task = scenario.simulate()
```

Running this with the random bathymetry above, we get the following simulation output. I am only representing a short time as a means of illustrating it works.


https://github.com/inductiva/inductiva/assets/11545632/ccd82ef7-8674-4040-b628-c9e11bd41bcd

