### PR TITLE
Remove `_in_template` name from template functions

### DIFF
--- a/inductiva/coastal/coastal_area.py
+++ b/inductiva/coastal/coastal_area.py
@@ -171,7 +171,7 @@ def _(self, simulator: simulators.SWASH, input_dir):  # pylint: disable=unused-a
     absorbing_boundary_locations = ["N", "S", "E", "W"]
     absorbing_boundary_locations.remove(self.wave_source_location)
 
-    utils.templates.replace_params_in_template(
+    utils.templates.replace_params(
         template_path=config_template_file_path,
         params={
             "bathymetry_filename": SWASH_BATHYMETRY_FILENAME,

--- a/inductiva/design.py
+++ b/inductiva/design.py
@@ -45,7 +45,7 @@ def explore_design_space(simulator: Simulator,
         template_path = os.path.join(input_dir, template_filename)
         input_file = os.path.join(input_dir, input_filename)
 
-        templates.replace_params_in_template(
+        templates.replace_params(
             template_path,
             {tag: value},
             input_file,

--- a/inductiva/fluids/fluid_block/fluid_block.py
+++ b/inductiva/fluids/fluid_block/fluid_block.py
@@ -172,7 +172,7 @@ def _(self, simulator: simulators.SplishSplash, input_dir):  # pylint: disable=u
     # Generate the simulation configuration file.
     fluid_margin = 2 * self.particle_radius
 
-    utils.templates.replace_params_in_template(
+    utils.templates.replace_params(
         template_path=os.path.join(template_files_dir,
                                    SPLISHSPLASH_TEMPLATE_FILENAME),
         params={
@@ -210,7 +210,7 @@ def _(self, simulator: simulators.DualSPHysics, input_dir):  # pylint: disable=u
 
     template_files_dir = os.path.join(SCENARIO_TEMPLATE_DIR,
                                       DUALSPHYSICS_TEMPLATE_INPUT_DIR)
-    utils.templates.replace_params_in_template(
+    utils.templates.replace_params(
         template_path=os.path.join(template_files_dir,
                                    DUALSPHYSICS_TEMPLATE_FILENAME),
         params={

--- a/inductiva/fluids/fluid_tank/fluid_tank.py
+++ b/inductiva/fluids/fluid_tank/fluid_tank.py
@@ -304,7 +304,7 @@ def _(self, simulator: simulators.SplishSplash, input_dir):  # pylint: disable=u
         bounding_box_max[2],
     ]
 
-    utils.templates.replace_params_in_template(
+    utils.templates.replace_params(
         template_path=os.path.join(template_files_dir,
                                    SPLISHSPLASH_TEMPLATE_FILENAME),
         params={

--- a/inductiva/fluids/heat_sink/heat_sink.py
+++ b/inductiva/fluids/heat_sink/heat_sink.py
@@ -155,7 +155,7 @@ def _(self, simulator: simulators.OpenFOAM, input_dir):  # pylint: disable=unuse
         os.path.join(input_dir, file_name) for file_name in
         [OPENFOAM_TEMPLATE_PARAMS_FILE_NAME, OPENFOAM_PARAMS_FILE_NAME])
 
-    utils.templates.replace_params_in_template(
+    utils.templates.replace_params(
         template_path=template_file_path,
         params={
             "simulation_time": self.simulation_time,

--- a/inductiva/fluids/wind_terrain/wind_terrain.py
+++ b/inductiva/fluids/wind_terrain/wind_terrain.py
@@ -139,7 +139,7 @@ class WindOverTerrain(scenarios.Scenario):
                                               COMMANDS_TEMPLATE_FILE_NAME)
 
         inmemory_file = io.StringIO()
-        utils.templates.replace_params_in_template(
+        utils.templates.replace_params(
             template_path=commands_template_path,
             params={"n_cores": self.n_cores},
             output_file=inmemory_file,
@@ -167,7 +167,7 @@ def _(self, simulator: simulators.OpenFOAM, input_dir):  # pylint: disable=unuse
                     dirs_exist_ok=True,
                     symlinks=True)
 
-    utils.templates.batch_replace_params_in_template(
+    utils.templates.batch_replace_params(
         templates_dir=input_dir,
         template_filenames=[
             os.path.join("system", "blockMeshDict_template.openfoam.jinja"),

--- a/inductiva/fluids/wind_tunnel/wind_tunnel.py
+++ b/inductiva/fluids/wind_tunnel/wind_tunnel.py
@@ -153,7 +153,7 @@ class WindTunnel(scenarios.Scenario):
                                               COMMANDS_TEMPLATE_FILE_NAME)
 
         inmemory_file = io.StringIO()
-        utils.templates.replace_params_in_template(
+        utils.templates.replace_params(
             template_path=commands_template_path,
             params={"n_cores": self.n_cores},
             output_file=inmemory_file,
@@ -181,7 +181,7 @@ def _(self, simulator: simulators.OpenFOAM, input_dir):  # pylint: disable=unuse
                     dirs_exist_ok=True,
                     symlinks=True)
 
-    utils.templates.batch_replace_params_in_template(
+    utils.templates.batch_replace_params(
         templates_dir=input_dir,
         template_filenames=[
             os.path.join("0", "include",

--- a/inductiva/molecules/md_water_box/md_water_box.py
+++ b/inductiva/molecules/md_water_box/md_water_box.py
@@ -92,7 +92,7 @@ class MDWaterBox(scenarios.Scenario):
                                               COMMANDS_TEMPLATE_FILE_NAME)
 
         inmemory_file = io.StringIO()
-        utils.templates.replace_params_in_template(
+        utils.templates.replace_params(
             template_path=commands_template_path,
             params={"box_size": self.box_size},
             output_file=inmemory_file,
@@ -115,7 +115,7 @@ def _(self, simulator: simulators.GROMACS, input_dir):  # pylint: disable=unused
 
     shutil.copytree(template_files_dir, input_dir, dirs_exist_ok=True)
 
-    utils.templates.batch_replace_params_in_template(
+    utils.templates.batch_replace_params(
         templates_dir=input_dir,
         template_filenames=[
             "simulation.mdp.jinja",

--- a/inductiva/molecules/protein_solvation/protein_solvation.py
+++ b/inductiva/molecules/protein_solvation/protein_solvation.py
@@ -130,7 +130,7 @@ def _(self, simulator: simulators.GROMACS, input_dir):  # pylint: disable=unused
 
     shutil.copytree(template_files_dir, input_dir, dirs_exist_ok=True)
 
-    utils.templates.batch_replace_params_in_template(
+    utils.templates.batch_replace_params(
         templates_dir=input_dir,
         template_filenames=[
             "simulation.mdp.jinja",

--- a/inductiva/utils/templates.py
+++ b/inductiva/utils/templates.py
@@ -12,7 +12,7 @@ from inductiva.utils.files import find_path_to_package
 TEMPLATES_PATH = find_path_to_package("templates")
 
 
-def replace_params_in_template(
+def replace_params(
     template_path: str,
     params: Dict,
     output_file: Union[str, io.StringIO],
@@ -34,7 +34,7 @@ def replace_params_in_template(
         os.remove(template_path)
 
 
-def batch_replace_params_in_template(
+def batch_replace_params(
     templates_dir: str,
     template_filenames: List[str],
     params: Dict,
@@ -60,7 +60,7 @@ def batch_replace_params_in_template(
     for index, template_filename in enumerate(template_filenames):
         template_path = os.path.join(templates_dir, template_filename)
 
-        replace_params_in_template(
+        replace_params(
             template_path=template_path,
             params=params,
             output_file=output_filename_paths[index],


### PR DESCRIPTION
This PR addresses the principle of DRY and removes the `_in_template` from the functions of the templates module, since the imports already tell us about that.