### PR TITLE
Add unzip argument to download from url method

### DIFF
--- a/inductiva/molecules/utils.py
+++ b/inductiva/molecules/utils.py
@@ -1,5 +1,4 @@
 """Tools to analyze molecular dynamics simulations."""
-from typing import Optional
 
 try:
     import MDAnalysis as mda

--- a/inductiva/molecules/utils.py
+++ b/inductiva/molecules/utils.py
@@ -47,7 +47,7 @@ def align_trajectory_to_average(universe, trajectory_output_path):
                     in_memory=False).run()
 
 
-def download_pdb_from_rcsb(pdb_id: str, save_dir: Optional[str] = None) -> str:
+def download_pdb_from_rcsb(pdb_id: str) -> str:
     """Download a PDB file from the RCSB database according
     to its pdb ID.
     Args:
@@ -61,6 +61,6 @@ def download_pdb_from_rcsb(pdb_id: str, save_dir: Optional[str] = None) -> str:
     """
     pdb_url = f"https://files.rcsb.org/download/{pdb_id}.pdb"
 
-    file_path = files.download_from_url(pdb_url, save_dir)
+    file_path = files.download_from_url(pdb_url)
 
     return file_path

--- a/inductiva/tests/test_download_examples.py
+++ b/inductiva/tests/test_download_examples.py
@@ -1,5 +1,7 @@
 """Test examples download."""
+import os
 import pathlib
+import zipfile
 import inductiva
 
 
@@ -10,13 +12,16 @@ def test_download_from_rcsb(tmp_path: pathlib.Path):
     assert (tmp_path / "1A3N.pdb").exists()
 
 
-def test_download_zip(tmp_path: pathlib.Path):
-    inductiva.working_dir = tmp_path
+def test_download_from_url():
+    url = "https://storage.googleapis.com/inductiva-api-demo-files/" \
+          "openfoam-input-example.zip"
 
-    downloaded_to = inductiva.utils.files.download_from_url(
-        "https://downloads.emodnet-bathymetry.eu/high_resolution/"
-        "590_HR_Lidar_Algarve.emo.zip")
+    # Check if the unzip argument works.
+    download_path = inductiva.utils.files.download_from_url(url, unzip=True)
+    assert os.path.exists(download_path)
+    assert not zipfile.is_zipfile(download_path)
 
-    path = tmp_path / "590_HR_Lidar_Algarve.emo"
-    assert str(path.absolute()) == downloaded_to
-    assert path.exists()
+    # Check if the default is a zip file.
+    download_path = inductiva.utils.files.download_from_url(url)
+    assert os.path.exists(download_path)
+    assert zipfile.is_zipfile(download_path)

--- a/inductiva/tests/test_download_examples.py
+++ b/inductiva/tests/test_download_examples.py
@@ -13,6 +13,7 @@ def test_download_from_rcsb():
     assert os.path.exists(file_path)
     assert pdb_file == "1A3N.pdb"
 
+
 def test_download_from_url():
     url = "https://storage.googleapis.com/inductiva-api-demo-files/" \
           "openfoam-input-example.zip"

--- a/inductiva/tests/test_download_examples.py
+++ b/inductiva/tests/test_download_examples.py
@@ -1,6 +1,5 @@
 """Test examples download."""
 import os
-import pathlib
 import zipfile
 import inductiva
 
@@ -9,7 +8,7 @@ def test_download_from_rcsb():
     """Check if files with extensions are correctly created."""
 
     file_path = inductiva.molecules.utils.download_pdb_from_rcsb("1A3N")
-    pdb_file = file_path.split("/")[-1]
+    pdb_file = file_path.rsplit("/", maxsplit=1)[-1]
     assert os.path.exists(file_path)
     assert pdb_file == "1A3N.pdb"
 

--- a/inductiva/tests/test_download_examples.py
+++ b/inductiva/tests/test_download_examples.py
@@ -5,12 +5,13 @@ import zipfile
 import inductiva
 
 
-def test_download_from_rcsb(tmp_path: pathlib.Path):
+def test_download_from_rcsb():
     """Check if files with extensions are correctly created."""
-    inductiva.working_dir = tmp_path
-    inductiva.molecules.utils.download_pdb_from_rcsb("1A3N")
-    assert (tmp_path / "1A3N.pdb").exists()
 
+    file_path = inductiva.molecules.utils.download_pdb_from_rcsb("1A3N")
+    pdb_file = file_path.split("/")[-1]
+    assert os.path.exists(file_path)
+    assert pdb_file == "1A3N.pdb"
 
 def test_download_from_url():
     url = "https://storage.googleapis.com/inductiva-api-demo-files/" \

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -117,8 +117,7 @@ def _unzip(zip_path: pathlib.Path):
     zip_path.unlink()
 
 
-def download_from_url(url: str,
-                      unzip: bool = False) -> str:
+def download_from_url(url: str, unzip: bool = False) -> str:
     """Download a file from an URL.
 
     This function downloads from a set of files from an url.
@@ -140,12 +139,10 @@ def download_from_url(url: str,
     except urllib.error.URLError as url_error:
         logging.error("Could not download file from %s", url)
         raise url_error
-    print(downloaded_to)
 
     # Unzip all files as they were zipped.
     if unzip and zipfile.is_zipfile(downloaded_to):
         local_path = local_path.with_suffix("")
-        print(local_path)
         _unzip(downloaded_to)
 
     return str(local_path.absolute())

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -172,12 +172,8 @@ def download_from_url(url: str,
     if unzip:
         # Unzip the ZIP archive containing a single zip file to the
         # correct path
-        if zipfile.is_zipfile(local_path.suffix):
-            local_path = local_path.with_suffix("")
-        else:
-            raise ValueError("The file in the url is not a ZIP archive.")
-
-        _unzip(downloaded_to, local_path)
+        if zipfile.is_zipfile(local_path):
+            _unzip(downloaded_to, local_path.with_suffix(""))
     else:
         # Rename the file to the correct path;
         # Use shutil copy to be consistent among OS's.

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -169,11 +169,12 @@ def download_from_url(url: str,
     # File was downloaded to a temporary file
     downloaded_to = pathlib.Path(downloaded_to)
 
-    if unzip:
+    if unzip and zipfile.is_zipfile(downloaded_to):
         # Unzip the ZIP archive containing a single zip file to the
         # correct path
-        if zipfile.is_zipfile(local_path):
-            _unzip(downloaded_to, local_path.with_suffix(""))
+        if local_path.suffix == ".zip":
+            local_path = local_path.with_suffix("")
+            _unzip(downloaded_to, local_path)
     else:
         # Rename the file to the correct path;
         # Use shutil copy to be consistent among OS's.

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -130,7 +130,9 @@ def _unzip(zip_path: pathlib.Path, dest_path: pathlib.Path):
     zip_path.unlink()
 
 
-def download_from_url(url: str, save_dir: Optional[str] = None) -> str:
+def download_from_url(url: str,
+                      save_dir: Optional[str] = None,
+                      unzip: bool = False) -> str:
     """Download a file from an URL.
 
     If the file is a ZIP archive containing a single file, the method
@@ -139,13 +141,11 @@ def download_from_url(url: str, save_dir: Optional[str] = None) -> str:
 
     Args:
         url: The URL to download the file from.
-        local_file_path: Name attributed to the file to download.
-            If None is passed, it attributes the name given to
-            the file on the url.
         save_dir: The directory to save the file to. If None
             is passed, this will download to the current working
             directory. If the save_dir passed does not exist, this
             method will try to create it.
+        unzip: Whether to unzip the file after downloading.
     Returns:
         The path to the downloaded file.
     """
@@ -161,21 +161,22 @@ def download_from_url(url: str, save_dir: Optional[str] = None) -> str:
         local_path.parent.mkdir(parents=True)
 
     try:
-        downloaded_to, headers = urllib.request.urlretrieve(url)
+        downloaded_to, _ = urllib.request.urlretrieve(url)
     except urllib.error.URLError as url_error:
         logging.error("Could not download file from %s", url)
         raise url_error
 
     # File was downloaded to a temporary file
     downloaded_to = pathlib.Path(downloaded_to)
-    is_zip = headers.get_content_type() == "application/zip"
+    #is_zip = headers.get_content_type() == "application/zip"
 
-    if is_zip:
+    if unzip:
         # Unzip the ZIP archive containing a single zip file to the
         # correct path
-
         if local_path.suffix == ".zip":  # Remove the .zip extension
             local_path = local_path.with_suffix("")
+        else:
+            raise ValueError("The file in the url is not a ZIP archive.")
 
         _unzip(downloaded_to, local_path)
     else:

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -2,7 +2,6 @@
 import os
 import time
 import pathlib
-import shutil
 from typing import Optional
 import urllib.error
 import urllib.request

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -168,12 +168,11 @@ def download_from_url(url: str,
 
     # File was downloaded to a temporary file
     downloaded_to = pathlib.Path(downloaded_to)
-    #is_zip = headers.get_content_type() == "application/zip"
 
     if unzip:
         # Unzip the ZIP archive containing a single zip file to the
         # correct path
-        if local_path.suffix == ".zip":  # Remove the .zip extension
+        if zipfile.is_zipfile(local_path.suffix):
             local_path = local_path.with_suffix("")
         else:
             raise ValueError("The file in the url is not a ZIP archive.")


### PR DESCRIPTION
Based on the least astonishment principle and on giving control to the user, this PR adds an argument to unzip the file in `download_from_url` function. The previous behaviour extracted the argument automatically if the the file in the url had zip extension.

The existing test was modified to include both behaviour.