### PR TITLE
Fix possible issues when running scenarios with preprocessing

### DIFF
--- a/inductiva/fluids/fluid_tank/fluid_tank.py
+++ b/inductiva/fluids/fluid_tank/fluid_tank.py
@@ -205,7 +205,7 @@ class FluidTank(Scenario):
 
     def simulate(
         self,
-        simulator: Simulator = SPlisHSPlasH("fluid_tank"),
+        simulator: Simulator = SPlisHSPlasH(),
         machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
         device: Literal["cpu", "gpu"] = "cpu",
@@ -227,6 +227,7 @@ class FluidTank(Scenario):
             particle_sorting: Whether to use particle sorting.
             run_async: Whether to run the simulation asynchronously.
         """
+        simulator.override_api_method_prefix("fluid_tank")
 
         self.simulation_time = simulation_time
         self.particle_radius = ParticleRadius[resolution.upper()].value

--- a/inductiva/fluids/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/wind_tunnel/wind_tunnel.py
@@ -100,8 +100,7 @@ class WindTunnel(scenarios.Scenario):
         ]
 
     def simulate(self,
-                 simulator: simulators.Simulator = simulators.OpenFOAM(
-                     "windtunnel"),
+                 simulator: simulators.Simulator = simulators.OpenFOAM(),
                  machine_group: Optional[resources.MachineGroup] = None,
                  run_async: bool = False,
                  object_path: Optional[types.Path] = None,
@@ -122,6 +121,7 @@ class WindTunnel(scenarios.Scenario):
                 Options: "high", "medium" or "low".
             machine_group: The machine group to use for the simulation.
         """
+        simulator.override_api_method_prefix("windtunnel")
 
         if object_path:
             self.object_path = files.resolve_path(object_path)

--- a/inductiva/molecules/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/protein_solvation/protein_solvation.py
@@ -58,7 +58,7 @@ class ProteinSolvation(Scenario):
 
     def simulate(
             self,
-            simulator: Simulator = GROMACS("proteinsolvation"),
+            simulator: Simulator = GROMACS(),
             machine_group: Optional[resources.MachineGroup] = None,
             run_async: bool = False,
             simulation_time_ns: float = 10,  # ns
@@ -86,6 +86,7 @@ class ProteinSolvation(Scenario):
             n_steps_min: Number of steps for energy minimization.
             run_async: Whether to run the simulation asynchronously.
         """
+        simulator.override_api_method_prefix("proteinsolvation")
 
         self.nsteps = int(
             simulation_time_ns * 1e6 / 2

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -9,9 +9,9 @@ from inductiva.simulators import Simulator
 class DualSPHysics(Simulator):
     """Class to invoke a generic DualSPHysics simulation on the API."""
 
-    @property
-    def api_method_name(self) -> str:
-        return "sph.dualsphysics.run_simulation"
+    def __init__(self):
+        super().__init__()
+        self.api_method_name = "sph.dualsphysics.run_simulation"
 
     def run(
         self,

--- a/inductiva/simulators/fenicsx.py
+++ b/inductiva/simulators/fenicsx.py
@@ -9,13 +9,9 @@ from inductiva.simulators import Simulator
 class FEniCSx(Simulator):
     """Class to invoke a generic FEniCSx simulation on the API."""
 
-    def __init__(self, api_method: str = "fem.fenicsx.run_simulation"):
+    def __init__(self):
         super().__init__()
-        self.api_method = api_method
-
-    @property
-    def api_method_name(self) -> str:
-        return self.api_method
+        self.api_method = "fem.fenicsx.run_simulation"
 
     def run(
         self,

--- a/inductiva/simulators/gromacs.py
+++ b/inductiva/simulators/gromacs.py
@@ -9,13 +9,9 @@ from inductiva.simulators import Simulator
 class GROMACS(Simulator):
     """Class to invoke any GROMACS command on the API."""
 
-    def __init__(self, api_method: str = "md"):
+    def __init__(self):
         super().__init__()
-        self.api_method = api_method + ".gromacs.run_simulation"
-
-    @property
-    def api_method_name(self) -> str:
-        return self.api_method
+        self.api_method_name = "md.gromacs.run_simulation"
 
     def run(
         self,

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -6,15 +6,11 @@ from inductiva.simulators import Simulator
 
 
 class OpenFOAM(Simulator):
-    """Class to invoke a generic DualSPHysics simulation on the API."""
+    """Class to invoke a generic OpenFOAM simulation on the API."""
 
-    def __init__(self, api_method: str = "fvm"):
+    def __init__(self):
         super().__init__()
-        self.api_method = api_method + ".openfoam.run_simulation"
-
-    @property
-    def api_method_name(self) -> str:
-        return self.api_method
+        self.api_method_name = "fvm.openfoam.run_simulation"
 
     def run(
         self,

--- a/inductiva/simulators/simsopt.py
+++ b/inductiva/simulators/simsopt.py
@@ -7,9 +7,9 @@ from inductiva import simulators, tasks, types, resources
 class Simsopt(simulators.Simulator):
     """Invokes a simsopt simulation on the API."""
 
-    @property
-    def api_method_name(self) -> str:
-        return "stellarators.simsopt.run_simulation"
+    def __init__(self):
+        super().__init__()
+        self.api_method_name = "stellarators.simsopt.run_simulation"
 
     def run(
         self,
@@ -35,22 +35,22 @@ class Simsopt(simulators.Simulator):
             plasma_surface_filename: Name of the file with the description of
               the plasma surface on which the magnetic field will be calculated.
             num_field_periods: Number of magnetic field periods.
-              Refers to the number of complete magnetic field repetitions 
+              Refers to the number of complete magnetic field repetitions
               within a stellarator. Represents how many times the magnetic
               field pattern repeats itself along the toroidal direction.
-            num_iterations: Number of iterations to run for the searching 
+            num_iterations: Number of iterations to run for the searching
               process.
-            num_samples: Number of different stellarator samples generated per 
+            num_samples: Number of different stellarator samples generated per
               iteration from a configuration. The samples are generated using
-              normal distribution noise for each coefficient of the Fourier 
+              normal distribution noise for each coefficient of the Fourier
               Series that describes the coils.
-            sigma_scaling_factor: Scaling factor for the sigma value used in 
-              the random generation of noise. This argument makes sure that 
-              the noise is generated proportionally to each coefficient. It 
+            sigma_scaling_factor: Scaling factor for the sigma value used in
+              the random generation of noise. This argument makes sure that
+              the noise is generated proportionally to each coefficient. It
               also determines the range of search for new values of the
               coefficients.
             objectives_weights_filename: Name of the file with the weights for
-              each objective function used in the construction of the total 
+              each objective function used in the construction of the total
               objective.
             other arguments: See the documentation of the base class.
         """

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -1,6 +1,6 @@
 """Base class for low-level simulators."""
 from typing import Optional
-from abc import ABC, abstractmethod
+from abc import ABC
 
 from inductiva import types, tasks, resources
 from inductiva.utils import files
@@ -9,10 +9,24 @@ from inductiva.utils import files
 class Simulator(ABC):
     """Base simulator class."""
 
-    @property
-    @abstractmethod
-    def api_method_name(self) -> str:
-        pass
+    def __init__(self):
+        self.api_method_name = ""
+
+    def override_api_method_prefix(self, prefix: str):
+        """Override the API method prefix.
+
+        Example:
+            # prefix = "protein_solvation"
+            "md.gromacs.run_simulation" becomes
+              "protein_solvation.gromacs.run_simulation"
+
+        Args:
+            prefix: The new prefix to use.
+        """
+        last_elements = self.api_method_name.split(".")[1:]
+        all_elements = [prefix] + last_elements
+
+        self.api_method_name = ".".join(all_elements)
 
     def _setup_input_dir(self, input_dir: types.Path):
         """Setup the simulator input directory."""

--- a/inductiva/simulators/splishsplash.py
+++ b/inductiva/simulators/splishsplash.py
@@ -8,13 +8,9 @@ from inductiva.simulators import Simulator
 class SPlisHSPlasH(Simulator):
     """Class to invoke a generic SPlisHSPlasH simulation on the API."""
 
-    def __init__(self, api_method: str = "sph"):
+    def __init__(self):
         super().__init__()
-        self.api_method = api_method + ".splishsplash.run_simulation"
-
-    @property
-    def api_method_name(self) -> str:
-        return self.api_method
+        self.api_method_name = "sph.splishsplash.run_simulation"
 
     def run(
         self,

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -8,9 +8,9 @@ from inductiva import types, tasks, resources
 class SWASH(Simulator):
     """Class to invoke a generic SWASH simulation on the API."""
 
-    @property
-    def api_method_name(self) -> str:
-        return "sw.swash.run_simulation"
+    def __init__(self):
+        super().__init__()
+        self.api_method_name = "sw.swash.run_simulation"
 
     def run(
         self,

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -8,9 +8,9 @@ from inductiva.simulators import Simulator
 class XBeach(Simulator):
     """Class to invoke a generic XBeach simulation on the API."""
 
-    @property
-    def api_method_name(self) -> str:
-        return "sw.xbeach.run_simulation"
+    def __init__(self):
+        super().__init__()
+        self.api_method_name = "sw.xbeach.run_simulation"
 
     def run(
         self,

--- a/inductiva/tests/test_simulator.py
+++ b/inductiva/tests/test_simulator.py
@@ -1,3 +1,4 @@
+"""Tests for the Simulator class."""
 import inductiva
 
 

--- a/inductiva/tests/test_simulator.py
+++ b/inductiva/tests/test_simulator.py
@@ -1,0 +1,8 @@
+import inductiva
+
+
+def test_override_api_method_prefix():
+    simulator = inductiva.simulators.OpenFOAM()
+    assert simulator.api_method_name == "fvm.openfoam.run_simulation"
+    simulator.override_api_method_prefix("windtunnel")
+    assert simulator.api_method_name == "windtunnel.openfoam.run_simulation"


### PR DESCRIPTION
I ran into an issue when running the FluidTank scenario.
The following:
```python
scenario = FluidTank()
scenario.simulate(simulator=SPlisHSPlasH())
```
It would not work because we need to call splishsplash with a different executer script due to needed additional preprocessing. This was being passed in the constructor of the default simulator, but if I passed my simulator as an argument it wouldn't work. This fixes that so that the scenario configures the simulator with scenario-specific things inside the simulate method.