### PR TITLE
[WindTunnel] Remove --allow-run-as-root

### DIFF
--- a/inductiva/templates/wind_tunnel/openfoam/commands.json.jinja
+++ b/inductiva/templates/wind_tunnel/openfoam/commands.json.jinja
@@ -3,14 +3,14 @@
     {"cmd": "blockMesh", "prompts":[]},
     {% if n_cores > 1 %} 
     {"cmd": "decomposePar -copyZero", "prompts":[]},
-    {"cmd": "mpirun --allow-run-as-root -np {{ n_cores }} snappyHexMesh -overwrite -parallel", "prompts":[]},
+    {"cmd": "mpirun -np {{ n_cores }} snappyHexMesh -overwrite -parallel", "prompts":[]},
     {"cmd": "reconstructParMesh -constant", "prompts":[]},
     {% else %} 
     {"cmd": "snappyHexMesh -overwrite", "prompts":[]},
     {% endif %}
     {"cmd": "potentialFoam", "prompts":[]},
     {% if n_cores > 1 %} 
-    {"cmd": "mpirun --allow-run-as-root -np {{ n_cores }} simpleFoam -parallel", "prompts":[]},
+    {"cmd": "mpirun -np {{ n_cores }} simpleFoam -parallel", "prompts":[]},
     {"cmd": "reconstructPar -latestTime", "prompts":[]}
     {% else %} {"cmd": "simpleFoam", "prompts":[]}
     {% endif %}


### PR DESCRIPTION
This PR removes the flag "--allow-run-as-root" from the Client and we process in the backend the correct approach to do it.

In this way, even for the OpenFOAM simulator a command now only works if is like:
`{"cmd": "mpirun -np 4 simpleFoam", "prompts": []}`.

This is a first step to remove the number of cores.