### PR TITLE
[Utils/files.py] Fix copy of files 

### DIFF
--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -2,6 +2,7 @@
 import os
 import time
 import pathlib
+import shutil
 from typing import Optional
 import urllib.error
 import urllib.request
@@ -182,6 +183,6 @@ def download_from_url(url: str, save_dir: Optional[str] = None) -> str:
         # using replace instead of rename to have consistent behaviour
         # on windows and linux if the file already exists.
         # If the file exists, it will be overwritten.
-        downloaded_to.replace(local_path)
+        shutil.copy(downloaded_to, local_path)
 
     return str(local_path.absolute())

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -180,8 +180,7 @@ def download_from_url(url: str, save_dir: Optional[str] = None) -> str:
         _unzip(downloaded_to, local_path)
     else:
         # Rename the file to the correct path;
-        # using replace instead of rename to have consistent behaviour
-        # on windows and linux if the file already exists.
+        # Use shutil copy to be consistent among OS's.
         # If the file exists, it will be overwritten.
         shutil.copy(downloaded_to, local_path)
 


### PR DESCRIPTION
This PR addresses an error that can occur due to different partitions being used in the user environment.

Below follows the log of an error that occurred:
```
Traceback (most recent call last):
  File "example_WindTunnel.py", line 11, in <module>
    vehicle_path = inductiva.utils.files.download_from_url(vehicle_url)
  File "/home/*****/anaconda3/envs/inductiva-test/lib/python3.8/site-packages/inductiva/utils/files.py", line 185, in download_from_url
    downloaded_to.replace(local_path)
  File "/home/*****/anaconda3/envs/inductiva-test/lib/python3.8/pathlib.py", line 1374, in replace
    self._accessor.replace(self, target)
OSError: [Errno 18] Invalid cross-device link: '/tmp/tmpjbw9z33y' -> '/home/******/Work/cfd/inductiva-test/examples/vehicle.obj'
```

The `shutil.copy` fixes this bug.