### PR TITLE
Add file export of a key

### DIFF
--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -26,7 +26,7 @@ output_dir = os.environ.get("INDUCTIVA_OUTPUT_DIR", "inductiva_output")
 
 credentials_file_path = os.getenv("INDUCTIVA_API_CREDENTIALS")
 if credentials_file_path:
-    with open(credentials_file_path, 'r') as file:
+    with open(credentials_file_path, "r", encoding="utf-8") as file:
         api_key = file.read().strip()
 else:
     api_key = os.environ.get("INDUCTIVA_API_KEY")

--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -23,7 +23,14 @@ from . import tasks
 
 api_url = os.environ.get("INDUCTIVA_API_URL", "http://api.inductiva.ai")
 output_dir = os.environ.get("INDUCTIVA_OUTPUT_DIR", "inductiva_output")
-api_key = os.environ.get("INDUCTIVA_API_KEY")
+
+credentials_file_path = os.getenv("INDUCTIVA_API_CREDENTIALS")
+if credentials_file_path:
+    with open(credentials_file_path, 'r') as file:
+        api_key = file.read().strip()
+else:
+    api_key = os.environ.get("INDUCTIVA_API_KEY")
+
 working_dir = None
 
 absl.logging.set_verbosity(absl.logging.INFO)

--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -24,12 +24,16 @@ from . import tasks
 api_url = os.environ.get("INDUCTIVA_API_URL", "http://api.inductiva.ai")
 output_dir = os.environ.get("INDUCTIVA_OUTPUT_DIR", "inductiva_output")
 
-credentials_file_path = os.getenv("INDUCTIVA_API_CREDENTIALS")
-if credentials_file_path:
-    with open(credentials_file_path, "r", encoding="utf-8") as file:
-        api_key = file.read().strip()
-else:
-    api_key = os.environ.get("INDUCTIVA_API_KEY")
+api_key = os.environ.get("INDUCTIVA_API_KEY")
+
+if not api_key:
+    credentials_file_path = os.getenv("INDUCTIVA_API_CREDENTIALS",
+                                      "~/.inductiva/credentials.txt")
+    try:
+        with open(credentials_file_path, "r", encoding="utf-8") as file:
+            api_key = file.read().strip()
+    except FileNotFoundError:
+        api_key = None
 
 working_dir = None
 

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -29,8 +29,9 @@ def validate_api_key(api_key: Optional[str]) -> Configuration:
     if inductiva.api_key is None:
         raise ValueError(
             "No API Key specified. "
-            "Set it in the code with \"inductiva.api_key = <YOUR_SECRET_KEY>\""
-            " or set the INDUCTIVA_API_KEY environment variable.")
+            "Use the INDUCTIVA_API_CREDENTIALS environment variable with a "
+            "path to TXT file or set the INDUCTIVA_API_KEY "
+            "environment variable.")
 
     api_config = Configuration(host=inductiva.api_url)
     api_config.api_key["APIKeyHeader"] = api_key

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -30,7 +30,7 @@ def validate_api_key(api_key: Optional[str]) -> Configuration:
         raise ValueError(
             "No API Key specified. "
             "Use the INDUCTIVA_API_CREDENTIALS environment variable with a "
-            "path to TXT file or set the INDUCTIVA_API_KEY "
+            "path to a TXT file or set the INDUCTIVA_API_KEY "
             "environment variable.")
 
     api_config = Configuration(host=inductiva.api_url)


### PR DESCRIPTION
This PR makes it possible for a user set and env variable `INDUCTIVA_API_CREDENTIALS` with a path to the TXT file where the api key is stored. 