### PR TITLE
[CoastalArea] Add warning if user inputs invalid wave source direction

### DIFF
--- a/inductiva/coastal/bathymetry.py
+++ b/inductiva/coastal/bathymetry.py
@@ -249,7 +249,7 @@ class Bathymetry:
     def y_num(self) -> int:
         """Returns the length of unique y values."""
 
-        return int(len(self.x_uniques()))
+        return int(len(self.y_uniques()))
 
     @optional_deps.needs_coastal_extra_deps
     def x_uniques(self, sort: bool = False) -> np.ndarray:
@@ -274,6 +274,12 @@ class Bathymetry:
         if sort:
             y_uniques = np.sort(y_uniques)
         return y_uniques
+
+    @optional_deps.needs_coastal_extra_deps
+    def depths_grid(self) -> np.ndarray:
+        """Returns the depths as a 2D grid."""
+
+        return self.depths.reshape((self.x_num(), self.y_num()))
 
     @optional_deps.needs_coastal_extra_deps
     def crop(self,

--- a/inductiva/coastal/coastal_area.py
+++ b/inductiva/coastal/coastal_area.py
@@ -160,9 +160,9 @@ class CoastalArea(scenarios.Scenario):
         if self.wave_amplitude > minimum_depth:
             raise ValueError("Wave amplitude is larger than the "
                              "minimum depth of the bathymetry in the "
-                             "boundary where waves are generated."
+                             "boundary where waves are generated. \n"
                              "This can be due to a very high wave "
-                             "amplitude the waves are being generated "
+                             "amplitude or the waves are being generated "
                              "on land")
 
 

--- a/inductiva/coastal/coastal_area.py
+++ b/inductiva/coastal/coastal_area.py
@@ -5,6 +5,7 @@ import math
 import os
 import shutil
 from typing import Literal, Optional
+import numpy as np
 
 from absl import logging
 
@@ -83,6 +84,7 @@ class CoastalArea(scenarios.Scenario):
         self.water_level = water_level
         self.wave_source_location = wave_source_location
         self.wave_amplitude = wave_amplitude
+        self._check_valid_wave_amplitude()
         self.wave_period = wave_period
 
     def simulate(
@@ -125,6 +127,39 @@ class CoastalArea(scenarios.Scenario):
     @singledispatchmethod
     def create_input_files(self, simulator: simulators.Simulator):
         pass
+
+    def _check_valid_wave_amplitude(self):
+        """Checks that the wave amplitude is valid.
+
+        Raises:
+            ValueError: If the wave amplitude is not valid.
+        """
+
+        depths_grid = self.bathymetry.depths_grid()
+
+        if self.wave_source_location == "W":
+            wave_boundary = depths_grid[0, :]
+
+        elif self.wave_source_location == "E":
+            wave_boundary = depths_grid[-1, :]
+
+        elif self.wave_source_location == "N":
+            wave_boundary = depths_grid[:, -1]
+
+        elif self.wave_source_location == "S":
+            wave_boundary = depths_grid[:, 0]
+
+        else:
+            raise ValueError("Invalid wave source location.")
+
+        #The greater the value of depth, the deeper the water, so
+        #we want to check the minimum depth using the min value
+
+        minimum_depth = np.min(wave_boundary)
+        if self.wave_amplitude > minimum_depth:
+            raise ValueError("Wave amplitude cannot be larger than the "
+                             "minimum depth of the bathymetry in the "
+                             "boundary where waves are generated.")
 
 
 @CoastalArea.get_config_filename.register

--- a/inductiva/coastal/coastal_area.py
+++ b/inductiva/coastal/coastal_area.py
@@ -84,7 +84,7 @@ class CoastalArea(scenarios.Scenario):
         self.water_level = water_level
         self.wave_source_location = wave_source_location
         self.wave_amplitude = wave_amplitude
-        self._check_valid_wave_amplitude()
+        self._check_valid_wave()
         self.wave_period = wave_period
 
     def simulate(
@@ -128,7 +128,7 @@ class CoastalArea(scenarios.Scenario):
     def create_input_files(self, simulator: simulators.Simulator):
         pass
 
-    def _check_valid_wave_amplitude(self):
+    def _check_valid_wave(self):
         """Checks that the wave amplitude is valid.
 
         Raises:

--- a/inductiva/coastal/coastal_area.py
+++ b/inductiva/coastal/coastal_area.py
@@ -157,9 +157,12 @@ class CoastalArea(scenarios.Scenario):
 
         minimum_depth = np.min(wave_boundary)
         if self.wave_amplitude > minimum_depth:
-            raise ValueError("Wave amplitude cannot be larger than the "
+            raise ValueError("Wave amplitude is larger than the "
                              "minimum depth of the bathymetry in the "
-                             "boundary where waves are generated.")
+                             "boundary where waves are generated."
+                             "This can be due to a very high wave "
+                             "amplitude the waves are being generated "
+                             "on land")
 
 
 @CoastalArea.get_config_filename.register

--- a/inductiva/coastal/coastal_area.py
+++ b/inductiva/coastal/coastal_area.py
@@ -150,7 +150,8 @@ class CoastalArea(scenarios.Scenario):
             wave_boundary = depths_grid[:, 0]
 
         else:
-            raise ValueError("Invalid wave source location.")
+            raise ValueError("Invalid wave source location. "
+                             "Supported locations are: N, S, E, W")
 
         #The greater the value of depth, the deeper the water, so
         #we want to check the minimum depth using the min value


### PR DESCRIPTION
The user can input to the scneario a bad set of instructions to set the wave. They can be:
-the user choses a direction that contains land (negative values of depths);
-the user choses a wave amplitude that is too big for the shallow waters of the bathymetry (there can't be waves of 5 meters in a pond with 0.1 m depth). Since what we are doing is forcing the 
boundary to have a sinusoidal behaviour, this breaks the simulation.

To check for this two cases, we can implement a _check_valid_wave() method that runs in the initialization of the scenario, raising an error if the wave direction is ill defined or if the amplitude 
exceeds the minimum depth in the boundary where the wave is being generated.

Test:

import inductiva
bathymetry = inductiva.coastal.Bathymetry.from_random_depths(
        x_range=(0, 100),
        y_range=(0, 100),
        x_num=100,
        y_num=100,
        max_depth=1,
        random_seed=12,
        roughness_factor=0.5)

The direction with the most depth is W. E represents land. So:


scenario = inductiva.coastal.CoastalArea(bathymetry=bathymetry,
                                         wave_source_location="E",
                                         wave_amplitude=0.1,
                                         wave_period=5.5)

Returns:

ValueError: Wave amplitude cannot be larger than the minimum depth of the bathymetry in the boundary where waves are generated.
