### PR TITLE
Consolidate main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ This yields an interactive visualization of the protein's trajectory that can be
 ![Protein solvation simulation.](resources/media/protein_solvation.gif)
 
 
+
+### Available scenarios
+
+These are currently available scenarios:
+
+- [Coastal Dynamics](inductiva/coastal/README.md)
+- [Wind Tunnel](inductiva/fluids/scenarios/wind_tunnel/README.md)
+- [Fluid Tank](inductiva/fluids/scenarios/fluid_tank/README.md)
+- [Protein Solvation](inductiva/molecules/scenarios/protein_solvation/README.md)
+
+
 ## Simulators
 
 **Inductiva API** has available several open-source simulators ready to use. Users familiar with the simulators can easily start running simulations with their previously prepared simulation configuration files. In this way, they can take advantage of performant hardware to speed up their simulation and exploration.


### PR DESCRIPTION
This PR serves to further consolidate the main README. However, there were somethings I wasn't able to be 100% sure how they should be done. I'll list them here:
- [] The Protein Solvation should be simplified in the main README. I wanted to move it to a separate page, but I noticed that there's already a separate page with Protein Solvation documentation. Which one is the most recent?
- [] Is there any scenario missing a link in the main README?