### PR TITLE
Pip install --upgrade inductiva

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This offers several distinct advantages:
 On your terminal:
 
 ```
-pip install inductiva
+pip install --upgrade inductiva
 ```
 
 ## API access tokens


### PR DESCRIPTION
By default the pip install will not install the latest version of the package, if there was already an older version of inductiva installed.