### PR TITLE
[Coastal area scenario] Adds crop method

### DIFF
--- a/inductiva/fluids/scenarios/coastal_area/bathymetry.py
+++ b/inductiva/fluids/scenarios/coastal_area/bathymetry.py
@@ -246,6 +246,41 @@ class Bathymetry:
             y_uniques = np.sort(y_uniques)
         return y_uniques
 
+    def crop(self,
+             x_range: Sequence[float],
+             y_range: Sequence[float],
+             remove_offset=True):
+        """Crops the bathymetry to a given range of x and y values.
+        
+        Args:
+            x_range: The range of x values, in meters.
+            y_range: The range of y values, in meters.    
+        """
+        x_min, x_max = x_range
+        y_min, y_max = y_range
+
+        mask = (self.x >= x_min) & (self.x <= x_max) & \
+               (self.y >= y_min) & (self.y <= y_max)
+
+        if np.sum(mask) == 0:
+            raise ValueError(
+                "The bathymetry cannot be cropped because no points are "
+                "defined in the given coordinate ranges.")
+
+        x = self.x[mask]
+        y = self.y[mask]
+        depths = self.depths[mask]
+
+        if remove_offset:
+            x = x - x.min()
+            y = y - y.min()
+
+        return Bathymetry(
+            depths=depths,
+            x=x,
+            y=y,
+        )
+
     def is_uniform_grid(self) -> bool:
         """Determines whether the bathymetry is defined on a uniform grid."""
 


### PR DESCRIPTION
This PR adds a simple cropping method to the bathymetry. For context on why this is relevant, see #478.

Here is an example with [this bathymetry](https://sextant.ifremer.fr/record/SDN_CPRD_590_HR_Lidar_Algarve/) from Algarve:

```python
import inductiva

bathymetry = inductiva.fluids.scenarios.coastal_area.Bathymetry.from_ascii_xyz_file(file_path)
bathymetry.plot(...)
```

This yields the figure below.

![bathymetry_demo_imshow](https://github.com/inductiva/inductiva/assets/11545632/3bd457fa-be6f-4d00-9bcd-c14022c7e945)


Cropping the bathymetry is simple.

```python
cropped_bathymetry = bathymetry.crop(x_range=(51000, 52000), y_range=(12150, 13000))
cropped_bathymetry.plot(...)
```

After cropping, the figure representing the bathymetry is as shown below.

![bathymetry_demo_cropped](https://github.com/inductiva/inductiva/assets/11545632/ec61a92b-a0a8-4759-baa5-c51276a30cb8)
