### PR TITLE
Update client version

### DIFF
--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -36,4 +36,4 @@ logging.basicConfig(level=absl.logging.INFO,
 urllib3_logger = logging.getLogger("urllib3.connectionpool")
 urllib3_logger.setLevel(logging.CRITICAL)
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"


### PR DESCRIPTION
Bump the version of the package. The currently available version in PyPI is 0.3.7, this updates it to 0.3.8. After merging this, assigning a tag to the latest commit will trigger the workflow that'll publish the new package to PyPI.