### PR TITLE
Fix failed tasks output configuration

### DIFF
--- a/inductiva/coastal/output.py
+++ b/inductiva/coastal/output.py
@@ -223,8 +223,12 @@ class CoastalAreaOutput:
     @optional_deps.needs_coastal_extra_deps
     def render(
         self,
-        quantity: Literal["water_level", "velocity_x", "velocity_y",
-                          "velocity_magnitude",] = "water_level",
+        quantity: Literal[
+            "water_level",
+            "velocity_x",
+            "velocity_y",
+            "velocity_magnitude",
+        ] = "water_level",
         movie_path: Path = "movie.mp4",
         fps: int = 5,
         cmap: str = "viridis",

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -244,6 +244,7 @@ class Task:
             output_class, filenames = self._get_output_config(all_files)
         else:
             output_class = None
+            logging.info("Downloading the 'stdout.txt' and 'stderr.txt' files.")
             filenames = ["stdout.txt", "stderr.txt"]
 
         output_dir = self.download_outputs(
@@ -254,8 +255,11 @@ class Task:
 
         # output_class can only be not None if the task is successful
         if output_class is not None:
+            logging.info("Post-processing tools are available " 
+                         "through the output object.")
             return output_class(output_dir)
 
+        logging.info("The output was downloaded to %s.", output_dir)
         return output_dir
 
     def get_output_files_info(self) -> output_contents.OutputContents:

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -156,7 +156,8 @@ class Task:
                     logging.info("Task failed.")
                     logging.info("Download the task output and check the "
                                  "'stdout.txt' and 'stderr.txt' files for "
-                                 "more information.")
+                                 "more information. "
+                                 "Post-processing tools will fail.")
                 elif status == models.TaskStatusCode.KILLED:
                     logging.info("Task killed.")
                 else:
@@ -244,9 +245,6 @@ class Task:
         else:
             output_class = None
             filenames = ["stdout.txt", "stderr.txt"]
-            logging.info("Task failed. Downloading 'stdout.txt' and"
-                         "'stderr.txt'."
-                         "Any post-processing after this point will fail.")
 
         output_dir = self.download_outputs(
             filenames=filenames,

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -255,7 +255,7 @@ class Task:
 
         # output_class can only be not None if the task is successful
         if output_class is not None:
-            logging.info("Post-processing tools are available " 
+            logging.info("Post-processing tools are available "
                          "through the output object.")
             return output_class(output_dir)
 

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -154,9 +154,9 @@ class Task:
                     logging.info("Task completed successfully.")
                 elif status == models.TaskStatusCode.FAILED:
                     logging.info("Task failed.")
-                    logging.info("Download the task output and check the "
-                                 "'stdout.txt' and 'stderr.txt' files for "
-                                 "more information. "
+                    logging.info("Download the 'stdout.txt' and 'stderr.txt' "
+                                 "files with `task.get_output()` for "
+                                 "more detail. "
                                  "Post-processing tools will fail.")
                 elif status == models.TaskStatusCode.KILLED:
                     logging.info("Task killed.")
@@ -179,16 +179,19 @@ class Task:
         self._api.kill_task(path_params=self._get_path_params())
 
     def _get_output_config(self, all_files: bool = False):
-        """Get configuration of the output wrt the task method name.
+        """Get configuration of the output with the task method name.
         
         Args:
             all_files: Whether to download all the files in the output.
 
         Returns:
-            The output class and default files for the task related
-            with classes that have these features configured. If the task
-            method name does not refer to a scenario, the filenames will
-            be all downloaded.
+            output_class, filenames - If the task method name is not of
+                a scenario, this method returns None, None and all
+                simulation are downloaded. Otherwise, and if available,
+                it returns the output_class of that
+                respective scenario and the filenames of that simulation.
+                If all_files is False, then the filenames are the default
+                files set for that scenario.
         """
 
         # Fetch the first part of the method_name (e.g., "wind_tunnel")


### PR DESCRIPTION
This PR addresses the concerns in issue #633 to handle the tasks that fail more gracefully. The goal is that the stderr.txt and stdout.txt are downloaded immediately for the user when he does task.get_output() and that afterwards we are not initializing a class that won't work. Thus the output will be a path.

To address all of these a couple of loggings were added to clarify the user.