### PR TITLE
[ProteinSolvation] Add maxwarn flag to grompp command

### DIFF
--- a/inductiva/molecules/protein_solvation/README.md
+++ b/inductiva/molecules/protein_solvation/README.md
@@ -44,7 +44,6 @@ insulin_pdb_file = inductiva.molecules.utils.download_pdb_from_rcsb(pdb_id="1ZNI
 # Initialize the scenario
 scenario = inductiva.molecules.ProteinSolvation(
      protein_pdb = insulin_pdb_file,
-
      temperature = 300)
 
 # Run a simulation

--- a/inductiva/templates/protein_solvation/gromacs/commands.json
+++ b/inductiva/templates/protein_solvation/gromacs/commands.json
@@ -4,8 +4,8 @@
     {"cmd": "gmx solvate -cp protein_box.gro -o protein_solv.gro -p topol.top", "prompts":[]},
     {"cmd": "gmx grompp -f ions.mdp -c protein_solv.gro -p topol.top -o ions.tpr -maxwarn 5", "prompts":[]},
     {"cmd": "gmx genion -s ions.tpr -o protein_solv_ions.gro -p topol.top -pname NA -nname CL -neutral yes", "prompts":["SOL"]},
-    {"cmd": "gmx grompp -f energy_minimization.mdp -c protein_solv_ions.gro -p topol.top -o em.tpr", "prompts":[]},
+    {"cmd": "gmx grompp -f energy_minimization.mdp -c protein_solv_ions.gro -p topol.top -o em.tpr -maxwarn 1", "prompts":[]},
     {"cmd": "gmx mdrun -deffnm em -v yes", "prompts":[]},
-    {"cmd": "gmx grompp -f simulation.mdp -c em.gro -r em.gro -p topol.top -o solvated_protein.tpr", "prompts":[]},
+    {"cmd": "gmx grompp -f simulation.mdp -c em.gro -r em.gro -p topol.top -o solvated_protein.tpr -maxwarn 1", "prompts":[]},
     {"cmd": "gmx mdrun -deffnm solvated_protein -o full_trajectory.trr -x compressed_trajectory.xtc -v yes", "prompts":[]}
 ]

--- a/inductiva/templates/protein_solvation/gromacs/commands.json.jinja
+++ b/inductiva/templates/protein_solvation/gromacs/commands.json.jinja
@@ -2,10 +2,10 @@
     {"cmd": "gmx pdb2gmx -f protein.pdb -o protein.gro -water tip3p -ff amber99sb-ildn -ignh", "prompts":[]},
     {"cmd": "gmx editconf -f protein.gro -o protein_box.gro -c yes -d 1.0 -bt cubic", "prompts":[]},
     {"cmd": "gmx solvate -cp protein_box.gro -o protein_solv.gro -p topol.top", "prompts":[]},
-    {"cmd": "gmx grompp -f ions.mdp -c protein_solv.gro -p topol.top -o ions.tpr -maxwarn 5", "prompts":[]},
+    {"cmd": "gmx grompp -f ions.mdp -c protein_solv.gro -p topol.top -o ions.tpr -maxwarn {{ max_warn }}", "prompts":[]},
     {"cmd": "gmx genion -s ions.tpr -o protein_solv_ions.gro -p topol.top -pname NA -nname CL -neutral yes", "prompts":["SOL"]},
-    {"cmd": "gmx grompp -f energy_minimization.mdp -c protein_solv_ions.gro -p topol.top -o em.tpr -maxwarn 1", "prompts":[]},
+    {"cmd": "gmx grompp -f energy_minimization.mdp -c protein_solv_ions.gro -p topol.top -o em.tpr -maxwarn {{ max_warn }}", "prompts":[]},
     {"cmd": "gmx mdrun -deffnm em -v yes", "prompts":[]},
-    {"cmd": "gmx grompp -f simulation.mdp -c em.gro -r em.gro -p topol.top -o solvated_protein.tpr -maxwarn 1", "prompts":[]},
+    {"cmd": "gmx grompp -f simulation.mdp -c em.gro -r em.gro -p topol.top -o solvated_protein.tpr -maxwarn {{ max_warn }}", "prompts":[]},
     {"cmd": "gmx mdrun -deffnm solvated_protein -o full_trajectory.trr -x compressed_trajectory.xtc -v yes", "prompts":[]}
 ]

--- a/inductiva/templates/protein_solvation/gromacs/energy_minimization.mdp.jinja
+++ b/inductiva/templates/protein_solvation/gromacs/energy_minimization.mdp.jinja
@@ -4,7 +4,6 @@ emtol		    = 1000  	         ; Stop minimization when the maximum force < 1000.0
 emstep          = 0.01               ; Energy step size
 nsteps		    = {{ nsteps_minim }} ; Maximum number of (minimization) steps to perform
 cutoff-scheme   = Verlet             ; Cut-off scheme used for short-range interactions
-ns_type         = grid               ; Method to determine neighbor list (simple, grid)
 coulombtype	    = PME		         ; Treatment of long range electrostatic interactions
 rcoulomb	    = 1.0		         ; Short-range electrostatic cut-off
 pbc		        = xyz 		         ; Periodic Boundary Conditions (yes/no)


### PR DESCRIPTION
The addition of the maxwarn flag to the grompp command prevents experiments to fail for this common errors: 
```
 WARNING 1 [file energy_minimization.mdp]:
  The largest distance between excluded atoms is 1.208 nm, which is larger
  than the cut-off distance. This will lead to missing long-range
  corrections in the forces and energies. If you expect that minimization
  will bring such distances within the cut-off, you can ignore this warning.
```
According to [this](https://gromacs.bioexcel.eu/t/the-largest-distance-between-excluded-atoms-is-1-725-nm-which-is-larger-than-the-cut-off-distance/4153/2) the user should take a look to check if the protein structure is correct, however, the problem can be overriden by setting the `maxwarn` flag to 1.
I also remove the ns_type variable, since it was already the default value. 