### PR TITLE
[DualSPH] Change FluidBlock and DamBreak scenarios for new DualSPHysics

### DIFF
--- a/inductiva/fluids/dam_break/dam_break.py
+++ b/inductiva/fluids/dam_break/dam_break.py
@@ -70,12 +70,16 @@ class DamBreak(fluids.FluidBlock):
         self.params["time_step"] = 0.001
         self.params["output_export_rate"] = 60
 
+        self.set_template_dir(simulator)
+        commands = self.get_commands()
+
         # Inherit the simulate from the Parent of FluidBlock (Scenario) to
         # avoid overriding the api_method_prefix with the one of FluidBlock.
         task = super(fluids.FluidBlock, self).simulate(
             simulator=simulator,
             machine_group=machine_group,
             storage_dir=storage_dir,
+            commands=commands,
             sim_config_filename=self.get_config_filename(simulator))
 
         return task

--- a/inductiva/fluids/fluid_block/fluid_block.py
+++ b/inductiva/fluids/fluid_block/fluid_block.py
@@ -147,7 +147,7 @@ class FluidBlock(scenarios.Scenario):
 
 
 @FluidBlock.set_template_dir.register
-def _(self, simulator: simulators.SplishSplash): # pylint: disable=unused-argument
+def _(self, simulator: simulators.SplishSplash):  # pylint: disable=unused-argument
     """Set the template directory for DualSPHysics."""
 
     self.template_files_dir = os.path.join(SCENARIO_TEMPLATE_DIR,
@@ -188,7 +188,7 @@ def _(self, simulator: simulators.SplishSplash, input_dir):  # pylint: disable=u
 
 
 @FluidBlock.set_template_dir.register
-def _(self, simulator: simulators.DualSPHysics): # pylint: disable=unused-argument
+def _(self, simulator: simulators.DualSPHysics):  # pylint: disable=unused-argument
     """Set the template directory for DualSPHysics."""
 
     self.template_files_dir = os.path.join(SCENARIO_TEMPLATE_DIR,

--- a/inductiva/scenarios.py
+++ b/inductiva/scenarios.py
@@ -120,7 +120,9 @@ class Scenario(ABC):
             self.create_input_files(simulator, input_dir)
             self.add_extra_input_files(simulator, input_dir)
 
-            kwargs = {key: value for key, value in kwargs.items() if value is not None}
+            kwargs = {
+                key: value for key, value in kwargs.items() if value is not None
+            }
 
             return simulator.run(
                 input_dir,

--- a/inductiva/scenarios.py
+++ b/inductiva/scenarios.py
@@ -87,13 +87,16 @@ class Scenario(ABC):
 
         commands_file = self.create_command_file()
 
-        if isinstance(commands_file, str):
-            with open(commands_file, "r", encoding="utf-8") as f:
-                return json.load(f)
+        if os.path.exists(commands_file):
+            if isinstance(commands_file, str):
+                with open(commands_file, "r", encoding="utf-8") as f:
+                    return json.load(f)
 
-        # Make sure already opened file is read from the beginning
-        commands_file.seek(0)
-        return json.load(commands_file)
+            # Make sure already opened file is read from the beginning
+            commands_file.seek(0)
+            return json.load(commands_file)
+        else:
+            return None
 
     def validate_simulator(self, simulator: simulators.Simulator):
         """Checks if the scenario can be simulated with the given simulator."""
@@ -116,6 +119,8 @@ class Scenario(ABC):
             self.config_params(simulator, input_dir)
             self.create_input_files(simulator, input_dir)
             self.add_extra_input_files(simulator, input_dir)
+
+            kwargs = {key: value for key, value in kwargs.items() if value is not None}
 
             return simulator.run(
                 input_dir,

--- a/inductiva/templates/fluid_block/dualsphysics/commands.json
+++ b/inductiva/templates/fluid_block/dualsphysics/commands.json
@@ -1,0 +1,5 @@
+[
+    {"cmd": "gencase fluid_block fluid_block -save:all", "prompts": []},
+    {"cmd": "dualsphysics fluid_block fluid_block -dirdataout data -svres", "prompts": []},
+    {"cmd": "partvtk -dirin fluid_block/data -savevtk vtk/PartFluid -onlytype:-all,+fluid", "prompts": []}
+]


### PR DESCRIPTION
**TLDR:** Fix the FluidBlock and DamBreak to address the commands passed to DualSPHysics.

This PR addresses the latest backend change to the DualSPHysics executer, which now allows the commands to be passed by the user.

We add a commands file for the FluidBlock scenario for DualSPHysics and address the necessary changes for running two simulators for the same scenario. These changes regard the difference in arguments for both simulators:
- DualSPHysics now doesn't require a sim_config_filename;
- SplishSplash runs with a single command.

To address the arguments when they aren't needed a change in the scenario.simulate() was added that remove None arguments from the **kwargs. Hence, for SplishSplash the commands aren't considered and the sim_config_filename is not considered for DualSPHysics.

Tests were performed both for the FluidBlock and DamBreak with both simulators and making sure that the output post-processing still works. **Proof of success:**
<img width="830" alt="Screenshot 2023-11-21 at 14 02 36" src="https://github.com/inductiva/inductiva/assets/104431973/60dd4a71-cac4-41bb-88a4-8032817e92e7">




