### PR TITLE
[WindTunnel] Address testing errors with Documentation

### DIFF
--- a/inductiva/fluids/scenarios/wind_tunnel/README.md
+++ b/inductiva/fluids/scenarios/wind_tunnel/README.md
@@ -8,21 +8,21 @@ To initialize the scenario, the user can define the following parameters:
 
 Now, the user is ready to simulate the steady state. Here, the user chooses the object to be inserted inside the wind tunnel. This object is defined with a geometry file in STL or OBJ format. Notice that, the required meshing step will automatically be made before starting the simulation. The meshing is done with the [snappyHexMesh tool](https://www.openfoam.com/documentation/user-guide/4-mesh-generation-and-conversion/4.4-mesh-generation-with-the-snappyhexmesh-utility) of OpenFOAM.
 
-To test this scenario we have available one example of a vehicle geometry in OBJ format - [download it here](../../../../resources/geometry/test_vehicle.obj). The user can also use his own geometry file, as long as it is in STL or OBJ format.
+To test this scenario we have available one example of a vehicle geometry in OBJ format - [download it here](/resources/geometry/test_vehicle.obj). The user can also use his own geometry file, as long as it is in STL or OBJ format.
 
 The simulation parameters available for the user to configure are:
 - `num_iterations`: Set the maximum number of iterations for the iterative algorithm to converge.
 - `resolution`: Controls the resolution of the meshing that is done prior to the simulation. The higher the resolution, the finer the meshing. Possibilities: "high", "medium", "low".
 
 Moreover, the hardware and interaction are configured with the usual general parameters - `machine_group`, `run_async`, `n_cores`.
-Launching a simulation returns a task object, which can be used to verify the status of the simulation, get the simulation outputs and access post-processing tools. See more in the [Tasks section](../../../../README.md).
+Launching a simulation returns a task object, which can be used to verify the status of the simulation, get the simulation outputs and access post-processing tools. See more in the [Tasks section](inductiva/tasks/README.md).
 
 
 
 
 ### Example:
 
-To run this example download a vehicle geometry in OBJ format from [here](../../../../resources/geometry/test_vehicle.obj) and
+To run this example download a vehicle geometry in OBJ format from [here](/resources/geometry/test_vehicle.obj) and
 do not forget to insert your API Key (get one by filling this [form](https://docs.google.com/forms/d/e/1FAIpQLSflytIIwzaBE_ZzoRloVm3uTo1OQCH6Cqhw3bhFVnC61s7Wmw/viewform?usp=sf_link)).
 
 ```python
@@ -85,7 +85,7 @@ pressure_field = output.get_object_pressure_field()
 pressure_field.render_frame()
 ```
 
-<img src="../../../../resources/media/openfoam/default_pressure_field.png" width="400" height="300" />
+<img src="/resources/media/openfoam/default_pressure_field.png" width="400" height="300" />
 
 ```python
 # Get a mesh of the streamlines 
@@ -99,7 +99,7 @@ streamlines.render_frame(physical_field="velocity",
                          save_path="default_streamlines.png")
 ```
 
-<img src="../../../../resources/media/openfoam/default_streamlines.png" width="400" height="300" />
+<img src="/resources/media/openfoam/default_streamlines.png" width="400" height="300" />
 
 
 ```python
@@ -112,7 +112,7 @@ flow_slice.render_frame(physical_field="pressure",
                         save_path="default_flow_slice.png")
 ```
 
-<img src="../../../../resources/media/openfoam/default_flow_slice.png" width="400" height="300" />
+<img src="/resources/media/openfoam/default_flow_slice.png" width="400" height="300" />
 
 ### Example for general Post-processing
 
@@ -127,7 +127,7 @@ pressure_field = output.get_object_pressure_field()
 pressure_field.render_frame(save_path="pressure_field.png")
 ```
 
-<img src="../../../../resources/media/openfoam/pressure_field.png" width="400" height="300" />
+<img src="/resources/media/openfoam/pressure_field.png" width="400" height="300" />
 
 ```python
 # Get the streamlines mesh
@@ -145,7 +145,7 @@ streamlines.render_frame(physical_field="pressure",
                          save_path="streamlines.png")
 ```
 
-<img src="../../../../resources/media/openfoam/streamlines.png" width="400" height="300" />
+<img src="/resources/media/openfoam/streamlines.png" width="400" height="300" />
 
 ```python
 
@@ -159,4 +159,4 @@ flow_slice.render_frame(physical_field="velocity",
                         save_path="flow_slice.png")
 ```
 
-<img src="../../../../resources/media/openfoam/flow_slice.png" width="400" height="300" />
+<img src="/resources/media/openfoam/flow_slice.png" width="400" height="300" />

--- a/inductiva/fluids/scenarios/wind_tunnel/README.md
+++ b/inductiva/fluids/scenarios/wind_tunnel/README.md
@@ -22,10 +22,13 @@ Launching a simulation returns a task object, which can be used to verify the st
 
 ### Example:
 
-Download a vehicle geometry in OBJ format from [here](../../../../resources/geometry/test_vehicle.obj).
+To run this example download a vehicle geometry in OBJ format from [here](../../../../resources/geometry/test_vehicle.obj) and
+do not forget to insert your API Key (get one by filling this [form](https://docs.google.com/forms/d/e/1FAIpQLSflytIIwzaBE_ZzoRloVm3uTo1OQCH6Cqhw3bhFVnC61s7Wmw/viewform?usp=sf_link)).
 
 ```python
 import inductiva
+
+inductiva.api_key = "YOUR_API_KEY"
 
 # Initialize the scenario
 scenario = inductiva.fluids.scenarios.WindTunnel(

--- a/inductiva/fluids/scenarios/wind_tunnel/README.md
+++ b/inductiva/fluids/scenarios/wind_tunnel/README.md
@@ -8,12 +8,17 @@ To initialize the scenario, the user can define the following parameters:
 
 Now, the user is ready to simulate the steady state. Here, the user chooses the object to be inserted inside the wind tunnel. This object is defined with a geometry file in STL or OBJ format. Notice that, the required meshing step will automatically be made before starting the simulation. The meshing is done with the [snappyHexMesh tool](https://www.openfoam.com/documentation/user-guide/4-mesh-generation-and-conversion/4.4-mesh-generation-with-the-snappyhexmesh-utility) of OpenFOAM.
 
+To test this scenario we have made available one example of a vehicle geometry in OBJ format. [Download it from here](../../../../resources/geometry/test_vehicle.obj). The user can also use his own geometry file, as long as it is in STL or OBJ format.
+
 The simulation parameters available for the user to configure are:
 - `num_iterations`: Set the maximum number of iterations for the iterative algorithm to converge.
 - `resolution`: Controls the resolution of the meshing that is done prior to the simulation. The higher the resolution, the finer the meshing. Possibilities: "high", "medium", "low".
 
 Moreover, the hardware and interaction are configured with the usual general parameters - `machine_group`, `run_async`, `n_cores`.
 Launching a simulation returns a task object, which can be used to verify the status of the simulation, get the simulation outputs and access post-processing tools. See more in the [Tasks section](../../../../README.md).
+
+
+
 
 ### Example:
 
@@ -23,12 +28,12 @@ import inductiva
 # Initialize the scenario
 scenario = inductiva.fluids.scenarios.WindTunnel(
     flow_velocity=[30, 0, 0],
-    dimensions={"x": [-5, 15], "y": [-5, 5], "z": [0, 8]})
+    domain={"x": [-5, 15], "y": [-5, 5], "z": [0, 8]})
 
 # Run a simulation
 task = scenario.simulate(
-    object_path="f1.obj",
-    num_iterations=1000, resolution=0.5,
+    object_path="test_vehicle.obj",
+    num_iterations=100, resolution="medium",
     run_async=True, n_cores=4)
 
 # Download the simulation output to your local machine.

--- a/inductiva/fluids/scenarios/wind_tunnel/README.md
+++ b/inductiva/fluids/scenarios/wind_tunnel/README.md
@@ -8,7 +8,7 @@ To initialize the scenario, the user can define the following parameters:
 
 Now, the user is ready to simulate the steady state. Here, the user chooses the object to be inserted inside the wind tunnel. This object is defined with a geometry file in STL or OBJ format. Notice that, the required meshing step will automatically be made before starting the simulation. The meshing is done with the [snappyHexMesh tool](https://www.openfoam.com/documentation/user-guide/4-mesh-generation-and-conversion/4.4-mesh-generation-with-the-snappyhexmesh-utility) of OpenFOAM.
 
-To test this scenario we have made available one example of a vehicle geometry in OBJ format. [Download it from here](../../../../resources/geometry/test_vehicle.obj). The user can also use his own geometry file, as long as it is in STL or OBJ format.
+To test this scenario we have available one example of a vehicle geometry in OBJ format - [download it here](../../../../resources/geometry/test_vehicle.obj). The user can also use his own geometry file, as long as it is in STL or OBJ format.
 
 The simulation parameters available for the user to configure are:
 - `num_iterations`: Set the maximum number of iterations for the iterative algorithm to converge.
@@ -21,6 +21,8 @@ Launching a simulation returns a task object, which can be used to verify the st
 
 
 ### Example:
+
+Download a vehicle geometry in OBJ format from [here](../../../../resources/geometry/test_vehicle.obj).
 
 ```python
 import inductiva


### PR DESCRIPTION
This PR addresses a few errors on the documentation. In particular, when would copy the code snippets there available they would not run due to inconsistencies between the args passed and the args the functions need.

Moreover, I added an example object that now can be downloaded.

Notice that the large number of changes is due to the addition of this obj file.