### PR TITLE
[CoastalArea] Add logging info about divergent simulations

### DIFF
--- a/inductiva/coastal/output.py
+++ b/inductiva/coastal/output.py
@@ -205,7 +205,7 @@ class CoastalAreaOutput:
     @optional_deps.needs_coastal_extra_deps
     def check_stability(self):
 
-        time_list, data_list = read_swash_grid_quantity_file(
+        _, data_list = read_swash_grid_quantity_file(
             file_path=os.path.join(self.sim_output_path, "water_level.mat"),
             quantity="water_level",
         )
@@ -214,7 +214,7 @@ class CoastalAreaOutput:
         inital_max_water_level = np.max(data_list[0])
         final_max_water_level = np.max(data_list[-1])
 
-        if final_max_water_level > 2*inital_max_water_level:
+        if final_max_water_level > 2 * inital_max_water_level:
             logging.info("Simulation can show unstable results.\n"
                          "Check the simulation visualization to corroborate.\n"
                          "If the results are unstable, try increasing "
@@ -223,12 +223,8 @@ class CoastalAreaOutput:
     @optional_deps.needs_coastal_extra_deps
     def render(
         self,
-        quantity: Literal[
-            "water_level",
-            "velocity_x",
-            "velocity_y",
-            "velocity_magnitude",
-        ] = "water_level",
+        quantity: Literal["water_level", "velocity_x", "velocity_y",
+                          "velocity_magnitude",] = "water_level",
         movie_path: Path = "movie.mp4",
         fps: int = 5,
         cmap: str = "viridis",

--- a/inductiva/coastal/output.py
+++ b/inductiva/coastal/output.py
@@ -200,6 +200,25 @@ class CoastalAreaOutput:
         """
 
         self.sim_output_path = sim_output_path
+        self.check_stability()
+
+    @optional_deps.needs_coastal_extra_deps
+    def check_stability(self):
+
+        time_list, data_list = read_swash_grid_quantity_file(
+            file_path=os.path.join(self.sim_output_path, "water_level.mat"),
+            quantity="water_level",
+        )
+
+        # Check if water level is stable
+        inital_max_water_level = np.max(data_list[0])
+        final_max_water_level = np.max(data_list[-1])
+
+        if final_max_water_level > 2*inital_max_water_level:
+            logging.info("Simulation can show unstable results.\n"
+                         "Check the simulation visualization to corroborate.\n"
+                         "If the results are unstable, try increasing "
+                         "the simulation resolution.")
 
     @optional_deps.needs_coastal_extra_deps
     def render(


### PR DESCRIPTION
Some simulations, in particular for low resolutions, tend to diverge (water level rises to unphysical values). This behaviour can de explained by numerical errors.
For a given resolution, the numerical instabilities should not cause issues, since the time step of the simulation is not fixed but instead controlled by a criterion that
aims to keep the Courant Number (a relation between the time step, velocity of the water and grid resolution) bellow an unstable treshold (Cr=1). The strictness of the time step controll is set in the
input file. At the moment, the timestep is changed if Cr>0.5, which should keep the instabilities in check. Nonetheless, they keep happening. The only thing that diminishes this
issue is increasing the resolution. Since there is not a clear way to controll this atm, I add a logging info that warns the user if the simulation exploded. 
