### PR TITLE
Cleanup function to list machine groups

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -23,7 +23,7 @@ from inductiva.types import Path
 from inductiva.utils.data import (extract_output, get_validate_request_params,
                                   pack_input, unpack_output)
 from inductiva.utils.meta import get_method_name, get_type_annotations
-from inductiva import utils
+from inductiva.utils import format_utils
 
 
 def validate_api_key(api_key: Optional[str]) -> Configuration:
@@ -86,7 +86,8 @@ def upload_input(api_instance: TasksApi, task_id, original_params,
     )
     file_size = os.path.getsize(input_zip_path)
     logging.info("Input archive created.")
-    logging.info("Input archive size: %s", utils.format_bytes(file_size))
+    logging.info("Input archive size: %s",
+                 format_utils.bytes_formatter(file_size))
 
     logging.info("Uploading input...")
     try:

--- a/inductiva/resources/__init__.py
+++ b/inductiva/resources/__init__.py
@@ -1,4 +1,4 @@
 #pylint: disable=missing-module-docstring
 from .machines import MachineGroup
-from .resources import list_machine_groups, get_machine_group
+from .resources import list_active_machine_groups, get_machine_group
 from . import storage

--- a/inductiva/utils/__init__.py
+++ b/inductiva/utils/__init__.py
@@ -1,4 +1,3 @@
 # pylint: disable=missing-module-docstring
-from .misc import format_bytes
 from . import grids
 from . import interpolation

--- a/inductiva/utils/format_utils.py
+++ b/inductiva/utils/format_utils.py
@@ -1,0 +1,60 @@
+"""Util functions for formatting data for printing to console."""
+import datetime
+import pandas as pd
+import numpy as np
+
+
+def bytes_formatter(n_bytes: int) -> str:
+    """Convert bytes to human readable string."""
+    res = float(n_bytes)
+
+    for unit in ["B", "KiB", "MiB", "GiB", "TiB"]:
+        if res < 1024:
+            if unit == "B":
+                return f"{res:.0f} {unit}"
+            else:
+                return f"{res:.2f} {unit}"
+        res /= 1024
+
+    return f"{bytes_formatter:.2f} PiB"
+
+
+def datetime_formatter(dt: str) -> str:
+    return datetime.datetime.fromisoformat(dt).strftime("%d %b, %H:%M:%S")
+
+
+def seconds_formatter(secs: float) -> str:
+    return (f"{int(secs // 3600)}h "
+            f"{int((secs % 3600) // 60)}m "
+            f"{int(secs % 60)}s")
+
+
+def get_tabular_str(
+    rows,
+    columns,
+    default_col_space=15,
+    override_col_space=None,
+    formatters=None,
+) -> str:
+    """Converts a list of lists to a string table.
+
+    Temporary solution to display tables. `pandas` dependency to print tables
+    is overkill, but since we have `pandas` anyway for now, we can use it.
+    """
+    df = pd.DataFrame(rows, columns=columns)
+
+    formatters = formatters or {}
+
+    col_space = {col: default_col_space for col in columns}
+    col_space.update(override_col_space or {})
+
+    # replace None with np.nan so that pandas can format them as "n/a"
+    # by passing na_rep="n/a" to to_string()
+    df.fillna(np.nan, inplace=True)
+
+    return df.to_string(
+        index=False,
+        na_rep="n/a",
+        formatters=formatters,
+        col_space=col_space,
+    )

--- a/inductiva/utils/misc.py
+++ b/inductiva/utils/misc.py
@@ -6,18 +6,3 @@ def split_camel_case(s):
     """Split a camel case string into a list of strings."""
     return re.sub("([A-Z][a-z]+)", r" \1", re.sub("([A-Z]+)", r" \1",
                                                   s)).split()
-
-
-def format_bytes(n_bytes: int) -> str:
-    """Convert bytes to human readable string."""
-    res = float(n_bytes)
-
-    for unit in ["B", "KiB", "MiB", "GiB", "TiB"]:
-        if res < 1024:
-            if unit == "B":
-                return f"{res:.0f} {unit}"
-            else:
-                return f"{res:.2f} {unit}"
-        res /= 1024
-
-    return f"{format_bytes:.2f} PiB"

--- a/inductiva/utils/output_contents.py
+++ b/inductiva/utils/output_contents.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from typing import List
 
-from inductiva.utils import misc
+from inductiva.utils import format_utils
 
 
 @dataclass
@@ -29,13 +29,14 @@ class OutputContents:
         name_header = "Name"
 
         lines = [
-            f"Archive size: {misc.format_bytes(self.size)}",
+            f"Archive size: {format_utils.bytes_formatter(self.size)}",
             "Contents:",
             f"  {size_header:<12} {compressed_header:<12} {name_header:<12}",
         ]
         for file in self.contents:
-            lines.append(f"  {misc.format_bytes(file.size):<12}"
-                         f" {misc.format_bytes(file.compressed_size):<12}"
-                         f" {file.name:<12}")
+            lines.append(
+                f"  {format_utils.bytes_formatter(file.size):<12}"
+                f" {format_utils.bytes_formatter(file.compressed_size):<12}"
+                f" {file.name:<12}")
 
         return "\n".join(lines)


### PR DESCRIPTION
Introduced changes:
- Change name of method to show machine group cost: now it's called `estimate_cloud_cost` to clarify that it doesn't represent a possible charge, but an estimation of the cost of the requested resources in google cloud.
- Change name of the method that lists active machine groups to reflect that it only displays active machine groups.
- Cleanup display of list of active machine groups:
```
INFO:absl:Active machine groups:
                                    Name         VM Type   # machines         Created at
api-c9054524-7d0c-41ef-a575-58b54ac30479   c2-standard-4            2   07 Sep, 05:56:51
api-c9054524-7d0c-41ef-a575-58b54ac30479   c2-standard-4            2   07 Sep, 05:56:51
```
