### PR TITLE
Change command file existence when not jinja

### DIFF
--- a/inductiva/molecules/md_water_box/md_water_box.py
+++ b/inductiva/molecules/md_water_box/md_water_box.py
@@ -83,7 +83,7 @@ class MDWaterBox(scenarios.Scenario):
         # of the simulation (2 fs)
 
         commands = self.get_commands()
-        print(commands)
+
         task = super().simulate(simulator,
                                 machine_group=machine_group,
                                 commands=commands,

--- a/inductiva/scenarios.py
+++ b/inductiva/scenarios.py
@@ -87,16 +87,15 @@ class Scenario(ABC):
 
         commands_file = self.create_command_file()
 
-        if os.path.exists(commands_file):
-            if isinstance(commands_file, str):
+        if isinstance(commands_file, str):
+            if os.path.exists(commands_file):
                 with open(commands_file, "r", encoding="utf-8") as f:
                     return json.load(f)
-
-            # Make sure already opened file is read from the beginning
-            commands_file.seek(0)
-            return json.load(commands_file)
-        else:
-            return None
+            else:
+                return None
+        # Make sure already opened file is read from the beginning
+        commands_file.seek(0)
+        return json.load(commands_file)
 
     def validate_simulator(self, simulator: simulators.Simulator):
         """Checks if the scenario can be simulated with the given simulator."""


### PR DESCRIPTION
This PR fixes the get_commands() function in the scenario base class. An error was occurring when the commands were in a ".jinja" file to be modified. The error is related to an incorrect approach of validating if we had a in memory file or an actual file. 