### PR TITLE
[Dualsph] Add commands to run method

### DIFF
--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -1,6 +1,6 @@
 """DualSPHysics simulator module of the API."""
 
-from typing import Optional
+from typing import Optional, List
 
 from inductiva import types, tasks, resources
 from inductiva.simulators import Simulator
@@ -16,7 +16,7 @@ class DualSPHysics(Simulator):
     def run(
         self,
         input_dir: types.Path,
-        sim_config_filename: str = "config.xml",
+        commands: List[dict],
         machine_group: Optional[resources.MachineGroup] = None,
         storage_dir: Optional[types.Path] = "",
     ) -> tasks.Task:
@@ -33,5 +33,5 @@ class DualSPHysics(Simulator):
         """
         return super().run(input_dir,
                            machine_group=machine_group,
-                           input_filename=sim_config_filename,
+                           commands=commands,
                            storage_dir=storage_dir)


### PR DESCRIPTION
This PR shifts the concept of passing a single simulation file for a DualSPHysics, since in fact the commands are essential to the method run in the backend. In this way, users are now able to pass the commands they want and execute the respective executables to run the desired simulations.

TLDR: Before, the backend was stuck to a single line of commands. Now, users can pass their own.

Next Step:
- Shift FluidBlock for DualSPH.
- Change the ReadMEs accordingly.