### PR TITLE
Bump version to 0.2.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = inductiva
-version = 0.0.33
+version = 0.2.5
 description = Python client for the Inductiva API
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Bump version on `setup.cfg`, as the package has been published to PyPI before but the version on the repository is outdated.