### PR TITLE
[FDS] Add visual parameter

### DIFF
--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -17,6 +17,7 @@ class FDS(Simulator):
         self,
         input_dir: types.Path,
         sim_config_filename: str,
+        post_processing_config: str = None,
         n_cores: int = 1,
         machine_group: Optional[resources.MachineGroup] = None,
         storage_dir: Optional[types.Path] = "",
@@ -31,5 +32,6 @@ class FDS(Simulator):
         return super().run(input_dir,
                            machine_group=machine_group,
                            input_filename=sim_config_filename,
+                           post_processing_config=post_processing_config,
                            storage_dir=storage_dir,
                            n_cores=n_cores)

--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -17,7 +17,7 @@ class FDS(Simulator):
         self,
         input_dir: types.Path,
         sim_config_filename: str,
-        post_processing_config: str = None,
+        post_processing_filename: str = None,
         n_cores: int = 1,
         machine_group: Optional[resources.MachineGroup] = None,
         storage_dir: Optional[types.Path] = "",
@@ -32,6 +32,6 @@ class FDS(Simulator):
         return super().run(input_dir,
                            machine_group=machine_group,
                            input_filename=sim_config_filename,
-                           post_processing_config=post_processing_config,
+                           post_processing_config=post_processing_filename,
                            storage_dir=storage_dir,
                            n_cores=n_cores)


### PR DESCRIPTION
This PR just serves to add a parameter to send the config file for Smokeview, the default visualizer built-in with FDS.

The bulk of the work is done in the backend. But now with this call, users can run their visuals after the simulation finishes.