### PR TITLE
[Proteins] Added IPython to molecules_extra extended package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ molecules_extra =
   MDAnalysis
   ipywidgets
   google.colab
+  IPython
 
 fluids_extra =
   %(common_extra)s


### PR DESCRIPTION
Added Ipython to the requirements in the molecules_extra package. It was missing from the stup.cfg file and its used in the protein post-processing
