### PR TITLE
Update and document sync simulation behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ pip install --upgrade inductiva
 These will provide the default installation of the package, that allow you to submit jobs, control machines and run simulations. To use the visualization and post-processing tools, you need to install extra dependencies depending on your area: `molecules_extra`, `fluids_extra` or `coastal_extra`. For example, for molecules:
 
 ```
-pip install inductiva[molecules_extra]
+pip install --upgrade "inductiva[molecules_extra]"
 ```
 
 ## API access tokens
 
-Please [request API token](https://docs.google.com/forms/d/e/1FAIpQLSflytIIwzaBE_ZzoRloVm3uTo1OQCH6Cqhw3bhFVnC61s7Wmw/viewform)  and add the following line to your code:
+Please [request API token](https://docs.google.com/forms/d/e/1FAIpQLSflytIIwzaBE_ZzoRloVm3uTo1OQCH6Cqhw3bhFVnC61s7Wmw/viewform) and add the following line to your code:
 
 ```python
 import inductiva

--- a/inductiva/tasks/README.md
+++ b/inductiva/tasks/README.md
@@ -1,4 +1,52 @@
-# Task management
+# Tasks
+
+## Submitting tasks
+
+### Sync. vs Async.
+
+The **Inductiva API** client allows running simulations both synchronously and asynchronously.
+This can be achieved by specifying the `run_async` argument to `scenario.simulate()` and `simulator.run()` calls.
+When tasks are submitted synchronously, the client blocks until the task's outputs are ready.
+Note that if the local process on blocking tasks is interrupted (for instance, with `CTRL+C` or a client-side exception), the task running remotely will be killed.
+When run tasks asynchronously, on the other hand, the client unblocks after successfuly submitting the simulation, and the user immediately gets a `Task` object, which is described in further detail [below](#managing-tasks). If the user calls `task.wait()`, the task will block until it completes, but without interrupting the remote task if the local process is interrupted.
+
+To recap:
+
+```python
+
+my_scenario = inductiva.molecules.ProteinSolvation(
+    protein_pdb="my_protein.pdb"
+)
+
+# Run simulation blocking the client, and killing the remote task if the local
+# process is interrupted.
+task = my_scenario.simulate()
+
+# Run simulation without blocking the client.
+task = my_scenario.simulate(run_async=True)
+
+# Run simulation async, blocking the client after submitting the task.
+task = my_senario.simulate(run_async=True)
+# This will block the client until the task complets..
+task.wait()
+
+# Run simulation async, turning it into a blocking call with the behavior of
+# killing the remote process if the local process is killed.
+task = my_scenario.simulate(run_async=True)
+with task.sync_context()
+    task.wait()
+```
+
+
+Running the task synchronously but without interrupting the remote process when can be achieved by
+submitting the task as
+
+
+
+
+
+## Managing tasks
+
 
 
 

--- a/inductiva/tasks/README.md
+++ b/inductiva/tasks/README.md
@@ -1,8 +1,16 @@
 # Tasks
 
-## Submitting tasks
 
-### Sync. vs Async.
+The **Inductiva API** client provides the ability to run complex simulations and contains easy-to-use tools to manage them. Each simulation submitted - with `scenario.simulate()` or `simulation.run()` - returns a `Task` object that contains methods to manage the simulation.
+
+
+Here, you'll learn:
+
+- [Submitting tasks sync vs. async](#submitting-tasks-sync-vs-async): the different ways you can submit a task.
+- [Managing tasks](#managing-tasks): the methods you can use to interact with a specific task.
+- [Retrieving tasks from previous sessions](#retrieving-tasks-from-previous-sessions): getting information from previously ran tasks.
+
+## Submitting tasks sync vs. async
 
 The **Inductiva API** client allows running simulations both synchronously and asynchronously.
 This can be achieved by specifying the `run_async` argument to `scenario.simulate()` and `simulator.run()` calls.
@@ -37,15 +45,7 @@ with task.sync_context():
     task.wait()
 ```
 
-
-
-
-
-
 ## Managing tasks
-
-
-
 
 The `Task` class provides methods for managing a specific task submitted to the **Inductiva API**. You get an instance of `Task` everytime you create a simulation. Moreover, you can [retrieve previously created tasks](#retrieving-tasks-from-previous-sessions).
 With a `Task` object, you can:

--- a/inductiva/tasks/README.md
+++ b/inductiva/tasks/README.md
@@ -6,9 +6,9 @@
 
 The **Inductiva API** client allows running simulations both synchronously and asynchronously.
 This can be achieved by specifying the `run_async` argument to `scenario.simulate()` and `simulator.run()` calls.
-When tasks are submitted synchronously, the client blocks until the task's outputs are ready.
-Note that if the local process on blocking tasks is interrupted (for instance, with `CTRL+C` or a client-side exception), the task running remotely will be killed.
-When run tasks asynchronously, on the other hand, the client unblocks after successfuly submitting the simulation, and the user immediately gets a `Task` object, which is described in further detail [below](#managing-tasks). If the user calls `task.wait()`, the task will block until it completes, but without interrupting the remote task if the local process is interrupted.
+When a task is submitted synchronously, the client blocks until its outputs are ready.
+Note that if the local process is interrupted (with `CTRL+C` or a client-side exception), the task running remotely will be killed.
+On the other hand, when a task is submitted asynchronously, the client unblocks after  submitting the simulation. The the user immediately gets a `Task` object, which is described in further detail [below](#managing-tasks). If the user calls `task.wait()`, the task will block until it completes, but without interrupting the remote task if the local process is interrupted.
 
 To recap:
 
@@ -27,19 +27,16 @@ task = my_scenario.simulate(run_async=True)
 
 # Run simulation async, blocking the client after submitting the task.
 task = my_senario.simulate(run_async=True)
-# This will block the client until the task complets..
+# This will block the client until the task completes.
 task.wait()
 
 # Run simulation async, turning it into a blocking call with the behavior of
 # killing the remote process if the local process is killed.
 task = my_scenario.simulate(run_async=True)
-with task.sync_context()
+with task.sync_context():
     task.wait()
 ```
 
-
-Running the task synchronously but without interrupting the remote process when can be achieved by
-submitting the task as
 
 
 

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -38,7 +38,7 @@ def run_simulation(
 
     # Blocking call for sync execution
     if not run_async:
-        with task:
+        with task.sync_context():
             task.wait()
 
     return task


### PR DESCRIPTION
Closes #585 

- Update blocking call context for readability
- Document sync task behavior

The code changes here don't affect functionality, only readability. Previously the blocking call context
was defined using the __enter__ and __exit__ methods of the Task class, which made it unclear what that
context was about. I moved the same functionality to a method of the Task called `sync_context`. This can
be used to turn an async call into a sync call, including the killing part. The snippets added to the 
documentation where experimented with to check if the behavior remains ok.
