### PR TITLE
Fix get_machine_type method of Task

### DIFF
--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -356,6 +356,9 @@ class Task:
             return None
 
         machine_info = info["executer"]
+        if "vm_type" not in machine_info:
+            return "inductiva-machine"
+
         machine_type = machine_info["vm_type"].split("/")[-1]
 
         return machine_type


### PR DESCRIPTION
Fix error that occurs when the machine used for the task was not a
google cloud VM.
