### PR TITLE
[WindTunnel] Simplify screenshot render

### DIFF
--- a/inductiva/fluids/post_processing/openfoam.py
+++ b/inductiva/fluids/post_processing/openfoam.py
@@ -278,8 +278,9 @@ class FlowSlice:
         plotter.add_mesh(self.object_mesh, color=object_color)
         plotter.add_mesh(self.mesh, scalars=field_notation, cmap=flow_cmap)
         plotter.reset_camera(bounds=self.mesh.bounds)
+        plotter.show()
         if save_path is not None:
-            plotter.show(screenshot=save_path)
+            plotter.screenshot(save_path, return_img=False)
             logging.info("Flow slice rendering saved to %s", save_path)
         plotter.close()
 
@@ -340,8 +341,9 @@ class Streamlines:
         # Slide along the vectord defined from camera position to focal point,
         # until all of the meshes are visible.
         plotter.reset_camera(bounds=self.mesh.bounds, render=False)
+        plotter.show()
         if save_path is not None:
-            plotter.show(screenshot=save_path)
+            plotter.screenshot(save_path, return_img=False)
             logging.info("Streamlines rendering saved to %s", save_path)
         plotter.close()
 
@@ -406,7 +408,8 @@ class MeshData:
         plotter = pv.Plotter(off_screen=off_screen)
         pv.global_theme.background = background_color
         plotter.add_mesh(self.mesh, scalars=self.scalar_name, cmap=scalars_cmap)
+        plotter.show()
         if save_path is not None:
-            plotter.show(screenshot=save_path)
+            plotter.screenshot(save_path, return_img=False)
             logging.info("Data rendering was saved to %s", save_path)
         plotter.close()

--- a/inductiva/fluids/wind_tunnel/README.md
+++ b/inductiva/fluids/wind_tunnel/README.md
@@ -91,7 +91,7 @@ Moreover, change the parameter `virtual_display` in the render method to `True`,
 streamlines.render(virtual_display=True, save_path="streamlines.png")
 ```
 
-- To save your visualizations, please use the q-key to close the plotter as some operating systems (namely Windows) will experience issues saving a screenshot  if the exit button in the GUI is pressed.
+- To save your visualizations, please use the 'q' key to close the plotter. Some operating systems, particularly Windows, may encounter issues when attempting to save a screenshot if you use the exit button in the GUI.
 
 The next example fetches the default post-processed files and renders the respective visualizations. The last one, fetches the full simulation outputs, and with the same interface the user can configure the post-processing methods to extract the metrics he desires and render the visualizations.
 

--- a/inductiva/fluids/wind_tunnel/README.md
+++ b/inductiva/fluids/wind_tunnel/README.md
@@ -82,17 +82,16 @@ In any case, to obtain these metrics the user can use the following post-process
 
 Each visualization method has extra configuration parameters that can be passed to the `render()` method, see in the examples below for an overview for each of them.
 
-**Remark: ** For those running on Google Colab or a headless server, further extra dependencies are required. Install them with 
-
-```
-!apt install libgl1-mesa-glx xvfb
-```
+**Remark: **
+- For those running on Google Colab or a headless server, further extra dependencies are required. Install them with `!apt install libgl1-mesa-glx xvfb`
 
 Moreover, change the parameter `virtual_display` in the render method to `True`, and pass a path to save the result, like 
 
 ```python
 streamlines.render(virtual_display=True, save_path="streamlines.png")
 ```
+
+- To save your visualizations, please use the q-key to close the plotter as some operating systems (namely Windows) will experience issues saving a screenshot  if the exit button in the GUI is pressed.
 
 The next example fetches the default post-processed files and renders the respective visualizations. The last one, fetches the full simulation outputs, and with the same interface the user can configure the post-processing methods to extract the metrics he desires and render the visualizations.
 


### PR DESCRIPTION
This PR fixes a few issues that were occurring when running the visualisations on the terminal. Namely, a widget is popping-up, but no image was being saved when passing a `save_path`.