### PR TITLE
Remove visuals dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,16 @@ This offers several distinct advantages:
 
 ## Installation
 
-On your terminal:
+Inductiva package is simple to install, just run on your terminal:
 
 ```
 pip install --upgrade inductiva
+```
+
+These will provide the default installation of the package, that allow you to submit jobs, control machines and run simulations. To use the visualization and post-processing tools, you need to install extra dependencies depending on your area: `molecules_extra`, `fluids_extra` or `coastal_extra`. For example, for molecules:
+
+```
+pip install inductiva[molecules_extra]
 ```
 
 ## API access tokens

--- a/inductiva/coastal/bathymetry.py
+++ b/inductiva/coastal/bathymetry.py
@@ -327,7 +327,7 @@ class Bathymetry:
         x_resolution: float = 10,
         y_resolution: float = 10,
         threshold_distance: float = 20,
-    ):
+    ) -> Union["matplotlib.axes.Axes", None]:
         """Plots the bathymetry.
 
         The bathymetry is represented as a 2D map of depths, with the x and y

--- a/inductiva/coastal/bathymetry.py
+++ b/inductiva/coastal/bathymetry.py
@@ -327,7 +327,7 @@ class Bathymetry:
         x_resolution: float = 10,
         y_resolution: float = 10,
         threshold_distance: float = 20,
-    ) :
+    ):
         """Plots the bathymetry.
 
         The bathymetry is represented as a 2D map of depths, with the x and y

--- a/inductiva/coastal/bathymetry.py
+++ b/inductiva/coastal/bathymetry.py
@@ -5,11 +5,16 @@ from typing import Optional, Sequence, Tuple, Union
 
 from absl import logging
 
-import matplotlib
 import numpy as np
-import utm
+try:
+    import matplotlib
+    import utm
+except ImportError:
+    matplotlib = None
+    utm = None
 
 import inductiva
+from inductiva.utils import optional_deps
 
 
 class Bathymetry:
@@ -25,6 +30,7 @@ class Bathymetry:
       depths are defined, in meters.
     """
 
+    @optional_deps.needs_coastal_extra_deps
     def __init__(
         self,
         depths: np.ndarray,
@@ -44,6 +50,7 @@ class Bathymetry:
         self.y = y
 
     @classmethod
+    @optional_deps.needs_coastal_extra_deps
     def from_bot_file(
         cls,
         bot_file_path: str,
@@ -72,6 +79,7 @@ class Bathymetry:
         return cls(depths.flatten(), x.flatten(), y.flatten())
 
     @classmethod
+    @optional_deps.needs_coastal_extra_deps
     def from_ascii_xyz_file(
         cls,
         ascii_xyz_file_path: str,
@@ -126,6 +134,7 @@ class Bathymetry:
         return cls(depths, x, y)
 
     @classmethod
+    @optional_deps.needs_coastal_extra_deps
     def from_random_depths(
         cls,
         x_range: Sequence[float],
@@ -190,6 +199,7 @@ class Bathymetry:
 
         return cls(depths.flatten(), x.flatten(), y.flatten())
 
+    @optional_deps.needs_coastal_extra_deps
     def to_bot_file(
         self,
         bot_file_path: str,
@@ -213,27 +223,32 @@ class Bathymetry:
         np.savetxt(bot_file_path, depths_grid)
 
     @property
+    @optional_deps.needs_coastal_extra_deps
     def x_range(self) -> Tuple[float]:
         """Returns the range of x values."""
 
         return (np.min(self.x), np.max(self.x))
 
     @property
+    @optional_deps.needs_coastal_extra_deps
     def y_range(self) -> Tuple[float]:
         """Returns the range of y values."""
 
         return (np.min(self.y), np.max(self.y))
 
+    @optional_deps.needs_coastal_extra_deps
     def x_ptp(self) -> float:
         """Returns the peak-to-peak range (max - min) of x values."""
 
         return np.ptp(self.x)
 
+    @optional_deps.needs_coastal_extra_deps
     def y_ptp(self) -> float:
         """Returns the peak-to-peak range (max - min) of y values."""
 
         return np.ptp(self.y)
 
+    @optional_deps.needs_coastal_extra_deps
     def x_uniques(self, sort: bool = False) -> np.ndarray:
         """Returns the unique x values.
         
@@ -245,6 +260,7 @@ class Bathymetry:
             x_uniques = np.sort(x_uniques)
         return x_uniques
 
+    @optional_deps.needs_coastal_extra_deps
     def y_uniques(self, sort: bool = False) -> np.ndarray:
         """Returns the unique y values.
         
@@ -256,6 +272,7 @@ class Bathymetry:
             y_uniques = np.sort(y_uniques)
         return y_uniques
 
+    @optional_deps.needs_coastal_extra_deps
     def crop(self,
              x_range: Sequence[float],
              y_range: Sequence[float],
@@ -291,6 +308,7 @@ class Bathymetry:
             y=y,
         )
 
+    @optional_deps.needs_coastal_extra_deps
     def is_uniform_grid(self) -> bool:
         """Determines whether the bathymetry is defined on a uniform grid."""
 
@@ -300,6 +318,7 @@ class Bathymetry:
         return (np.unique(x_uniques_diffs.round(decimals=2)).size == 1 and
                 np.unique(y_uniques_diffs.round(decimals=2)).size == 1)
 
+    @optional_deps.needs_coastal_extra_deps
     def plot(
         self,
         cmap: Optional[str] = None,
@@ -308,7 +327,7 @@ class Bathymetry:
         x_resolution: float = 10,
         y_resolution: float = 10,
         threshold_distance: float = 20,
-    ) -> Union[matplotlib.axes.Axes, None]:
+    ) :
         """Plots the bathymetry.
 
         The bathymetry is represented as a 2D map of depths, with the x and y
@@ -395,6 +414,7 @@ class Bathymetry:
         else:
             return ax
 
+    @optional_deps.needs_coastal_extra_deps
     def to_uniform_grid(
         self,
         x_resolution: float = 2,
@@ -424,6 +444,7 @@ class Bathymetry:
                           x=x_grid.flatten(),
                           y=y_grid.flatten())
 
+    @optional_deps.needs_coastal_extra_deps
     def _interpolate_to_uniform_grid(
         self,
         x_resolution: float,

--- a/inductiva/coastal/output.py
+++ b/inductiva/coastal/output.py
@@ -4,12 +4,15 @@ import os
 import tempfile
 from typing import Dict, Literal, Optional, Sequence, Tuple
 
-import matplotlib.pyplot as plt
 import numpy as np
 import scipy
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    plt = None
 
 from inductiva.types import Path
-from inductiva.utils import visualization
+from inductiva.utils import visualization, optional_deps
 
 # Labels used in SWASH simulation outputs.
 QUANTITY_SWASH_LABELS = {
@@ -38,6 +41,7 @@ QUANTITY_UNITS = {
 GRID_POSITIONS_FILE_NAME = "grid_positions.mat"
 
 
+@optional_deps.needs_coastal_extra_deps
 def read_swash_output_file(file_path: str) -> Dict[str, np.ndarray]:
     """Reads a SWASH output file.
     
@@ -55,6 +59,7 @@ def read_swash_output_file(file_path: str) -> Dict[str, np.ndarray]:
     return data_dict
 
 
+@optional_deps.needs_coastal_extra_deps
 def read_swash_grid_positions_file(file_path: str) -> Tuple[np.ndarray]:
     """Reads a SWASH output file containing grid positions."""
 
@@ -72,6 +77,7 @@ def read_swash_grid_positions_file(file_path: str) -> Tuple[np.ndarray]:
     return x_array, y_array
 
 
+@optional_deps.needs_coastal_extra_deps
 def read_swash_grid_quantity_file(file_path: str, quantity: str):
     """Reads a SWASH output file containing a quantity defined over a grid.
 
@@ -120,6 +126,7 @@ def read_swash_grid_quantity_file(file_path: str, quantity: str):
     return time_list, data_list
 
 
+@optional_deps.needs_coastal_extra_deps
 def _render_quantity_grid_data(x_array: np.ndarray,
                                y_array: np.ndarray,
                                time_list: Sequence[float],
@@ -192,6 +199,7 @@ class CoastalAreaOutput:
 
         self.sim_output_path = sim_output_path
 
+    @optional_deps.needs_coastal_extra_deps
     def render(
         self,
         quantity: Literal[

--- a/inductiva/fluids/post_processing/openfoam.py
+++ b/inductiva/fluids/post_processing/openfoam.py
@@ -14,11 +14,16 @@ from enum import Enum
 from typing import Literal
 import pathlib
 import glob
+
 from absl import logging
 
-import pyvista as pv
+try:
+    import pyvista as pv
+except ImportError:
+    pv = None
 
 from inductiva import types, utils
+from inductiva.utils import optional_deps
 
 
 class SteadyStateOutput:
@@ -82,6 +87,7 @@ class SteadyStateOutput:
 
         return last_iteration
 
+    @optional_deps.needs_fluids_extra_deps
     def get_output_mesh(self):
         """Get domain and object mesh info at the steady-state."""
 
@@ -106,6 +112,7 @@ class SteadyStateOutput:
 
         return domain_mesh, object_mesh
 
+    @optional_deps.needs_fluids_extra_deps
     def get_object_pressure_field(self, save_path: types.Path = None):
         """Get a pressure scalar field over mesh points of the object.
 
@@ -132,6 +139,7 @@ class SteadyStateOutput:
 
         return pressure_field
 
+    @optional_deps.needs_fluids_extra_deps
     def get_streamlines(self,
                         max_time: float = 100,
                         n_points: int = 100,
@@ -179,6 +187,7 @@ class SteadyStateOutput:
 
         return Streamlines(object_mesh, streamlines_mesh)
 
+    @optional_deps.needs_fluids_extra_deps
     def get_flow_slice(self,
                        plane: Literal["xy", "xz", "yz"] = "xz",
                        origin: tuple = (0, 0, 0),

--- a/inductiva/fluids/post_processing/splishsplash.py
+++ b/inductiva/fluids/post_processing/splishsplash.py
@@ -46,7 +46,7 @@ def convert_vtk_data_dir_to_netcdf(
         xr_dataset.to_netcdf(os.path.join(netcdf_data_dir, f"{file_stem}.nc"))
 
 
-def read_vtk_file_to_xr_dataset(file_path: str, time: float):
+def read_vtk_file_to_xr_dataset(file_path: str, time: float) -> "xr.Dataset":
     """Reads a single simulation output file to an xarray Dataset.
 
     Args:

--- a/inductiva/fluids/post_processing/splishsplash.py
+++ b/inductiva/fluids/post_processing/splishsplash.py
@@ -17,7 +17,6 @@ except ImportError:
     np = None
     _vtk_data_to_numpy = None
 
-
 from inductiva.utils.files import get_sorted_files
 
 

--- a/inductiva/fluids/post_processing/splishsplash.py
+++ b/inductiva/fluids/post_processing/splishsplash.py
@@ -4,12 +4,19 @@ import os
 import pathlib
 
 from absl import logging
-
 import numpy as np
+
 from tqdm import tqdm
-import vtk
-from vtk.util.numpy_support import vtk_to_numpy as _vtk_data_to_numpy
-import xarray as xr
+try:
+    import vtk
+    from vtk.util.numpy_support import vtk_to_numpy as _vtk_data_to_numpy
+    import xarray as xr
+except ImportError:
+    xr = None
+    vtk = None
+    np = None
+    _vtk_data_to_numpy = None
+
 
 from inductiva.utils.files import get_sorted_files
 
@@ -40,7 +47,7 @@ def convert_vtk_data_dir_to_netcdf(
         xr_dataset.to_netcdf(os.path.join(netcdf_data_dir, f"{file_stem}.nc"))
 
 
-def read_vtk_file_to_xr_dataset(file_path: str, time: float) -> xr.Dataset:
+def read_vtk_file_to_xr_dataset(file_path: str, time: float):
     """Reads a single simulation output file to an xarray Dataset.
 
     Args:

--- a/inductiva/fluids/scenarios/_post_processing.py
+++ b/inductiva/fluids/scenarios/_post_processing.py
@@ -1,7 +1,7 @@
 """Post process SPH simulation outputs."""
 import os
 
-from inductiva.utils.visualization import create_movie_from_vtk
+from inductiva.utils import visualization, optional_deps
 from inductiva.types import Path
 
 
@@ -16,6 +16,7 @@ class SPHSimulationOutput:
             """
         self.sim_output_dir = sim_output_path
 
+    @optional_deps.needs_fluids_extra_deps
     def render(self,
                virtual_display: bool = False,
                movie_path: str = "movie.mp4",
@@ -33,9 +34,10 @@ class SPHSimulationOutput:
 
         vtk_dir = os.path.join(self.sim_output_dir, "vtk")
 
-        create_movie_from_vtk(vtk_dir,
-                              movie_path,
-                              virtual_display=virtual_display,
-                              camera=[(3., 3., 2.), (0., 0., 0.), (1., 1., 2.)],
-                              fps=fps,
-                              color=color)
+        visualization.create_movie_from_vtk(vtk_dir,
+                                            movie_path,
+                                            virtual_display=virtual_display,
+                                            camera=[(3., 3., 2.), (0., 0., 0.),
+                                                    (1., 1., 2.)],
+                                            fps=fps,
+                                            color=color)

--- a/inductiva/fluids/scenarios/fluid_tank/output.py
+++ b/inductiva/fluids/scenarios/fluid_tank/output.py
@@ -3,11 +3,14 @@
 import os
 from typing import Optional
 
-import xarray as xr
+try:
+    import xarray as xr
+except ImportError:
+    xr = None
 
 from inductiva.types import Path
 from inductiva.fluids.post_processing.splishsplash import convert_vtk_data_dir_to_netcdf
-from inductiva.utils import files, visualization
+from inductiva.utils import files, visualization, optional_deps
 
 
 class FluidTankOutput:
@@ -23,6 +26,7 @@ class FluidTankOutput:
         self.sim_output_path = sim_output_path
         self.output_time_step = output_time_step
 
+    @optional_deps.needs_fluids_extra_deps
     def render(
         self,
         movie_path: Path = "movie.mp4",

--- a/inductiva/fluids/scenarios/heat_sink/output.py
+++ b/inductiva/fluids/scenarios/heat_sink/output.py
@@ -4,10 +4,13 @@ import os
 import pathlib
 from typing import Literal, Sequence
 
-import pyvista as pv
+try:
+    import pyvista as pv
+except ImportError:
+    pv = None
 
 from inductiva.types import Path
-from inductiva.utils import files
+from inductiva.utils import files, optional_deps
 
 
 class HeatSinkOutput:
@@ -22,6 +25,7 @@ class HeatSinkOutput:
 
         self.sim_output_path = sim_output_path
 
+    @optional_deps.needs_fluids_extra_deps
     def render(
         self,
         movie_path: Path = "movie.mp4",

--- a/inductiva/fluids/scenarios/wind_terrain/wind_terrain.py
+++ b/inductiva/fluids/scenarios/wind_terrain/wind_terrain.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import inductiva
 from inductiva import fluids, simulators, resources, scenarios, world
-from inductiva.utils import templates
+from inductiva.utils import templates, optional_deps
 
 SCENARIO_TEMPLATE_DIR = os.path.join(inductiva.utils.templates.TEMPLATES_PATH,
                                      "wind_terrain")
@@ -56,6 +56,7 @@ class WindOverTerrain(scenarios.Scenario):
 
     valid_simulators = [simulators.OpenFOAM]
 
+    @optional_deps.needs_fluids_extra_deps
     def __init__(self,
                  terrain: world.Terrain,
                  wind_velocity: List[float],

--- a/inductiva/molecules/scenarios/protein_solvation/post_processing.py
+++ b/inductiva/molecules/scenarios/protein_solvation/post_processing.py
@@ -3,12 +3,13 @@ import os
 import pathlib
 from typing import Literal
 
-import matplotlib.pyplot as plt
 import numpy as np
 try:
+    import matplotlib.pyplot as plt
     import nglview as nv
 except ImportError:
     nv = None
+    plt = None
 
 import inductiva
 from inductiva.utils import optional_deps
@@ -80,6 +81,7 @@ class ProteinSolvationOutput:
         print(f"Number of trajectory frames: {len(self.universe.trajectory)}")
         return view
 
+    @optional_deps.needs_molecules_extra_deps
     def plot_rmsf_per_residue(self):
         """Plot the root mean square fluctuation (RMSF) over a trajectory.
 

--- a/inductiva/utils/optional_deps.py
+++ b/inductiva/utils/optional_deps.py
@@ -54,6 +54,7 @@ def _missing_deps_msg(extra_deps_name):
     return (f"You can install the missing dependencies for '{extra_deps_name}' "
             f"with `pip install 'inductiva[{extra_deps_name}_extra]'`.")
 
+
 # Apply the two first arguments to _needs_optional_deps function, creating
 # a new decorator function with those arguments already set.
 needs_molecules_extra_deps = functools.partial(
@@ -76,5 +77,6 @@ needs_coastal_extra_deps = functools.partial(
 
 needs_common_extra_deps = functools.partial(
     _needs_optional_deps,
-    ["imageio", "matplotlib"], _missing_deps_msg("common"),
+    ["imageio", "matplotlib"],
+    _missing_deps_msg("common"),
 )

--- a/inductiva/utils/optional_deps.py
+++ b/inductiva/utils/optional_deps.py
@@ -49,15 +49,35 @@ def _needs_optional_deps(module_names, extra_msg, func):
 
     return wrapper
 
+def _missing_deps_msg(extra_deps_name):
+    return (f"You can install the missing dependencies for '{extra_deps_name}' "
+    f"with `pip install 'inductiva[{extra_deps_name}_extra]'`.")
 
-molecules_missing_deps_msg = (
-    "You can install the missing dependencies for 'molecules' "
-    "with `pip install 'inductiva[molecules_extra]'`.")
+
 
 # Apply the two first arguments to _needs_optional_deps function, creating
 # a new decorator function with those arguments already set.
 needs_molecules_extra_deps = functools.partial(
     _needs_optional_deps,
-    ["MDAnalysis", "nglview"],
-    molecules_missing_deps_msg,
+    ["MDAnalysis", "nglview", "imageio", "matplotlib"],
+    _missing_deps_msg("molecules"),
 )
+
+needs_fluids_extra_deps = functools.partial(
+    _needs_optional_deps,
+    ["pyvista", "vtk", "xarray", "dask", "imageio", "matplotlib"],
+    _missing_deps_msg("fluids"),
+)
+
+needs_coastal_extra_deps = functools.partial(
+    _needs_optional_deps,
+    ["utm", "imageio", "matplotlib"],
+    _missing_deps_msg("coastal"),
+)
+
+needs_common_extra_deps = functools.partial(
+    _needs_optional_deps,
+    ["imageio", "matplotlib"],
+    _missing_deps_msg("common"),
+)
+

--- a/inductiva/utils/optional_deps.py
+++ b/inductiva/utils/optional_deps.py
@@ -49,11 +49,10 @@ def _needs_optional_deps(module_names, extra_msg, func):
 
     return wrapper
 
+
 def _missing_deps_msg(extra_deps_name):
     return (f"You can install the missing dependencies for '{extra_deps_name}' "
-    f"with `pip install 'inductiva[{extra_deps_name}_extra]'`.")
-
-
+            f"with `pip install 'inductiva[{extra_deps_name}_extra]'`.")
 
 # Apply the two first arguments to _needs_optional_deps function, creating
 # a new decorator function with those arguments already set.
@@ -77,7 +76,5 @@ needs_coastal_extra_deps = functools.partial(
 
 needs_common_extra_deps = functools.partial(
     _needs_optional_deps,
-    ["imageio", "matplotlib"],
-    _missing_deps_msg("common"),
+    ["imageio", "matplotlib"], _missing_deps_msg("common"),
 )
-

--- a/inductiva/utils/visualization.py
+++ b/inductiva/utils/visualization.py
@@ -7,20 +7,36 @@ from typing import Dict, List, Optional
 import base64
 import io
 from time import sleep
-from ipywidgets import Output
 
 from absl import logging
-
-import imageio
-import PIL
-import pyvista as pv
-import matplotlib
-import matplotlib.colors as clr
-import matplotlib.pyplot as plt
 from tqdm import tqdm
-import xarray as xr
+try:
+    import imageio
+    import matplotlib
+    import matplotlib.colors as clr
+    import matplotlib.pyplot as plt
+except ImportError:
+    imageio = None
+    matplotlib = None
+    clr = None
+    plt = None
 
-from inductiva.utils import files
+try:
+    import ipywidgets
+    import PIL
+except ImportError:
+    ipywidgets = None
+    PIL = None
+
+try:
+    import pyvista as pv
+    import xarray as xr
+except ImportError:
+    xr = None
+    pv = None
+
+
+from inductiva.utils import files, optional_deps
 import threading
 
 MPL_CONFIG_PARAMS = {
@@ -30,6 +46,7 @@ MPL_CONFIG_PARAMS = {
 }
 
 
+@optional_deps.needs_molecules_extra_deps
 def create_movie_from_widget(view,
                              output_path="movie.mp4",
                              fps=8,
@@ -73,7 +90,7 @@ def create_movie_from_widget(view,
                     sleep(timeout)
 
             if not event.is_set():
-                with Output():
+                with ipywidgets.Output():
                     create_movie_from_frames(tmp_dir, output_path, fps)
 
     thread = threading.Thread(target=_make, args=(event,))
@@ -210,8 +227,9 @@ def create_frame_from_vtk(frame_path: str,
                cmap=cmap)
 
 
+@optional_deps.needs_fluids_extra_deps
 def create_2d_scatter_plot(
-    dataset: xr.Dataset,
+    xr_dataset,
     x_var: str,
     y_var: str,
     image_path: str,
@@ -239,7 +257,7 @@ def create_2d_scatter_plot(
         if color_var is not None and color_limits is not None:
             color_norm = clr.Normalize(*color_limits)
 
-        dataset.plot.scatter(
+        xr_dataset.plot.scatter(
             ax=ax,
             x=x_var,
             y=y_var,
@@ -261,8 +279,9 @@ def create_2d_scatter_plot(
         plt.close(fig)
 
 
+@optional_deps.needs_fluids_extra_deps
 def create_3d_scatter_plot(
-    dataset: xr.Dataset,
+    xr_dataset,
     x_var: str,
     y_var: str,
     z_var: str,
@@ -291,7 +310,7 @@ def create_3d_scatter_plot(
         if color_var is not None and color_limits is not None:
             color_norm = clr.Normalize(*color_limits)
 
-        dataset.plot.scatter(
+        xr_dataset.plot.scatter(
             ax=ax,
             x=x_var,
             y=z_var,
@@ -313,8 +332,9 @@ def create_3d_scatter_plot(
         plt.close(fig)
 
 
+@optional_deps.needs_fluids_extra_deps
 def create_2d_scatter_plot_movie(
-    dataset: xr.Dataset,
+    xr_dataset,
     iter_var: str,
     x_var: str,
     y_var: str,
@@ -335,11 +355,11 @@ def create_2d_scatter_plot_movie(
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         logging.info("Creating movie frames...")
-        var_iterator = dataset.groupby(iter_var)
+        var_iterator = xr_dataset.groupby(iter_var)
         for i, (_, dataset_i) in tqdm(enumerate(var_iterator),
                                       total=len(var_iterator)):
             create_2d_scatter_plot(
-                dataset=dataset_i,
+                xr_dataset=dataset_i,
                 x_var=x_var,
                 y_var=y_var,
                 marker_size=marker_size,
@@ -363,8 +383,9 @@ def create_2d_scatter_plot_movie(
                                  fps=movie_fps)
 
 
+@optional_deps.needs_fluids_extra_deps
 def create_3d_scatter_plot_movie(
-    dataset: xr.Dataset,
+    xr_dataset,
     iter_var: str,
     x_var: str,
     y_var: str,
@@ -386,11 +407,11 @@ def create_3d_scatter_plot_movie(
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         logging.info("Creating movie frames...")
-        var_iterator = dataset.groupby(iter_var)
+        var_iterator = xr_dataset.groupby(iter_var)
         for i, (_, dataset_i) in tqdm(enumerate(var_iterator),
                                       total=len(var_iterator)):
             create_3d_scatter_plot(
-                dataset=dataset_i,
+                xr_dataset=dataset_i,
                 x_var=x_var,
                 y_var=y_var,
                 z_var=z_var,
@@ -415,8 +436,9 @@ def create_3d_scatter_plot_movie(
                                  fps=movie_fps)
 
 
+@optional_deps.needs_fluids_extra_deps
 def create_color_plot(
-    data_array: xr.DataArray,
+    xr_data_array,
     image_path: str,
     x_limits: Optional[List[float]] = None,
     y_limits: Optional[List[float]] = None,
@@ -438,7 +460,7 @@ def create_color_plot(
         if color_limits is not None:
             color_norm = clr.Normalize(*color_limits)
 
-        data_array.plot.pcolormesh(
+        xr_data_array.plot.pcolormesh(
             ax=ax,
             xlim=x_limits,
             ylim=y_limits,
@@ -454,8 +476,9 @@ def create_color_plot(
         plt.close(fig)
 
 
+@optional_deps.needs_fluids_extra_deps
 def create_color_plot_movie(
-    data_array: xr.DataArray,
+    xr_data_array,
     iter_var: str,
     movie_path: str,
     movie_fps: int = 10,
@@ -470,7 +493,7 @@ def create_color_plot_movie(
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         logging.info("Creating movie frames...")
-        var_iterator = data_array.groupby(iter_var)
+        var_iterator = xr_data_array.groupby(iter_var)
         for i, (_, data_array_i) in tqdm(enumerate(var_iterator),
                                          total=len(var_iterator)):
             create_color_plot(

--- a/inductiva/utils/visualization.py
+++ b/inductiva/utils/visualization.py
@@ -30,8 +30,10 @@ except ImportError:
 
 try:
     import pyvista as pv
+    import xarray as xr
 except ImportError:
     pv = None
+    xr = None
 
 from inductiva.utils import files, optional_deps
 import threading
@@ -226,7 +228,7 @@ def create_frame_from_vtk(frame_path: str,
 
 @optional_deps.needs_fluids_extra_deps
 def create_2d_scatter_plot(
-    xr_dataset,
+    xr_dataset: "xr.Dataset",
     x_var: str,
     y_var: str,
     image_path: str,
@@ -278,7 +280,7 @@ def create_2d_scatter_plot(
 
 @optional_deps.needs_fluids_extra_deps
 def create_3d_scatter_plot(
-    xr_dataset,
+    xr_dataset: "xr.Dataset",
     x_var: str,
     y_var: str,
     z_var: str,
@@ -331,7 +333,7 @@ def create_3d_scatter_plot(
 
 @optional_deps.needs_fluids_extra_deps
 def create_2d_scatter_plot_movie(
-    xr_dataset,
+    xr_dataset: "xr.Dataset",
     iter_var: str,
     x_var: str,
     y_var: str,
@@ -382,7 +384,7 @@ def create_2d_scatter_plot_movie(
 
 @optional_deps.needs_fluids_extra_deps
 def create_3d_scatter_plot_movie(
-    xr_dataset,
+    xr_dataset: "xr.Dataset",
     iter_var: str,
     x_var: str,
     y_var: str,
@@ -435,7 +437,7 @@ def create_3d_scatter_plot_movie(
 
 @optional_deps.needs_fluids_extra_deps
 def create_color_plot(
-    xr_data_array,
+    xr_data_array: "xr.DataArray",
     image_path: str,
     x_limits: Optional[List[float]] = None,
     y_limits: Optional[List[float]] = None,
@@ -475,7 +477,7 @@ def create_color_plot(
 
 @optional_deps.needs_fluids_extra_deps
 def create_color_plot_movie(
-    xr_data_array,
+    xr_data_array: "xr.DataArray",
     iter_var: str,
     movie_path: str,
     movie_fps: int = 10,

--- a/inductiva/utils/visualization.py
+++ b/inductiva/utils/visualization.py
@@ -30,11 +30,8 @@ except ImportError:
 
 try:
     import pyvista as pv
-    import xarray as xr
 except ImportError:
-    xr = None
     pv = None
-
 
 from inductiva.utils import files, optional_deps
 import threading
@@ -497,7 +494,7 @@ def create_color_plot_movie(
         for i, (_, data_array_i) in tqdm(enumerate(var_iterator),
                                          total=len(var_iterator)):
             create_color_plot(
-                data_array=data_array_i,
+                xr_data_array=data_array_i,
                 x_limits=x_limits,
                 y_limits=y_limits,
                 color_limits=color_limits,

--- a/inductiva/world/terrain.py
+++ b/inductiva/world/terrain.py
@@ -1,10 +1,14 @@
 """Represent a complex terrain profile."""
 import typing
 
-import pyvista as pv
+try:
+    import pyvista as pv
+except ImportError:
+    pv = None
 
 import inductiva
 from inductiva.generative import procedural
+from inductiva.utils import optional_deps
 
 
 class Terrain:
@@ -31,6 +35,7 @@ class Terrain:
         return cls(terrain_mesh)
 
     @classmethod
+    @optional_deps.needs_fluids_extra_deps
     def from_random_generation(cls,
                                x_range: typing.Sequence[float],
                                y_range: typing.Sequence[float],
@@ -82,6 +87,7 @@ class Terrain:
 
         return cls(terrain)
 
+    @optional_deps.needs_fluids_extra_deps
     def to_text_file(self, text_file_path: str):
         """Saves the terrain to a text file.
         
@@ -93,6 +99,7 @@ class Terrain:
         terrain_geometry.save(text_file_path)
 
     @property
+    @optional_deps.needs_fluids_extra_deps
     def bounds(self):
         """Returns the bounds of the terrain."""
 
@@ -105,6 +112,7 @@ class Terrain:
         return terrain_bounds
 
     @property
+    @optional_deps.needs_fluids_extra_deps
     def center(self):
         """Returns the center of the terrain."""
 
@@ -116,6 +124,7 @@ class Terrain:
         return terrain_center
 
     @property
+    @optional_deps.needs_fluids_extra_deps
     def mesh_resolution(self):
         """Returns the resolution of the terrain mesh."""
 
@@ -124,6 +133,7 @@ class Terrain:
 
         return num_cells, num_points
 
+    @optional_deps.needs_fluids_extra_deps
     def plot(self,
              off_screen: bool = False,
              save_path: str = None,

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,24 +22,34 @@ install_requires =
   urllib3 ~= 1.26.7
   python-dateutil
   absl-py
-  tqdm
   jinja2
   numpy
+  pandas
   scipy
-  matplotlib
-  xarray
-  vtk
-  imageio
-  pyvista
-  imageio-ffmpeg
-  ipywidgets
-  utm
-  dask
+  tqdm
 
 [options.extras_require]
+common_deps =
+  imageio
+  imageio-ffmpeg
+  matplotlib
+
 molecules_extra =
+  common_deps
   nglview
   MDAnalysis
+  ipywidgets
+
+fluids_extra =
+  common_deps
+  pyvista
+  vtk
+  xarray
+  dask
+
+coastal_extra =
+  common_deps
+  utm
 
 [options.package_data]
 # Include .obj and .jinja files:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,26 +29,26 @@ install_requires =
   tqdm
 
 [options.extras_require]
-common_deps =
+common_extra =
   imageio
   imageio-ffmpeg
   matplotlib
 
 molecules_extra =
-  common_deps
+  common_extra
   nglview
   MDAnalysis
   ipywidgets
 
 fluids_extra =
-  common_deps
+  common_extra
   pyvista
   vtk
   xarray
   dask
 
 coastal_extra =
-  common_deps
+  common_extra
   utm
 
 [options.package_data]


### PR DESCRIPTION
This PR removes all visualizations and post-processing dependencies. With it, users that just do `pip install inductiva` will be able to run simulations, perform the task.get_output() to retrieve the results, but won't be able to use the visualization classes that we have. A message error appears referring how to install those packages with inductiva as well.

Some further considerations:
- Scipy, numpy, pandas are still in the default installation. 
- To remove pandas, we need to change a few functions.
- To pass scipy into the common_extra it is better to remove the core package - linalg stuff.
- The numpy is used for type annotations and they trigger first than the decorator, which implies this approach won't work. Due to it's generality, we decided to keep it.