### PR TITLE
Add list of machines and termination to CLI 

### DIFF
--- a/inductiva/_cli/__init__.py
+++ b/inductiva/_cli/__init__.py
@@ -1,9 +1,9 @@
 """Inductiva CLI.
 
 `main` is the entrypoint for the CLI. It creates a parser and registers
-subparsers for several subcommands (e.g. `tasks` and `resources`).
+subparsers for several subcommands (e.g. `tasks` and `machines`).
 """
 from . import utils
 from .main import main
 from .tasks import register_tasks_cli
-from .resources import register_resources_cli
+from .machines import register_machines_cli

--- a/inductiva/_cli/machines.py
+++ b/inductiva/_cli/machines.py
@@ -61,9 +61,7 @@ def register_machines_cli(parser):
         "terminate", help="Terminate a machine-group")
 
     terminate_subparser.add_argument(
-        "name",
-        type=str,
-        help="Name of the machine group to terminate")
+        "name", type=str, help="Name of the machine group to terminate")
 
     # Register function to call when this subcommand is used
     list_subparser.set_defaults(func=list_machine_groups)

--- a/inductiva/_cli/machines.py
+++ b/inductiva/_cli/machines.py
@@ -35,7 +35,7 @@ def list_machine_types_available(args):
 
 def terminate_machine_group(args):
     """Terminate a machine group from a given name."""
-    machine_name = args.machine_name
+    machine_name = args.name
 
     print("Terminating machine group... If exists.")
     machines_list = inductiva.resources.machine_groups.get()

--- a/inductiva/_cli/machines.py
+++ b/inductiva/_cli/machines.py
@@ -3,13 +3,13 @@ import inductiva
 from inductiva import _cli
 
 
-def list_resources(args):
+def list_machine_groups(args):
+    """List machine groups."""
     del args  # unused
     inductiva.resources.machine_groups.list()
-    inductiva.resources.storage.get_space_used()
 
 
-def list_resources_available(args):
+def list_machine_types_available(args):
     """List all available machines"""
     del args  # unused
 
@@ -30,26 +30,26 @@ def list_resources_available(args):
         cores_str = ", ".join(str(core) for core in cores)
         print(f"{machine_type}: [{cores_str}]")
 
-    print("\n E.g. of machine: c2-standard-8\n")
+    print("\n E.g. of machine-type: c2-standard-8\n")
 
 
-def terminate_machine(args):
-    """Terminate a machine with the given name."""
+def terminate_machine_group(args):
+    """Terminate a machine group from a given name."""
     machine_name = args.machine_name
 
-    print("Terminating machine... If exists.")
+    print("Terminating machine group... If exists.")
     machines_list = inductiva.resources.machine_groups.get()
 
     for machine in machines_list:
         if machine.name == machine_name:
             machine.terminate()
-            print(f"Terminated machine {machine_name}")
+            print(f"Terminated machine group: {machine_name}")
             return
 
     print(f"Machine {machine_name} not found.")
 
 
-def register_resources_cli(parser):
+def register_machines_cli(parser):
     _cli.utils.show_help_msg(parser)
     subparsers = parser.add_subparsers()
 
@@ -61,11 +61,11 @@ def register_resources_cli(parser):
         "terminate", help="Terminate a machine-group")
 
     terminate_subparser.add_argument(
-        "machine-group-name",
+        "name",
         type=str,
         help="Name of the machine group to terminate")
 
     # Register function to call when this subcommand is used
-    list_subparser.set_defaults(func=list_resources)
-    available_subparser.set_defaults(func=list_resources_available)
-    terminate_subparser.set_defaults(func=terminate_machine)
+    list_subparser.set_defaults(func=list_machine_groups)
+    available_subparser.set_defaults(func=list_machine_types_available)
+    terminate_subparser.set_defaults(func=terminate_machine_group)

--- a/inductiva/_cli/machines.py
+++ b/inductiva/_cli/machines.py
@@ -33,6 +33,19 @@ def list_machine_types_available(args):
     print("\n E.g. of machine-type: c2-standard-8\n")
 
 
+def estimate_machine_cost(args):
+    machine_type = args.machine_type
+    zone = args.zone
+    spot = args.spot
+
+    cost = inductiva.resources.estimate_machine_cost(
+        machine_type=machine_type,
+        zone=zone,
+        spot=spot,
+    )
+    print(f"Estimated cost of machine: {cost} $/h.")
+
+
 def terminate_machine_group(args):
     """Terminate a machine group from a given name."""
     machine_name = args.name
@@ -55,11 +68,29 @@ def register_machines_cli(parser):
 
     list_subparser = subparsers.add_parser(
         "list", help="List currently active resources")
+
+    cost_subparser = subparsers.add_parser(
+        "cost",
+        help="Estimate cost of a machine in the cloud",
+    )
+    cost_subparser.add_argument("machine_type",
+                                type=str,
+                                help="Type of machine to launch")
+    cost_subparser.add_argument("-z",
+                                "--zone",
+                                default="europe-west1-b",
+                                type=str,
+                                help="Type of machine to launch")
+    cost_subparser.add_argument("--spot",
+                                default=False,
+                                type=bool,
+                                help="Type of machine to launch")
+
     available_subparser = subparsers.add_parser(
         "available", help="List available machine types")
+
     terminate_subparser = subparsers.add_parser(
         "terminate", help="Terminate a machine-group")
-
     terminate_subparser.add_argument(
         "name", type=str, help="Name of the machine group to terminate")
 
@@ -67,3 +98,4 @@ def register_machines_cli(parser):
     list_subparser.set_defaults(func=list_machine_groups)
     available_subparser.set_defaults(func=list_machine_types_available)
     terminate_subparser.set_defaults(func=terminate_machine_group)
+    cost_subparser.set_defaults(func=estimate_machine_cost)

--- a/inductiva/_cli/main.py
+++ b/inductiva/_cli/main.py
@@ -34,14 +34,14 @@ def main():
         "tasks",
         help="View tasks information",
     )
-    resources_subparser = subparsers.add_parser(
-        "resources",
-        help="View resources information",
+    machines_subparser = subparsers.add_parser(
+        "machines",
+        help="View machines information",
     )
 
     # Register subcommands (e.g. list) for each subcommand (e.g. tasks)
     _cli.register_tasks_cli(tasks_subparser)
-    _cli.register_resources_cli(resources_subparser)
+    _cli.register_machines_cli(machines_subparser)
 
     args = parser.parse_args()
     if args.api_key:

--- a/inductiva/_cli/resources.py
+++ b/inductiva/_cli/resources.py
@@ -57,13 +57,13 @@ def register_resources_cli(parser):
         "list", help="List currently active resources")
     available_subparser = subparsers.add_parser(
         "available", help="List available machine types")
-    terminate_subparser = subparsers.add_parser("terminate",
-                                                help="Terminate a machine")
+    terminate_subparser = subparsers.add_parser(
+        "terminate", help="Terminate a machine-group")
 
-    terminate_subparser.add_argument("-n",
-                                     "--machine-name",
-                                     type=str,
-                                     help="Name of the machine to terminate")
+    terminate_subparser.add_argument(
+        "machine-group-name",
+        type=str,
+        help="Name of the machine group to terminate")
 
     # Register function to call when this subcommand is used
     list_subparser.set_defaults(func=list_resources)

--- a/inductiva/_cli/resources.py
+++ b/inductiva/_cli/resources.py
@@ -48,6 +48,7 @@ def terminate_machine(args):
 
     print(f"Machine {machine_name} not found.")
 
+
 def register_resources_cli(parser):
     _cli.utils.show_help_msg(parser)
     subparsers = parser.add_subparsers()
@@ -56,12 +57,13 @@ def register_resources_cli(parser):
         "list", help="List currently active resources")
     available_subparser = subparsers.add_parser(
         "available", help="List available machine types")
-    terminate_subparser = subparsers.add_parser(
-        "terminate", help="Terminate a machine")
+    terminate_subparser = subparsers.add_parser("terminate",
+                                                help="Terminate a machine")
 
-    terminate_subparser.add_argument(
-        "-n", "--machine-name", type=str,
-        help="Name of the machine to terminate")
+    terminate_subparser.add_argument("-n",
+                                     "--machine-name",
+                                     type=str,
+                                     help="Name of the machine to terminate")
 
     # Register function to call when this subcommand is used
     list_subparser.set_defaults(func=list_resources)

--- a/inductiva/_cli/resources.py
+++ b/inductiva/_cli/resources.py
@@ -9,12 +9,61 @@ def list_resources(args):
     inductiva.resources.storage.get_space_used()
 
 
+def list_resources_available(args):
+    """List all available machines"""
+    del args  # unused
+
+    machines_dict = {
+        "c2-standard-": [4, 8, 16, 30, 60],
+        "c3-standard-": [4, 8, 22, 44, 88, 176],
+        "c2d-standard-": [2, 4, 8, 16, 32, 56, 112],
+        "c2d-highcpu-": [2, 4, 8, 16, 32, 56, 112],
+        "e2-standard-": [2, 4, 8, 16, 32],
+        "n2-standard-": [2, 4, 8, 16, 32, 48, 64, 80, 96, 128],
+        "n2d-standard-": [2, 4, 8, 16, 32, 48, 64, 80, 96, 128, 224],
+        "n1-standard-": [1, 2, 4, 8, 16, 32, 64, 96]
+    }
+
+    print("Available machine types\n")
+    print("machine-type: [cores-available]")
+    for machine_type, cores in machines_dict.items():
+        cores_str = " ,".join(str(core) for core in cores)
+        print(f"{machine_type}: [{cores_str}]")
+
+    print("\n E.g. of machine: c2-standard-8\n")
+
+
+def terminate_machine(args):
+    """Terminate a machine with the given name."""
+    machine_name = args.machine_name
+
+    print("Terminating machine... If exists.")
+    machines_list = inductiva.resources.machine_groups.get()
+
+    for machine in machines_list:
+        if machine.name == machine_name:
+            machine.terminate()
+            print(f"Terminated machine {machine_name}")
+            return
+
+    print(f"Machine {machine_name} not found.")
+
 def register_resources_cli(parser):
     _cli.utils.show_help_msg(parser)
     subparsers = parser.add_subparsers()
 
     list_subparser = subparsers.add_parser(
         "list", help="List currently active resources")
+    available_subparser = subparsers.add_parser(
+        "available", help="List available machine types")
+    terminate_subparser = subparsers.add_parser(
+        "terminate", help="Terminate a machine")
+
+    terminate_subparser.add_argument(
+        "-n", "--machine-name", type=str,
+        help="Name of the machine to terminate")
 
     # Register function to call when this subcommand is used
     list_subparser.set_defaults(func=list_resources)
+    available_subparser.set_defaults(func=list_resources_available)
+    terminate_subparser.set_defaults(func=terminate_machine)

--- a/inductiva/_cli/resources.py
+++ b/inductiva/_cli/resources.py
@@ -27,7 +27,7 @@ def list_resources_available(args):
     print("Available machine types\n")
     print("machine-type: [cores-available]")
     for machine_type, cores in machines_dict.items():
-        cores_str = " ,".join(str(core) for core in cores)
+        cores_str = ", ".join(str(core) for core in cores)
         print(f"{machine_type}: [{cores_str}]")
 
     print("\n E.g. of machine: c2-standard-8\n")


### PR DESCRIPTION
This PR attempts to address one hole of the script centric API: managing machines via the CLI.

We add two new functions to the CLI:
- List available machines to launch;
- Terminate machines.

In this way, before launching a python script users can check which machines are available to insert in their Python script, by doing on their terminal:
```inductiva resources available```
Outputs:
<img width="1061" alt="Screenshot 2023-11-28 at 14 39 34" src="https://github.com/inductiva/inductiva/assets/104431973/c43a6215-7d38-4544-a65e-fb0048ec1feb">

Further, when submitting a bunch of tasks and coming back later to check if everything is okay and end the machines, users would need a separate python script to fetch the machine and then kill it. To make this easier, users can just kill their machines from terminal as well.

## How to use it:
Find your machine name (already implemented):
```inductiva resources list```

Then, with the name they want to kill:
```inductiva resources terminate -n {api-machine-name}```

## Concerns
- The code to get the available resources should come from the backend, due to possible updating of new images (not urgent).
- Overlapping abilities between the API and the console, but I guess it is better to have them both available. 
- The code available here should be in the general package and just called from here.

Closes issue #859.