### PR TITLE
[Coastal area scenario] Fixes issues with random bathymetry generator

### DIFF
--- a/inductiva/coastal/bathymetry.py
+++ b/inductiva/coastal/bathymetry.py
@@ -136,6 +136,7 @@ class Bathymetry:
         initial_roughness: float = 1,
         roughness_factor: float = 0.5,
         percentile_above_water: float = 20,
+        random_seed=None,
     ):
         """Creates a `Bathymetry` object with random depths.
 
@@ -159,7 +160,10 @@ class Bathymetry:
               Diamond-Square algorithm decreases over iterations.
             percentile_above_water: Percentile of the depths that must be above
               water. Must be between 0 and 100.
+            random_seed: Random seed to use.
         """
+
+        random.seed(random_seed)
 
         corner_values = [
             random.uniform(0, max_depth),
@@ -174,6 +178,7 @@ class Bathymetry:
             corner_values,
             initial_roughness,
             roughness_factor,
+            random_seed=random_seed,
         )
 
         depths = inductiva.generative.procedural.adjust_map_level(

--- a/inductiva/generative/procedural/map_level.py
+++ b/inductiva/generative/procedural/map_level.py
@@ -73,6 +73,6 @@ def adjust_map_level(map_level: np.ndarray, percentile_translate_map: float):
     # is above or below the xy-plane.
     percentile_translate = np.percentile(map_level,
                                          abs(percentile_translate_map))
-    map_level += np.sign(percentile_translate_map) * percentile_translate
+    map_level -= np.sign(percentile_translate_map) * percentile_translate
 
     return map_level


### PR DESCRIPTION
This PR fixes a couple of issues with the random bathymetry generator:
- it adds a random seed for reproducibility.
- it reverses the sign of the offset applied when determining the percentage of point above water (because above water means subtracting depth).