### PR TITLE
Remove repeated info from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,4 @@
-certifi >= 14.5.14
-frozendict ~= 2.3.4
-setuptools >= 21.0.0
-typing-extensions ~= 4.3.0
-urllib3 ~= 1.26.7
-python-dateutil
-absl-py
-numpy
-scipy
-jinja2
-tqdm
-vtk
-xarray
-dask
-matplotlib
-imageio
-pyvista
-imageio-ffmpeg
-ipython
-MDAnalysis
-nglview
-utm
+-e .
+pylint
+pytest
+yapf

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,6 @@ install_requires =
     scipy
     matplotlib
     xarray
-    gmsh
-    meshio
     vtk
     imageio
     pyvista
@@ -38,6 +36,7 @@ install_requires =
     nglview
     MDAnalysis
     utm
+    dask
 
 [options.package_data]
 # Include .obj and .jinja files:


### PR DESCRIPTION
`setup.cfg` is where dependencies of the package that are installed when the user does `pip install inductiva` are specified. `requirements.txt` is just an utility to setup the local dev environment, it now installs the package in editable mode (`-e .`) and other dev dependencies.
