### PR TITLE
Update the disksize to 70Gb

### DIFF
--- a/inductiva/resources/machines.py
+++ b/inductiva/resources/machines.py
@@ -17,7 +17,7 @@ class MachineGroup(machines_base.BaseMachineGroup):
         machine_type: str,
         num_machines: int = 1,
         spot: bool = False,
-        disk_size_gb: int = 60,
+        disk_size_gb: int = 70,
         zone: str = "europe-west1-b",
         register: bool = True,
     ) -> None:
@@ -103,7 +103,7 @@ class ElasticMachineGroup(machines_base.BaseMachineGroup):
         min_machines: int = 1,
         max_machines: int = 1,
         spot: bool = False,
-        disk_size_gb: int = 60,
+        disk_size_gb: int = 70,
         zone: str = "europe-west1-b",
         register: bool = True,
     ) -> None:

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -15,7 +15,7 @@ class BaseMachineGroup():
     def __init__(self,
                  machine_type: str,
                  spot: bool = False,
-                 disk_size_gb: int = 60,
+                 disk_size_gb: int = 70,
                  zone: str = "europe-west1-b",
                  register: bool = True) -> None:
         """Create a BaseMachineGroup object.


### PR DESCRIPTION
This PR matches the backend change that was required to increase the lower bound for the disk size to 70Gb.

It serves just as a bandaid for the longer fix being developed.  