### PR TITLE
Workflow to publish to PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,10 +1,10 @@
 # Workflow that publishes package to PyPI.
 # The workflow is triggered on push of a tag that starts with "v", e.g. v0.3.0.
-# The worflow will build the package and then publish it to PyPI. Note that the
+# The workflow will build the package and then publish it to PyPI. Note that the
 # version specified in the tag is not the used for the package version on PyPI.
 # The version used is the one specified in the package's setup.cfg file. Ensure
 # that the version specified in the setup.cfg file in the repository is the
-# same used in the tag that triggers the worflow for consistency between the
+# same used in the tag that triggers the workflow for consistency between the
 # repository and the published package.
 name: Publish to PyPI
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,39 @@
+# Workflow that publishes package to PyPI.
+# The workflow is triggered on push of a tag that starts with "v", e.g. v0.3.0.
+# The worflow will build the package and then publish it to PyPI. Note that the
+# version specified in the tag is not the used for the package version on PyPI.
+# The version used is the one specified in the package's setup.cfg file. Ensure
+# that the version specified in the setup.cfg file in the repository is the
+# same used in the tag that triggers the worflow for consistency between the
+# repository and the published package.
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install build
+
+      - name: Build package
+        run: |
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR adds a workflow to publish the package to PyPI when a tag is created in GitHub. Note the caveat about the package version still needing to be defined in the `setup.cfg` file explained in the top of the workflow file.