### PR TITLE
Change dualsph example in main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,15 +116,19 @@ If you would like other simulators to be added, contact us at [simulations@induc
 Example of how to use the simulators:
 
 ```python
+import inductiva
+
+input_dir = inductiva.utils.files.download_from_url(
+    "https://storage.googleapis.com/inductiva-api-demo-files/"
+    "dualsph-flow-cylinder.zip"
+)
 
 simulator = inductiva.simulators.DualSPHysics()
 
-output_dir = simulator.run(input_dir="FlowCylinder",
-                           sim_config_filename="CaseFlowCylinder_Re200_Def.xml",
-                           output_dir="Flow")
+output_dir = simulator.run(input_dir=input_dir)
 ```
 
-The user must specify the input directory, the simulation configuration file and the output directory.
+The user must specify the input directory containing the files to run the simulation. In the above example, a directory with the configuration of a simulation is downloaded, and passed as argument to the simulator call.
 
 Find more examples of simulations in the [tutorials section](https://github.com/inductiva/inductiva/tree/main/demos).
 

--- a/inductiva/molecules/utils.py
+++ b/inductiva/molecules/utils.py
@@ -47,20 +47,19 @@ def align_trajectory_to_average(universe, trajectory_output_path):
 
 
 def download_pdb_from_rcsb(pdb_id: str, save_dir: Optional[str] = None) -> str:
-    """Download a PDB file from the RCSB database according 
+    """Download a PDB file from the RCSB database according
     to its pdb ID.
     Args:
         pdb_id: The PDB identifier of the molecule to download.
         save_dir: The directory to save the file to. If None
             is passed, this will download to the current working
             directory. If the save_dir passed does not exist, this
-            method will try to create it. 
+            method will try to create it.
     Returns:
         The path to the downloaded PDB file.
     """
-    file_path = f"{pdb_id}.pdb"
-    pdb_url = f"https://files.rcsb.org/download/{file_path}"
+    pdb_url = f"https://files.rcsb.org/download/{pdb_id}.pdb"
 
-    file_path = files.download_from_url(pdb_url, file_path, save_dir)
+    file_path = files.download_from_url(pdb_url, save_dir)
 
     return file_path

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -16,7 +16,7 @@ class DualSPHysics(Simulator):
     def run(
         self,
         input_dir: types.Path,
-        sim_config_filename: str,
+        sim_config_filename: str = "config.xml",
         machine_group: Optional[resources.MachineGroup] = None,
         run_async: bool = False,
     ) -> tasks.Task:


### PR DESCRIPTION
I added a zip file to a public cloud bucket with input files for the dualsphysics low level call, since it is the one in the main readme. The example now should run as is. I'm still fine tuning the input files to make sure the simulation doesn't take too long.
We can then follow a similar strategy for all our demos.