### PR TITLE
[WindTunnel] Update render methods in ReadME and for Colab

### DIFF
--- a/inductiva/fluids/dam_break/README.md
+++ b/inductiva/fluids/dam_break/README.md
@@ -36,6 +36,6 @@ output.render()
 <p align="center">
   <img src="https://github.com/inductiva/inductiva/blob/f52d0a733276996e02fdde942a4974c0a75d5038/resources/media/dam_break.gif" alt="Centered Image" width="400" height="300">
 
-**Remark:** For those running on Google Colab or a headless server, further extra dependencies are required. Install them with `!apt install libgl1-mesa-glx xvfb`. Moreover, change the parameter `virtual_display` in the render method to `True`, like `output.render(virtual_display=True)`.
+**Remark:** For those running on Google Colab or a headless server, further extra dependencies are required. Install them with `!apt install libgl1-mesa-glx xvfb`. Moreover, change the parameter `virtual_display` in the render method to `True`, and pass a path to save the result, like `streamlines.render(virtual_display=True, save_path="streamlines.png")`.
 
 Further, one can alter the `color` of the particles and `fps` of the rendering!

--- a/inductiva/fluids/fluid_block/README.md
+++ b/inductiva/fluids/fluid_block/README.md
@@ -41,6 +41,6 @@ output.render()
   <img src="https://github.com/inductiva/inductiva/blob/f52d0a733276996e02fdde942a4974c0a75d5038/resources/media/fluid_block.gif" alt="Centered Image" width="400" height="300">
 
 **Remark:** For those running on Google Colab or a headless server, further extra dependencies are required. Install them with `!apt install libgl1-mesa-glx xvfb`. 
-Moreover, change the parameter `virtual_display` in the render method to `True`, like `output.render(virtual_display=True)`.
+Moreover, change the parameter `virtual_display` in the render method to `True`, and pass a path to save the result, like `streamlines.render(virtual_display=True, save_path="streamlines.png")`. 
 
 Further, one can alter the `color` of the particles and `fps` of the rendering!

--- a/inductiva/fluids/post_processing/openfoam.py
+++ b/inductiva/fluids/post_processing/openfoam.py
@@ -259,6 +259,8 @@ class FlowSlice:
             save_path = utils.files.resolve_path(save_path)
 
         if virtual_display:
+            # Set off_screen to True, since screens aren't available.
+            off_screen = True
             pv.start_xvfb()
 
         plotter = pv.Plotter(off_screen=off_screen)
@@ -304,6 +306,8 @@ class Streamlines:
             save_path = utils.files.resolve_path(save_path)
 
         if virtual_display:
+            # Set off_screen to True, since screens aren't available.
+            off_screen = True
             pv.start_xvfb()
 
         plotter = pv.Plotter(off_screen=off_screen)
@@ -382,7 +386,7 @@ class MeshData:
 
     def render(self,
                off_screen: bool = False,
-               background_color: str = "black",
+               background_color: str = "white",
                scalars_cmap: str = "viridis",
                virtual_display: bool = False,
                save_path: types.Path = None):
@@ -391,6 +395,8 @@ class MeshData:
             save_path = utils.files.resolve_path(save_path)
 
         if virtual_display:
+            # Set off_screen to True, since screens aren't available.
+            off_screen = True
             pv.start_xvfb()
 
         plotter = pv.Plotter(off_screen=off_screen)

--- a/inductiva/fluids/wind_tunnel/README.md
+++ b/inductiva/fluids/wind_tunnel/README.md
@@ -165,4 +165,4 @@ flow_slice.render(physical_field="velocity",
 
 <img src="/resources/media/openfoam/flow_slice.png" width="400" height="300" />
 
-**Remark: ** For those running on Google Colab or a headless server, further extra dependencies are required. Install them with `!apt install libgl1-mesa-glx xvfb`. Moreover, change the parameter `virtual_display` in the render method to `True`, like `streamlines.render(virtual_display=True)`.
+**Remark: ** For those running on Google Colab or a headless server, further extra dependencies are required. Install them with `!apt install libgl1-mesa-glx xvfb`. Moreover, change the parameter `virtual_display` in the render method to `True`, and pass a path to save the result, like `streamlines.render(virtual_display=True, save_path="streamlines.png")`.  

--- a/inductiva/fluids/wind_tunnel/README.md
+++ b/inductiva/fluids/wind_tunnel/README.md
@@ -165,4 +165,14 @@ flow_slice.render(physical_field="velocity",
 
 <img src="/resources/media/openfoam/flow_slice.png" width="400" height="300" />
 
-**Remark: ** For those running on Google Colab or a headless server, further extra dependencies are required. Install them with `!apt install libgl1-mesa-glx xvfb`. Moreover, change the parameter `virtual_display` in the render method to `True`, and pass a path to save the result, like `streamlines.render(virtual_display=True, save_path="streamlines.png")`.  
+**Remark: ** For those running on Google Colab or a headless server, further extra dependencies are required. Install them with 
+
+```
+!apt install libgl1-mesa-glx xvfb
+```
+
+Moreover, change the parameter `virtual_display` in the render method to `True`, and pass a path to save the result, like 
+
+```python
+streamlines.render(virtual_display=True, save_path="streamlines.png")
+```

--- a/inductiva/fluids/wind_tunnel/README.md
+++ b/inductiva/fluids/wind_tunnel/README.md
@@ -86,7 +86,7 @@ output = task.get_output()
 pressure_field = output.get_object_pressure_field()
 
 # Render
-pressure_field.render_frame()
+pressure_field.render()
 ```
 
 <img src="/resources/media/openfoam/default_pressure_field.png" width="400" height="300" />
@@ -96,11 +96,11 @@ pressure_field.render_frame()
 streamlines = output.get_streamlines()
 
 # Render the streamlines
-streamlines.render_frame(physical_field="velocity",
-                         flow_cmap="viridis",
-                         view="isometric",
-                         streamline_radius=0.1
-                         save_path="default_streamlines.png")
+streamlines.render(physical_field="velocity",
+                   flow_cmap="viridis",
+                   view="isometric",
+                   streamline_radius=0.1
+                   save_path="default_streamlines.png")
 ```
 
 <img src="/resources/media/openfoam/default_streamlines.png" width="400" height="300" />
@@ -111,9 +111,9 @@ streamlines.render_frame(physical_field="velocity",
 flow_slice = output.get_flow_slice(plane="xz")
 
 # Render the pressure field over the slice
-flow_slice.render_frame(physical_field="pressure",
-                        flow_cmap="viridis",
-                        save_path="default_flow_slice.png")
+flow_slice.render(physical_field="pressure",
+                  flow_cmap="viridis",
+                  save_path="default_flow_slice.png")
 ```
 
 <img src="/resources/media/openfoam/default_flow_slice.png" width="400" height="300" />
@@ -128,7 +128,7 @@ output = task.get_output(all_files=True)
 pressure_field = output.get_object_pressure_field()
 
 # Render
-pressure_field.render_frame(save_path="pressure_field.png")
+pressure_field.render(save_path="pressure_field.png")
 ```
 
 <img src="/resources/media/openfoam/pressure_field.png" width="400" height="300" />
@@ -142,11 +142,11 @@ streamlines = output.get_streamlines(max_time=200,
                                      source_center=[-3, 0, 1])
 
 # Render the streamlines
-streamlines.render_frame(physical_field="pressure",
-                         flow_cmap="viridis",
-                         view="isometric",
-                         streamline_radius=0.1
-                         save_path="streamlines.png")
+streamlines.render(physical_field="pressure",
+                   flow_cmap="viridis",
+                   view="isometric",
+                   streamline_radius=0.1
+                   save_path="streamlines.png")
 ```
 
 <img src="/resources/media/openfoam/streamlines.png" width="400" height="300" />
@@ -158,9 +158,11 @@ flow_slice = output.get_flow_slice(plane="xz",
                                    origin=(0,0,0))
 
 # Render the velocity field over the flow slice.
-flow_slice.render_frame(physical_field="velocity",
-                        flow_cmap="Blues",
-                        save_path="flow_slice.png")
+flow_slice.render(physical_field="velocity",
+                  flow_cmap="Blues",
+                  save_path="flow_slice.png")
 ```
 
 <img src="/resources/media/openfoam/flow_slice.png" width="400" height="300" />
+
+**Remark: ** For those running on Google Colab or a headless server, further extra dependencies are required. Install them with `!apt install libgl1-mesa-glx xvfb`. Moreover, change the parameter `virtual_display` in the render method to `True`, like `streamlines.render(virtual_display=True)`.


### PR DESCRIPTION
This PR fixes the naming of the rendering methods, that before were `render_frame()` but that were updated to `render()` without updating the README.

Moreover, it adds a snippet mentioned the changes required for using this on Colab and addresses an issue related with Colab that would require the user to pass two arguments (`off_screen` and `virtual_display`) for the visualisation to work bug to allow to render in this environment. Notice that `virtual_display` is only to be used when no screen exists, so `off_screen=True`.

I tested these conditions in a Colab, with the most recent version of the package and everything works smoothly.