### PR TITLE
[ProteinSolvation] Fix import

### DIFF
--- a/inductiva/molecules/protein_solvation/post_processing.py
+++ b/inductiva/molecules/protein_solvation/post_processing.py
@@ -156,4 +156,5 @@ class ProteinSolvationOutput:
                               "only available in a python notebook.")
 
         if "google.cloud" in str(self.ipython_kernel):
+            print("here")
             gc.output.enable_custom_widget_manager()

--- a/inductiva/molecules/protein_solvation/post_processing.py
+++ b/inductiva/molecules/protein_solvation/post_processing.py
@@ -157,6 +157,4 @@ class ProteinSolvationOutput:
 
         if self.ipython_kernel.__module__.startswith("google.colab"):
             gc.output.enable_custom_widget_manager()
-        else: 
-            print("condition false")
-            print(str(self.ipython_kernel))
+

--- a/inductiva/molecules/protein_solvation/post_processing.py
+++ b/inductiva/molecules/protein_solvation/post_processing.py
@@ -150,7 +150,6 @@ class ProteinSolvationOutput:
     @optional_deps.needs_molecules_extra_deps
     def enable_vizualization(self):
         """Enable vizualization if IPython is available."""
-        print(str(self.ipython_kernel))
         if self.ipython_kernel is None:
             raise ImportError("IPython is not available. Visualization is "
                               "only available in a python notebook.")
@@ -158,3 +157,5 @@ class ProteinSolvationOutput:
         if "google.cloud" in str(self.ipython_kernel):
             print("here")
             gc.output.enable_custom_widget_manager()
+        else : 
+            print("condition false")

--- a/inductiva/molecules/protein_solvation/post_processing.py
+++ b/inductiva/molecules/protein_solvation/post_processing.py
@@ -8,7 +8,7 @@ try:
     import matplotlib.pyplot as plt
     import nglview as nv
     import IPython as ip
-except:
+except ImportError:
     nv = None
     plt = None
     ip = None
@@ -150,7 +150,7 @@ class ProteinSolvationOutput:
     @optional_deps.needs_molecules_extra_deps
     def enable_vizualization(self):
         """Enable vizualization if IPython is available."""
-
+        print(str(self.ipython_kernel))
         if self.ipython_kernel is None:
             raise ImportError("IPython is not available. Visualization is "
                               "only available in a python notebook.")

--- a/inductiva/molecules/protein_solvation/post_processing.py
+++ b/inductiva/molecules/protein_solvation/post_processing.py
@@ -1,5 +1,6 @@
 "Postprocessing steps for the MDWaterBox scenario."
 import os
+import sys
 import pathlib
 from typing import Literal
 
@@ -154,8 +155,7 @@ class ProteinSolvationOutput:
             raise ImportError("IPython is not available. Visualization is "
                               "only available in a python notebook.")
 
-        if "google.cloud" in str(self.ipython_kernel):
-            print("here")
+        if 'google.colab' in sys.modules:
             gc.output.enable_custom_widget_manager()
         else: 
             print("condition false")

--- a/inductiva/molecules/protein_solvation/post_processing.py
+++ b/inductiva/molecules/protein_solvation/post_processing.py
@@ -8,12 +8,14 @@ try:
     import matplotlib.pyplot as plt
     import nglview as nv
     import IPython as ip
-    import google.colab as gc
-
-except ImportError:
+except:
     nv = None
     plt = None
     ip = None
+
+try:
+    import google.colab as gc
+except ImportError:
     gc = None
 
 import inductiva

--- a/inductiva/molecules/protein_solvation/post_processing.py
+++ b/inductiva/molecules/protein_solvation/post_processing.py
@@ -155,7 +155,7 @@ class ProteinSolvationOutput:
             raise ImportError("IPython is not available. Visualization is "
                               "only available in a python notebook.")
 
-        if 'google.colab' in sys.modules:
+        if self.ipython_kernel.__module__.startswith("google.colab"):
             gc.output.enable_custom_widget_manager()
         else: 
             print("condition false")

--- a/inductiva/molecules/protein_solvation/post_processing.py
+++ b/inductiva/molecules/protein_solvation/post_processing.py
@@ -157,4 +157,3 @@ class ProteinSolvationOutput:
 
         if self.ipython_kernel.__module__.startswith("google.colab"):
             gc.output.enable_custom_widget_manager()
-

--- a/inductiva/molecules/protein_solvation/post_processing.py
+++ b/inductiva/molecules/protein_solvation/post_processing.py
@@ -1,6 +1,5 @@
 "Postprocessing steps for the MDWaterBox scenario."
 import os
-import sys
 import pathlib
 from typing import Literal
 

--- a/inductiva/molecules/protein_solvation/post_processing.py
+++ b/inductiva/molecules/protein_solvation/post_processing.py
@@ -157,5 +157,6 @@ class ProteinSolvationOutput:
         if "google.cloud" in str(self.ipython_kernel):
             print("here")
             gc.output.enable_custom_widget_manager()
-        else : 
+        else: 
             print("condition false")
+            print(str(self.ipython_kernel))

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ molecules_extra =
   nglview
   MDAnalysis
   ipywidgets
-  google.colab
   IPython
 
 fluids_extra =


### PR DESCRIPTION
In this PR, I'm removing the google.colab from the dependencies. It was causing me problems installing it and when you are using the Google Colab the dependency is already there. 
## How did I test this? 
**In Colab:**
![image](https://github.com/inductiva/inductiva/assets/114397668/4d710e39-9bc7-444e-a716-f70dee65ccdd)
However the video is not playing in Colab, I need to go deeper on it. I will address it in another PR, since the pip install inductiva[molecules_extra] is broken and I want to fix it ASAP. 
**In Terminal:** 
<img width="898" alt="image" src="https://github.com/inductiva/inductiva/assets/114397668/ec92632f-beb3-4463-b838-aa1530dd4d4b">
