### PR TITLE
[Coastal, Molecules] Clean Simulators and Scenarios

### DIFF
--- a/inductiva/coastal/coastal_area.py
+++ b/inductiva/coastal/coastal_area.py
@@ -11,7 +11,8 @@ from absl import logging
 from inductiva import tasks, resources, simulators, scenarios, utils
 from inductiva import coastal
 
-SCENARIO_TEMPLATE_DIR = os.path.join(utils.templates.TEMPLATES_PATH, "coastal_area")
+SCENARIO_TEMPLATE_DIR = os.path.join(utils.templates.TEMPLATES_PATH,
+                                     "coastal_area")
 SWASH_TEMPLATE_SUBDIR = "swash"
 SWASH_CONFIG_TEMPLATE_FILENAME = "input.sws.jinja"
 SWASH_CONFIG_FILENAME = "input.sws"

--- a/inductiva/coastal/coastal_area.py
+++ b/inductiva/coastal/coastal_area.py
@@ -8,23 +8,17 @@ from typing import Literal, Optional
 
 from absl import logging
 
-from inductiva import tasks, resources
-from inductiva.scenarios import Scenario
-from inductiva.simulators import Simulator
-from inductiva.simulators import SWASH
-from inductiva.utils.templates import (TEMPLATES_PATH,
-                                       replace_params_in_template)
-from inductiva.coastal.bathymetry import Bathymetry
-from inductiva.coastal.output import CoastalAreaOutput
+from inductiva import tasks, resources, simulators, scenarios, utils
+from inductiva import coastal
 
-SCENARIO_TEMPLATE_DIR = os.path.join(TEMPLATES_PATH, "coastal_area")
+SCENARIO_TEMPLATE_DIR = os.path.join(utils.templates.TEMPLATES_PATH, "coastal_area")
 SWASH_TEMPLATE_SUBDIR = "swash"
 SWASH_CONFIG_TEMPLATE_FILENAME = "input.sws.jinja"
 SWASH_CONFIG_FILENAME = "input.sws"
 SWASH_BATHYMETRY_FILENAME = "bathymetry.bot"
 
 
-class CoastalArea(Scenario):
+class CoastalArea(scenarios.Scenario):
     """Coastal area scenario.
 
     This is a simulation scenario for waves propagating in a coastal area
@@ -56,11 +50,11 @@ class CoastalArea(Scenario):
     The scenario can be simulated with SWASH.
     """
 
-    valid_simulators = [SWASH]
+    valid_simulators = [simulators.Swash]
 
     def __init__(
         self,
-        bathymetry: Bathymetry,
+        bathymetry: coastal.Bathymetry,
         water_level: float = 0,
         wave_source_location: Literal["N", "S", "E", "W"] = "W",
         wave_amplitude: float = 2,
@@ -92,7 +86,7 @@ class CoastalArea(Scenario):
 
     def simulate(
         self,
-        simulator: Simulator = SWASH(),
+        simulator: simulators.Simulator = simulators.Swash(),
         machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
         simulation_time: float = 100,
@@ -125,27 +119,27 @@ class CoastalArea(Scenario):
             n_cores=n_cores,
         )
 
-        task.set_output_class(CoastalAreaOutput)
+        task.set_output_class(coastal.CoastalAreaOutput)
 
         return task
 
     @singledispatchmethod
-    def get_config_filename(self, simulator: Simulator):
+    def get_config_filename(self, simulator: simulators.Simulator):
         pass
 
     @singledispatchmethod
-    def create_input_files(self, simulator: Simulator):
+    def create_input_files(self, simulator: simulators.Simulator):
         pass
 
 
 @CoastalArea.get_config_filename.register
-def _(cls, simulator: SWASH):  # pylint: disable=unused-argument
+def _(cls, simulator: simulators.Swash):  # pylint: disable=unused-argument
     """Returns the configuration filename for SWASH."""
     return SWASH_CONFIG_FILENAME
 
 
 @CoastalArea.create_input_files.register
-def _(self, simulator: SWASH, input_dir):  # pylint: disable=unused-argument
+def _(self, simulator: simulators.Swash, input_dir):  # pylint: disable=unused-argument
     """Creates SPlisHSPlasH simulation input files."""
 
     template_files_dir = os.path.join(SCENARIO_TEMPLATE_DIR,
@@ -177,7 +171,7 @@ def _(self, simulator: SWASH, input_dir):  # pylint: disable=unused-argument
     absorbing_boundary_locations = ["N", "S", "E", "W"]
     absorbing_boundary_locations.remove(self.wave_source_location)
 
-    replace_params_in_template(
+    utils.templates.replace_params_in_template(
         template_path=config_template_file_path,
         params={
             "bathymetry_filename": SWASH_BATHYMETRY_FILENAME,

--- a/inductiva/molecules/md_water_box/md_water_box.py
+++ b/inductiva/molecules/md_water_box/md_water_box.py
@@ -7,7 +7,8 @@ import io
 
 from inductiva import tasks, resources, simulators, scenarios, utils, molecules
 
-SCENARIO_TEMPLATE_DIR = os.path.join(utils.templates.TEMPLATES_PATH, "md_water_box")
+SCENARIO_TEMPLATE_DIR = os.path.join(utils.templates.TEMPLATES_PATH,
+                                     "md_water_box")
 GROMACS_TEMPLATE_INPUT_DIR = "gromacs"
 COMMANDS_TEMPLATE_FILE_NAME = "commands.json.jinja"
 

--- a/inductiva/molecules/md_water_box/md_water_box.py
+++ b/inductiva/molecules/md_water_box/md_water_box.py
@@ -5,22 +5,17 @@ import os
 import shutil
 import io
 
-from inductiva import tasks, resources
-from inductiva.simulators import GROMACS
-from inductiva.simulators import Simulator
-from inductiva.utils import templates
-from inductiva.scenarios import Scenario
-from inductiva.molecules.md_water_box.post_processing import MDWaterBoxOutput
+from inductiva import tasks, resources, simulators, scenarios, utils, molecules
 
-SCENARIO_TEMPLATE_DIR = os.path.join(templates.TEMPLATES_PATH, "md_water_box")
+SCENARIO_TEMPLATE_DIR = os.path.join(utils.templates.TEMPLATES_PATH, "md_water_box")
 GROMACS_TEMPLATE_INPUT_DIR = "gromacs"
 COMMANDS_TEMPLATE_FILE_NAME = "commands.json.jinja"
 
 
-class MDWaterBox(Scenario):
+class MDWaterBox(scenarios.Scenario):
     """Molecular dynamics water box scenario."""
 
-    valid_simulators = [GROMACS]
+    valid_simulators = [simulators.Gromacs]
 
     def __init__(
         self,
@@ -45,7 +40,7 @@ class MDWaterBox(Scenario):
 
     def simulate(
             self,
-            simulator: Simulator = GROMACS(),
+            simulator: simulators.Simulator = simulators.Gromacs(),
             machine_group: Optional[resources.MachineGroup] = None,
             run_async: bool = False,
             simulation_time_ns: float = 10,  # ns
@@ -84,7 +79,7 @@ class MDWaterBox(Scenario):
                                 commands=commands,
                                 run_async=run_async)
 
-        task.set_output_class(MDWaterBoxOutput)
+        task.set_output_class(molecules.MDWaterBoxOutput)
 
         return task
 
@@ -96,7 +91,7 @@ class MDWaterBox(Scenario):
                                               COMMANDS_TEMPLATE_FILE_NAME)
 
         inmemory_file = io.StringIO()
-        templates.replace_params_in_template(
+        utils.templates.replace_params_in_template(
             template_path=commands_template_path,
             params={"box_size": self.box_size},
             output_file=inmemory_file,
@@ -106,12 +101,12 @@ class MDWaterBox(Scenario):
         return commands
 
     @singledispatchmethod
-    def create_input_files(self, simulator: Simulator):
+    def create_input_files(self, simulator: simulators.Simulator):
         pass
 
 
 @MDWaterBox.create_input_files.register
-def _(self, simulator: GROMACS, input_dir):  # pylint: disable=unused-argument
+def _(self, simulator: simulators.Gromacs, input_dir):  # pylint: disable=unused-argument
     """Creates GROMACS simulation input files."""
 
     template_files_dir = os.path.join(SCENARIO_TEMPLATE_DIR,
@@ -119,7 +114,7 @@ def _(self, simulator: GROMACS, input_dir):  # pylint: disable=unused-argument
 
     shutil.copytree(template_files_dir, input_dir, dirs_exist_ok=True)
 
-    templates.batch_replace_params_in_template(
+    utils.templates.batch_replace_params_in_template(
         templates_dir=input_dir,
         template_filenames=[
             "simulation.mdp.jinja",

--- a/inductiva/molecules/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/protein_solvation/protein_solvation.py
@@ -7,7 +7,8 @@ import shutil
 
 from inductiva import tasks, resources, simulators, scenarios, utils, molecules
 
-SCENARIO_TEMPLATE_DIR = os.path.join(utils.templates.TEMPLATES_PATH, "protein_solvation")
+SCENARIO_TEMPLATE_DIR = os.path.join(utils.templates.TEMPLATES_PATH,
+                                     "protein_solvation")
 GROMACS_TEMPLATE_INPUT_DIR = "gromacs"
 COMMANDS_TEMPLATE_FILE_NAME = "commands.json"
 

--- a/inductiva/simulators/__init__.py
+++ b/inductiva/simulators/__init__.py
@@ -1,10 +1,10 @@
 # pylint: disable=missing-module-docstring
 from .simulator import Simulator
-from .swash import SWASH
-from .xbeach import XBeach
+from .swash import Swash
+from .xbeach import Xbeach
 from .splishsplash import Splishsplash
 from .dualsphysics import Dualsphysics
 from .openfoam import Openfoam
-from .gromacs import GROMACS
+from .gromacs import Gromacs
 from .simsopt import Simsopt
 from .fenicsx import FEniCSx

--- a/inductiva/simulators/gromacs.py
+++ b/inductiva/simulators/gromacs.py
@@ -2,11 +2,10 @@
 
 from typing import Optional, List
 
-from inductiva import types, tasks, resources
-from inductiva.simulators import Simulator
+from inductiva import types, tasks, resources, simulators
 
 
-class GROMACS(Simulator):
+class Gromacs(simulators.Simulator):
     """Class to invoke any GROMACS command on the API."""
 
     def __init__(self):

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -1,11 +1,10 @@
 """SWASH module of the API."""
 from typing import Optional
 
-from inductiva.simulators import Simulator
-from inductiva import types, tasks, resources
+from inductiva import types, tasks, resources, simulators
 
 
-class SWASH(Simulator):
+class Swash(simulators.Simulator):
     """Class to invoke a generic SWASH simulation on the API."""
 
     def __init__(self):

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -1,11 +1,10 @@
 """DualSPHysics module of the API."""
 from typing import Optional
 
-from inductiva import types, tasks, resources
-from inductiva.simulators import Simulator
+from inductiva import types, tasks, resources, simulators
 
 
-class XBeach(Simulator):
+class Xbeach(simulators.Simulator):
     """Class to invoke a generic XBeach simulation on the API."""
 
     def __init__(self):


### PR DESCRIPTION
This PR follows the same idea of https://github.com/inductiva/inductiva/pull/587 and simplifies the simulator name to Gromacs, Xbeach, Swash and cleans up the respective scenarios. I will leave the Fenicxs out of this change due to current development and Simsopt is already correct. So this is the last code change, in the next I will fix the documentation.

To test the changes I ran the following scripts:
```python
import inductiva

inductiva.api_key = "API_Key"

bathymetry = inductiva.coastal.Bathymetry.from_random_depths(
        x_range=(0, 100),
        y_range=(0, 100),
        x_num=50,
        y_num=50,
        max_depth=10)

scenario = inductiva.coastal.CoastalArea(bathymetry=bathymetry,
                                         wave_source_location="W",
                                         wave_amplitude=5,
                                         wave_period=5.5)

task = scenario.simulate(simulation_time=1, output_time_step=1)
```

```python
import inductiva

inductiva.api_key = "APi_KEY"

scenario = inductiva.molecules.ProteinSolvation(
     protein_pdb = "alanine.pdb",
     temperature = 300)

task = scenario.simulate(simulation_time_ns = 0.5)

# Get the simulation output on your local machine.
output = task.get_output()

```
