### PR TITLE
[Openfoam] Clean Simulator and Scenarios

### DIFF
--- a/inductiva/fluids/__init__.py
+++ b/inductiva/fluids/__init__.py
@@ -19,7 +19,6 @@ from .wind_terrain import WindOverTerrain
 from . import shapes
 from .fluid_tank import (FluidTank, CubicTankOutlet, CylindricalTankOutlet,
                          CircularTankInlet, FluidTankOutput)
-from .heat_sink import HeatSink
 from ._post_processing import SPHSimulationOutput
 
 from . import post_processing

--- a/inductiva/fluids/__init__.py
+++ b/inductiva/fluids/__init__.py
@@ -10,9 +10,11 @@ from .fluid_types import (
     HONEY,
 )
 
-from .wind_tunnel import WindTunnel
+from .post_processing import SteadyStateOutput
+from .wind_tunnel import WindTunnel, WindTunnelOutput
 from .fluid_block import FluidBlock
 from .dam_break import DamBreak
+from .heat_sink import HeatSink, HeatSinkOutput
 from .wind_terrain import WindOverTerrain
 from . import shapes
 from .fluid_tank import (FluidTank, CubicTankOutlet, CylindricalTankOutlet,
@@ -21,4 +23,3 @@ from .heat_sink import HeatSink
 from ._post_processing import SPHSimulationOutput
 
 from . import post_processing
-from .post_processing import SteadyStateOutput

--- a/inductiva/fluids/heat_sink/heat_sink.py
+++ b/inductiva/fluids/heat_sink/heat_sink.py
@@ -4,7 +4,7 @@ import os
 import shutil
 from typing import Optional
 
-from inductiva import tasks, resources, simulators, scenarios, utils
+from inductiva import fluids, tasks, resources, simulators, scenarios, utils
 
 SCENARIO_TEMPLATE_DIR = os.path.join(utils.templates.TEMPLATES_PATH,
                                      "heat_sink")

--- a/inductiva/fluids/heat_sink/heat_sink.py
+++ b/inductiva/fluids/heat_sink/heat_sink.py
@@ -4,16 +4,10 @@ import os
 import shutil
 from typing import Optional
 
-from inductiva.fluids.heat_sink.output import HeatSinkOutput
+from inductiva import tasks, resources, simulators, scenarios, utils
 
-from inductiva import tasks, resources
-from inductiva.simulators import OpenFOAM
-from inductiva.simulators import Simulator
-from inductiva.scenarios import Scenario
-from inductiva.utils.templates import (TEMPLATES_PATH,
-                                       replace_params_in_template)
-
-SCENARIO_TEMPLATE_DIR = os.path.join(TEMPLATES_PATH, "heat_sink")
+SCENARIO_TEMPLATE_DIR = os.path.join(utils.templates.TEMPLATES_PATH,
+                                     "heat_sink")
 OPENFOAM_TEMPLATE_SUBDIR = "openfoam"
 FILES_SUBDIR = "files"
 OPENFOAM_TEMPLATE_PARAMS_FILE_NAME = "parameters.jinja"
@@ -21,7 +15,7 @@ OPENFOAM_PARAMS_FILE_NAME = "parameters"
 COMMANDS_FILE_NAME = "commands.json"
 
 
-class HeatSink(Scenario):
+class HeatSink(scenarios.Scenario):
     """Heat sink scenario.
 
     This is a simulation scenario for a heat sink. A heat source is placed
@@ -77,7 +71,7 @@ class HeatSink(Scenario):
     The scenario can be simulated with OpenFOAM.
     """
 
-    valid_simulators = [OpenFOAM]
+    valid_simulators = [simulators.Openfoam]
 
     def __init__(
         self,
@@ -99,7 +93,7 @@ class HeatSink(Scenario):
 
     def simulate(
         self,
-        simulator: Simulator = OpenFOAM(),
+        simulator: simulators.Simulator = simulators.Openfoam(),
         machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
         simulation_time=300,
@@ -125,7 +119,7 @@ class HeatSink(Scenario):
                                 run_async=run_async,
                                 commands=commands)
 
-        task.set_output_class(HeatSinkOutput)
+        task.set_output_class(fluids.HeatSinkOutput)
 
         return task
 
@@ -141,12 +135,12 @@ class HeatSink(Scenario):
         return commands
 
     @singledispatchmethod
-    def create_input_files(self, simulator: Simulator):
+    def create_input_files(self, simulator: simulators.Simulator):
         pass
 
 
 @HeatSink.create_input_files.register
-def _(self, simulator: OpenFOAM, input_dir):  # pylint: disable=unused-argument
+def _(self, simulator: simulators.Openfoam, input_dir):  # pylint: disable=unused-argument
     """Creates OpenFOAM simulation input files."""
 
     template_files_dir = os.path.join(SCENARIO_TEMPLATE_DIR,
@@ -161,7 +155,7 @@ def _(self, simulator: OpenFOAM, input_dir):  # pylint: disable=unused-argument
         os.path.join(input_dir, file_name) for file_name in
         [OPENFOAM_TEMPLATE_PARAMS_FILE_NAME, OPENFOAM_PARAMS_FILE_NAME])
 
-    replace_params_in_template(
+    utils.templates.replace_params_in_template(
         template_path=template_file_path,
         params={
             "simulation_time": self.simulation_time,

--- a/inductiva/fluids/wind_terrain/wind_terrain.py
+++ b/inductiva/fluids/wind_terrain/wind_terrain.py
@@ -9,10 +9,9 @@ from typing import List, Optional
 import numpy as np
 
 import inductiva
-from inductiva import fluids, simulators, resources, scenarios, world
-from inductiva.utils import templates, optional_deps
+from inductiva import fluids, simulators, resources, scenarios, world, utils
 
-SCENARIO_TEMPLATE_DIR = os.path.join(inductiva.utils.templates.TEMPLATES_PATH,
+SCENARIO_TEMPLATE_DIR = os.path.join(utils.templates.TEMPLATES_PATH,
                                      "wind_terrain")
 OPENFOAM_TEMPLATE_INPUT_DIR = "openfoam"
 FILES_SUBDIR = "files"
@@ -54,9 +53,9 @@ class WindOverTerrain(scenarios.Scenario):
     This scenario can be simulated with OpenFOAM.
     """
 
-    valid_simulators = [simulators.OpenFOAM]
+    valid_simulators = [simulators.Openfoam]
 
-    @optional_deps.needs_fluids_extra_deps
+    @utils.optional_deps.needs_fluids_extra_deps
     def __init__(self,
                  terrain: world.Terrain,
                  wind_velocity: List[float],
@@ -100,7 +99,7 @@ class WindOverTerrain(scenarios.Scenario):
 
     def simulate(
         self,
-        simulator: simulators.Simulator = simulators.OpenFOAM(),
+        simulator: simulators.Simulator = simulators.Openfoam(),
         machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
         n_cores: int = 1,
@@ -140,7 +139,7 @@ class WindOverTerrain(scenarios.Scenario):
                                               COMMANDS_TEMPLATE_FILE_NAME)
 
         inmemory_file = io.StringIO()
-        templates.replace_params_in_template(
+        utils.templates.replace_params_in_template(
             template_path=commands_template_path,
             params={"n_cores": self.n_cores},
             output_file=inmemory_file,
@@ -155,7 +154,7 @@ class WindOverTerrain(scenarios.Scenario):
 
 
 @WindOverTerrain.create_input_files.register
-def _(self, simulator: simulators.OpenFOAM, input_dir):  # pylint: disable=unused-argument
+def _(self, simulator: simulators.Openfoam, input_dir):  # pylint: disable=unused-argument
     """Creates OpenFOAM simulation input files."""
 
     # The WindTunnel with OpenFOAM requires changing multiple files
@@ -168,7 +167,7 @@ def _(self, simulator: simulators.OpenFOAM, input_dir):  # pylint: disable=unuse
                     dirs_exist_ok=True,
                     symlinks=True)
 
-    templates.batch_replace_params_in_template(
+    utils.templates.batch_replace_params_in_template(
         templates_dir=input_dir,
         template_filenames=[
             os.path.join("system", "blockMeshDict_template.openfoam.jinja"),

--- a/inductiva/fluids/wind_tunnel/output.py
+++ b/inductiva/fluids/wind_tunnel/output.py
@@ -4,11 +4,10 @@ Currently, we only support the OpenFOAM simulator.
 import os
 import csv
 
-from inductiva.fluids import post_processing
-from inductiva import types
+from inductiva import fluids, types
 
 
-class WindTunnelOutput(post_processing.SteadyStateOutput):
+class WindTunnelOutput(fluids.SteadyStateOutput):
     """Post-Process WindTunnel simulation outputs.
     This class is based on a more general class for post-processing the
     outputs of steady-state simulations. It inherits the following tools:

--- a/inductiva/simulators/__init__.py
+++ b/inductiva/simulators/__init__.py
@@ -4,7 +4,7 @@ from .swash import SWASH
 from .xbeach import XBeach
 from .splishsplash import Splishsplash
 from .dualsphysics import Dualsphysics
-from .openfoam import OpenFOAM
+from .openfoam import Openfoam
 from .gromacs import GROMACS
 from .simsopt import Simsopt
 from .fenicsx import FEniCSx

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -1,11 +1,10 @@
 """OpenFOAM module of the API for fluid dynamics."""
 from typing import Optional, List
 
-from inductiva import types, tasks, resources
-from inductiva.simulators import Simulator
+from inductiva import types, tasks, resources, simulators
 
 
-class OpenFOAM(Simulator):
+class Openfoam(simulators.Simulator):
     """Class to invoke a generic OpenFOAM simulation on the API."""
 
     def __init__(self):

--- a/inductiva/tests/test_simulator.py
+++ b/inductiva/tests/test_simulator.py
@@ -3,7 +3,7 @@ import inductiva
 
 
 def test_override_api_method_prefix():
-    simulator = inductiva.simulators.OpenFOAM()
+    simulator = inductiva.simulators.Openfoam()
     assert simulator.api_method_name == "fvm.openfoam.run_simulation"
     simulator.override_api_method_prefix("windtunnel")
     assert simulator.api_method_name == "windtunnel.openfoam.run_simulation"

--- a/inductiva/utils/__init__.py
+++ b/inductiva/utils/__init__.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-module-docstring
 from . import grids
+from . import files
 from . import interpolation
 from . import optional_deps
 from . import templates


### PR DESCRIPTION
This PR follows the same idea of #587 and simplifies the simulator name to `Openfoam` and cleans up the respective scenarios.

To test the changes I ran the following script for the WindTunnel - moreover I also perform tests in the WindOverTerrain and HeatSink eventhough they won't be documented for the release:

```python
scenario = inductiva.fluids.WindTunnel(
        flow_velocity=[20, 0, 0],
        domain={"x": [-7, 12], "y": [-5, 5], "z": [0, 8]})

task = scenario.simulate(
    num_iterations=100,
    object_path="meta_object.obj",
    resolution="low",
    n_cores=2)

# Get all the WindTunnel simulation files
output = task.get_output(all_files=True)
```