### PR TITLE
Reef3d is almost alive

### DIFF
--- a/inductiva/simulators/README.md
+++ b/inductiva/simulators/README.md
@@ -165,7 +165,7 @@ import inductiva
 inductiva.api_key = "YOUR_API_KEY"
 
 # Set simulation input directory
-input_dir = "swash_example"
+input_dir = "xbeach_example"
 
 # Initialize the Simulator
 simulator = inductiva.simulators.XBeach()
@@ -173,6 +173,31 @@ simulator = inductiva.simulators.XBeach()
 # Run simulation with config files in the input directory
 task = simulator.run(input_dir=input_dir)
 ```
+
+## Reef3D simulator
+
+REEF3D is an open-source hydrodynamics framework with a focus on coastal, marine and hydraulic engineering flows. Tailor-made multiphysics solvers are available for a range of relevant problems (e.g. sediment transport or floating body dynamics). The modular programming approach allows the framework to incorporate a range of different flow solvers which together represent all relevant length scales.  Depending on the wave or flow conditions, the following optimized hydrodynamic modules are available:
+
+- **REEF3D::CFD** solves the Navier-Stokes equations in three-dimensions. For near-field simulations with a complex free surface pattern,  it  uses a two-phase flow approach with the level set method for interface capturing.
+- **REEF3D::FNPF** is a three-dimensional fully nonlinear potential flow solver. It is massively parallelized and can be used to create large-scale phase-resolved sea states at all water depths.
+- **REEF3D::SFLOW** is a depth-averaged model, solving the non-hydrostatic shallow water equations ideal for near-shore hydrodynamics and river flow.
+
+A simulator call will execute the following two steps sequentially: the meshing with **DiveMESH** and the simulation with **Reef3D**. Each step is configured with an input files, `control.txt` and `ctrl.txt`, respectively. Other files may be used to inform the simulator about the grid, geographical data or wave information. Reef3D has strict naming policies for each file and we reccommend users to follow [their guidelines](https://reef3d.wordpress.com/user-guide/). Due to this, the only required argument to run the simulator is the name of the input directory with the respective input files. 
+
+Furthermore, the parallelization strategy is controlled by selecting the machine type even if stated explicitly on the input files otherwise.
+
+### Example
+
+```python
+import inductiva
+
+input_dir = "reef3d_example"
+
+simulator = inductiva.simulators.REEF3D()
+
+task = simulator.run(input_dir=input_dir)
+```
+
 
 ## GROMACS simulator
 

--- a/inductiva/simulators/__init__.py
+++ b/inductiva/simulators/__init__.py
@@ -9,3 +9,4 @@ from .gromacs import GROMACS
 from .simsopt import SIMSOPT
 from .fenicsx import FEniCSx
 from .fds import FDS
+from .reef3d import REEF3D

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -1,0 +1,30 @@
+"""Reef3D simulator module of the API."""
+
+from typing import Optional
+
+from inductiva import simulators, types, tasks, resources
+
+
+class REEF3D(simulators.Simulator):
+    """Class to invoke a generic FDS simulation on the API."""
+
+    def __init__(self):
+        super().__init__()
+        self.api_method_name = "reef3d.reef3d.run_simulation"
+
+    def run(
+        self,
+        input_dir: types.Path,
+        machine_group: Optional[resources.MachineGroup] = None,
+        storage_dir: Optional[types.Path] = "",
+    ) -> tasks.Task:
+        """Run the simulation.
+
+        Args:
+            input_dir: Path to the directory of the simulation input files.
+            sim_config_filename: Name of the simulation configuration file.
+            other arguments: See the documentation of the base class.
+        """
+        return super().run(input_dir,
+                           machine_group=machine_group,
+                           storage_dir=storage_dir)


### PR DESCRIPTION
This PR adds the client low-level call for Reef3D. 

Reef3D is called with two files "control.txt" and "ctrl.txt" which call two executables `DiveMESH` and `Reef3D`, respectively. On the backend, we are assuming that this will be always called one after the other. The first performs the meshing, the second the simulation. 

To test the simulator, we have used several tutorials examples present in https://github.com/REEF3D/REEF3D/tree/master/Tutorials. Notice that Reef3D as the ability to apply 3 types of models to simulate the hydrodynamics. This is all configured by the input files.

Further testing will occur, with green lights being presented below for a scenario of each type of model.