### PR TITLE
[Protein Solvation] Allow user to only download the compressed trajectory in ProteinSolvation

### DIFF
--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -44,7 +44,7 @@ class ProteinSolvation(Scenario):
         self.temperature = temperature
 
     def set_default_output_files(self):
-        """Set the downloadable files as the compressed trajectory adjacent.
+        """Set the default output files for the Protein Solvation Scenario.
 
         Instead of downloading the full trajectory, the user can choose
         to download only the compressed trajectory file. The following files

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -43,6 +43,16 @@ class ProteinSolvation(Scenario):
         self.protein_pdb = files.resolve_path(protein_pdb)
         self.temperature = temperature
 
+    def set_small_files(self):
+        """Set the downloadable files as the compressed trajectory.
+
+        Instead of downloading the full trajectory, the user can choose
+        to download only the compressed trajectory file. This requires
+        the name of the compressed trajectory file to be set as the
+        default output file at simulate() time."""
+
+        return ["compressed_trajectory.xtc"]
+
     def simulate(
             self,
             simulator: Simulator = GROMACS("proteinsolvation"),
@@ -51,7 +61,8 @@ class ProteinSolvation(Scenario):
             simulation_time_ns: float = 10,  # ns
             output_timestep_ps: float = 1,  # ps
             integrator: Literal["md", "sd", "bd"] = "md",
-            n_steps_min: int = 5000) -> tasks.Task:
+            n_steps_min: int = 5000,
+            compressed_trajectory: bool = False) -> tasks.Task:
         """Simulate the solvation of a protein.
 
         Args:
@@ -90,6 +101,9 @@ class ProteinSolvation(Scenario):
                                 run_async=run_async)
 
         task.set_output_class(ProteinSolvationOutput)
+
+        if compressed_trajectory is True:
+            task.set_default_output_files(self.set_small_files())
 
         return task
 

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -52,7 +52,8 @@ class ProteinSolvation(Scenario):
         the user does not require the full trajectory at task.get_output()."""
 
         return [
-            "protein.gro", "compressed_trajectory.xtc", "solvated_protein.tpr"
+            "protein.gro", "compressed_trajectory.xtc", "solvated_protein.tpr",
+            "topol.top"
         ]
 
     def simulate(
@@ -96,6 +97,7 @@ class ProteinSolvation(Scenario):
         self.integrator = integrator
         self.n_steps_min = n_steps_min
         commands = self.get_commands()
+
         task = super().simulate(simulator,
                                 machine_group=machine_group,
                                 commands=commands,

--- a/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/scenarios/protein_solvation/protein_solvation.py
@@ -43,15 +43,17 @@ class ProteinSolvation(Scenario):
         self.protein_pdb = files.resolve_path(protein_pdb)
         self.temperature = temperature
 
-    def set_small_files(self):
-        """Set the downloadable files as the compressed trajectory.
+    def set_default_output_files(self):
+        """Set the downloadable files as the compressed trajectory adjacent.
 
         Instead of downloading the full trajectory, the user can choose
-        to download only the compressed trajectory file. This requires
-        the name of the compressed trajectory file to be set as the
-        default output file at simulate() time."""
+        to download only the compressed trajectory file. The following files
+        are set as the default ones, and will be the only ones downloaded if
+        the user does not require the full trajectory at task.get_output()."""
 
-        return ["compressed_trajectory.xtc"]
+        return [
+            "protein.gro", "compressed_trajectory.xtc", "solvated_protein.tpr"
+        ]
 
     def simulate(
             self,
@@ -61,8 +63,7 @@ class ProteinSolvation(Scenario):
             simulation_time_ns: float = 10,  # ns
             output_timestep_ps: float = 1,  # ps
             integrator: Literal["md", "sd", "bd"] = "md",
-            n_steps_min: int = 5000,
-            compressed_trajectory: bool = False) -> tasks.Task:
+            n_steps_min: int = 5000) -> tasks.Task:
         """Simulate the solvation of a protein.
 
         Args:
@@ -101,9 +102,7 @@ class ProteinSolvation(Scenario):
                                 run_async=run_async)
 
         task.set_output_class(ProteinSolvationOutput)
-
-        if compressed_trajectory is True:
-            task.set_default_output_files(self.set_small_files())
+        task.set_default_output_files(self.set_default_output_files())
 
         return task
 


### PR DESCRIPTION
Instead of downloading the full trajectory, the user can choose to download only the compressed trajectory file. This requires the name of the compressed trajectory file to be set as the default output file at simulate() time. The user controls if only wants the compressed trajectory setting compressed_trajectory to True