### PR TITLE
[Coastal area scenario] Adds flexibility to grid interpolation method

### DIFF
--- a/inductiva/fluids/scenarios/coastal_area/bathymetry.py
+++ b/inductiva/fluids/scenarios/coastal_area/bathymetry.py
@@ -334,33 +334,20 @@ class Bathymetry:
               defined.
         """
 
-        # Determine grid size based on ranges and resolution.
-        x_size = int(self.x_ptp() / x_resolution)
-        y_size = int(self.y_ptp() / y_resolution)
+        logging.info("Plotting the bathymetry on a uniform grid...")
+        depths_grid, _ = self._interpolate_to_uniform_grid(
+            x_resolution,
+            y_resolution,
+            threshold_distance=threshold_distance,
+            nullable=True,
+        )
 
-        logging.info(
-            "Plotting the bathymetry on a uniform grid...\n"
-            "- grid resolution %f x %f (m x m) m \n"
-            "- grid size %d x %d", x_resolution, y_resolution, x_size, y_size)
+        x_size = self.x_ptp() / x_resolution
+        y_size = self.y_ptp() / y_resolution
 
         if x_size > 1000 and y_size > 1000:
             logging.warning(
                 "The plotting grid is large. It may take a while to plot.")
-
-        # Create uniform grid for interpolation.
-        (x_grid, y_grid) = inductiva.utils.grids.get_meshgrid(
-            x_range=self.x_range,
-            y_range=self.y_range,
-            x_num=x_size,
-            y_num=y_size,
-        )
-
-        depths_grid = inductiva.utils.interpolation.interpolate_to_uniform_grid(
-            x=(self.x, self.y),
-            values=self.depths,
-            x_grid=(x_grid, y_grid),
-            threshold_distance=threshold_distance,
-        )
 
         # Plot the bathymetry.
         extent = (

--- a/inductiva/fluids/scenarios/coastal_area/bathymetry.py
+++ b/inductiva/fluids/scenarios/coastal_area/bathymetry.py
@@ -389,16 +389,26 @@ class Bathymetry:
         self,
         x_resolution: float = 2,
         y_resolution: float = 2,
+        fill_value: Optional[Union[float, str]] = None,
     ):
         """Converts the bathymetry to a uniform grid.
+
+        The bathymetry is interpolated to a grid with uniform resolution (i.e.
+        spacing) in the x and y directions. Linear interpolation is used to
+        interpolate the bathymetry to the grid.
+        
+        Grid points for which no interpolation is possible may be filled with
+        a constant or with the nearest depth value.
 
         Args:
             x_resolution: Resolution, in meters, of the grid in the x direction.
             y_resolution: Resolution, in meters, of the grid in the y direction.
+            fill_value: Value to fill the grid points for which no interpolation
+              is possible. If "nearest", the nearest depth value is used.
         """
 
         depths_grid, (x_grid, y_grid) = self._interpolate_to_uniform_grid(
-            x_resolution, y_resolution)
+            x_resolution, y_resolution, fill_value=fill_value, nullable=False)
 
         return Bathymetry(depths=depths_grid.flatten(),
                           x=x_grid.flatten(),

--- a/inductiva/utils/interpolation.py
+++ b/inductiva/utils/interpolation.py
@@ -1,51 +1,61 @@
 """Interpolation utilities."""
 
-from typing import Tuple
+from typing import Literal, Optional, Tuple
 
 import numpy as np
 import scipy
 
 
-def interpolate_to_uniform_grid(x: Tuple[np.ndarray],
-                                values: np.ndarray,
-                                x_grid: Tuple[np.ndarray],
-                                threshold_distance=None):
-    """Interpolate values to a uniform grid.
+def interpolate_to_coordinates(
+    x: Tuple[np.ndarray],
+    values: np.ndarray,
+    x_interpolation: Tuple[np.ndarray],
+    method: Literal["nearest", "linear"] = "linear",
+    threshold_distance: Optional[float] = None,
+):
+    """Interpolate values defined at coordinates x to interpolation coordinates.
 
     Args:
         x: Tuple of arrays with the coordinates of the points where values are
           defined.
         values: Array with the values defined at the points defined by `x`.
-        x_grid: Tuple of arrays with the coordinates of the points where values
-          will be interpolated.
-        threshold_distance: If not None, points in `x_grid` that are further
-          than `threshold_distance` from the closest point in `x` will be set to
-          NaN.
+        x_interpolation: Tuple of arrays with the coordinates of the points
+          where values will be interpolated.
+        threshold_distance: If not None, points in `x_interpolation` that are
+          further than `threshold_distance` from the closest point in `x` are
+          set to NaN.
     
     Returns:
-        Array with the interpolated values.
+        Array with the interpolated values. Its shape matches that of the
+        interpolation coordinate arrays.
     """
 
-    interpolator = scipy.interpolate.LinearNDInterpolator(x, values)
+    if method == "nearest":
+        interpolator = scipy.interpolate.NearestNDInterpolator(x, values)
+    elif method == "linear":
+        interpolator = scipy.interpolate.LinearNDInterpolator(x, values)
+    else:
+        raise ValueError("Invalid interpolation method.")
 
-    values_grid = interpolator(x_grid)
+    values_interpolation = interpolator(x_interpolation)
 
     if threshold_distance is not None:
         # Filter out points that are far from x.
         tree = scipy.spatial.KDTree(np.transpose(x))
 
-        # Obtain distance between each point on the uniform grid and the closest
+        # Obtain distance between each interpolation point and the closest
         # location where values are defined.
-        x_grid_shape = np.shape(x_grid)
+        x_interpolation_shape = np.shape(x_interpolation)
 
         distance, _ = tree.query(
-            np.transpose(np.reshape(x_grid, (x_grid_shape[0], -1))),
+            np.transpose(
+                np.reshape(x_interpolation, (x_interpolation_shape[0], -1))),
             k=1,
         )
-        distance = distance.reshape(x_grid_shape[1:])
+        distance = distance.reshape(x_interpolation_shape[1:])
 
         # Set values to NaN for points that are far from locations where values
         # are defined.
-        values_grid[distance > threshold_distance] = np.nan
+        values_interpolation[distance > threshold_distance] = np.nan
 
-    return values_grid
+    return values_interpolation


### PR DESCRIPTION
This PR adds flexibility to the grid interpolation method of the bathymetry class, which allows for other class methods to use it. For context on why we need an interpolation method in this class, see #478.

With this PR, the expected user workflow is now possible:

1 - Read the bathymetry

```python
import inductiva

bathymetry = inductiva.fluids.scenarios.coastal_area.Bathymetry.from_ascii_xyz_file(file_path)
bathymetry.plot()
```

This may read a large, complex bathymetry, for instance:

![bathymetry_demo_imshow](https://github.com/inductiva/inductiva/assets/11545632/0b154ec6-434f-4ad2-b397-8e20d5765d69)

The user then chooses a cropping region and crops the bathymetry.

```python
bathymetry = bathymetry.crop(x_range=(51000, 52000), y_range=(12150, 13000))
bathymetry.plot()
```

The result is the expected crop of the bathymetry.
![bathymetry_demo_cropped](https://github.com/inductiva/inductiva/assets/11545632/5774ebee-c355-4bc8-82b7-a9f06d543d3c)

Note that cropping doesn't do any interpolation, so the bathymetry may end up with patches where it is undefined. See for instance the lower left corner of the image above.

To be used in SWASH simulations, a bathymetry must be converted to a uniform grid. To do so, the user may call:

```python
bathymetry = bathymetry.to_uniform_grid(x_resolution=5,
                                        y_resolution=5,
                                        fill_value="nearest")
bathymetry.plot()
```

This allows setting the grid resolution and the strategy used to fill grid values for which no linear interpolation is possible. For the example snippet, above one would get something similar to the following image.

![bathymetry_demo_cropped_uniform](https://github.com/inductiva/inductiva/assets/11545632/a25577c4-5a36-4e2c-affb-1d4d5f07e211)

Note that the whole domain is now colored.

The final step is simulating a scenario with this bathymetry.

```python
scenario = inductiva.fluids.scenarios.CoastalArea(bathymetry=bathymetry,
                                                  wave_source_location="S",
                                                  wave_amplitude=5,
                                                  wave_period=5.5)

task = scenario.simulate(simulation_time=100)
```

The result is, as expected:


https://github.com/inductiva/inductiva/assets/11545632/1ac063fa-6963-4714-b6b1-4c1fd825a72e

NB: if the user doesn't convert the bathymetry to a uniform grid, the coastal area scenario attempts to do so by calling `bathymetry.to_uniform_grid()`. However, it does so without specifying a strategy to fill nan regions, since the validity of such operation depends strongly on the bathymetry in use.