### PR TITLE
[CoastalArea] Check if bathymetry is uniform at plot()

### DIFF
--- a/inductiva/coastal/bathymetry.py
+++ b/inductiva/coastal/bathymetry.py
@@ -155,7 +155,7 @@ class Bathymetry:
         boundary (East) are assumed to be below water (i.e. have 0 < depths <
         `max_depth`). The corners on the upper x boundary (West) are assumed to
         be above water (i.e. have - `max_depth` < depths < 0).
-        
+
         Args:
             x_range: The range of x values, in meters.
             y_range: The range of y values, in meters.
@@ -251,7 +251,7 @@ class Bathymetry:
     @optional_deps.needs_coastal_extra_deps
     def x_uniques(self, sort: bool = False) -> np.ndarray:
         """Returns the unique x values.
-        
+
         Args:
             sort: Whether to sort the unique values.
         """
@@ -263,7 +263,7 @@ class Bathymetry:
     @optional_deps.needs_coastal_extra_deps
     def y_uniques(self, sort: bool = False) -> np.ndarray:
         """Returns the unique y values.
-        
+
         Args:
             sort: Whether to sort the unique values.
         """
@@ -278,10 +278,10 @@ class Bathymetry:
              y_range: Sequence[float],
              remove_offset=True):
         """Crops the bathymetry to a given range of x and y values.
-        
+
         Args:
             x_range: The range of x values, in meters.
-            y_range: The range of y values, in meters.    
+            y_range: The range of y values, in meters.
         """
         x_min, x_max = x_range
         y_min, y_max = y_range
@@ -336,14 +336,14 @@ class Bathymetry:
         The bathymetry data is plotted with a color plot on a grid with uniform
         spacing in the x and y directions. The spacing in the x and y directions
         is controlled by the `x_resolution` and `y_resolution` arguments.
-        
+
         The data is interpolated from the points where the bathymetry is defined
         to the uniform grid using linear interpolation.
 
         Points on the uniform grid at a distance larger than a threshold
         distance `threshold_distance` from points where the bathymetry is
         defined are omitted.
-    
+
         The plot is produced with matplotlib.
 
         Args:
@@ -427,7 +427,7 @@ class Bathymetry:
         The bathymetry is interpolated to a grid with uniform resolution (i.e.
         spacing) in the x and y directions. Linear interpolation is used to
         interpolate the bathymetry to the grid.
-        
+
         Grid points for which no interpolation is possible may be filled with
         a constant or with the nearest depth value.
 
@@ -454,7 +454,7 @@ class Bathymetry:
         fill_value: Optional[Union[float, str]] = None,
         nullable: bool = False,
     ):
-        """Interpolates the bathymetry to a uniform grid.     
+        """Interpolates the bathymetry to a uniform grid.
 
         Args:
             x_resolution: Resolution, in meters, of the grid in the x direction.
@@ -467,7 +467,7 @@ class Bathymetry:
             nullable: Whether to allow the bathymetry to be undefined in some
               grid points. If `False`, an error is raised if the bathymetry is
               undefined in one or more grid points.
-        
+
         Returns:
             depths_grid: A 2D array with the depths on the uniform grid.
             (x_grid, y_grid): The x and y coordinates of the points where the

--- a/inductiva/coastal/bathymetry.py
+++ b/inductiva/coastal/bathymetry.py
@@ -19,10 +19,10 @@ from inductiva.utils import optional_deps
 
 class Bathymetry:
     """Represents a bathymetric profile.
-    
+
     A bathymetric profile defines the depth of the sea bottom as a function of
     space, here described in Cartesian coordinates (x, y).
-    
+
     Here, a bathymetry is represented with:
     - a 1D array of depths, in meters, measured at arbitrary points in space.
       Positive depths are below the water level.
@@ -38,7 +38,7 @@ class Bathymetry:
         y: np.ndarray,
     ):
         """Initializes a `Bathymetry` object.
-        
+
         Args:
             depths: A 1D array with the depths, in meters.
             x: A 1D array with the x coordinates of the points where depths are
@@ -58,7 +58,7 @@ class Bathymetry:
         y_range: Sequence[float],
     ):
         """Creates a `Bathymetry` object from a bot file.
-        
+
         The depth values are read from a bot file, i.e. a text file with a 2D
         array with the depths, in meters. The first and second dimensions of the
         array in the text file (i.e. rows and columns) correspond to the x and y
@@ -86,7 +86,7 @@ class Bathymetry:
         remove_offset: bool = True,
     ):
         """Creates a `Bathymetry` object from an ASCII XYZ file.
-        
+
         ASCII XYZ files store bathymetric data in a table where each line
         corresponds to a location (latitude, longitude pair). Several columns
         are available to characterize the depth at each location, namely:
@@ -363,13 +363,14 @@ class Bathymetry:
               defined.
         """
 
-        logging.info("Plotting the bathymetry on a uniform grid...")
-        depths_grid, _ = self._interpolate_to_uniform_grid(
-            x_resolution,
-            y_resolution,
-            threshold_distance=threshold_distance,
-            nullable=True,
-        )
+        if not self.is_uniform_grid():
+            logging.info("Plotting the bathymetry on a uniform grid...")
+            depths_grid, _ = self._interpolate_to_uniform_grid(
+                x_resolution,
+                y_resolution,
+                threshold_distance=threshold_distance,
+                nullable=True,
+            )
 
         x_size = self.x_ptp() / x_resolution
         y_size = self.y_ptp() / y_resolution


### PR DESCRIPTION
First in a serie of micro PRs, each to address a specific issue with CoastalArea.
In this one, in the plot() method, we check if the bathymetry is uniform at the start of the method, in order for the _interpolate_to_uniform_grid to not be raised all the times, but only when in fact the grid is not uniform.
