### PR TITLE
Move estimate cloud cost to an upper layer

### DIFF
--- a/inductiva/_cli/resources.py
+++ b/inductiva/_cli/resources.py
@@ -34,17 +34,18 @@ def register_resources_cli(parser):
         help="Estimate cost of a machine in the cloud",
     )
 
-    cost_subparser.add_argument(
-        "machine_type",
-        type=str, help="Type of machine to launch")
-    cost_subparser.add_argument(
-        "-z", "--zone",
-        default="europe-west1-b",
-        type=str, help="Type of machine to launch")
-    cost_subparser.add_argument(
-        "--spot",
-        default=False,
-        type=bool, help="Type of machine to launch")
+    cost_subparser.add_argument("machine_type",
+                                type=str,
+                                help="Type of machine to launch")
+    cost_subparser.add_argument("-z",
+                                "--zone",
+                                default="europe-west1-b",
+                                type=str,
+                                help="Type of machine to launch")
+    cost_subparser.add_argument("--spot",
+                                default=False,
+                                type=bool,
+                                help="Type of machine to launch")
 
     # Register function to call when this subcommand is used
     list_subparser.set_defaults(func=list_resources)

--- a/inductiva/_cli/resources.py
+++ b/inductiva/_cli/resources.py
@@ -9,6 +9,19 @@ def list_resources(args):
     inductiva.resources.storage.get_space_used()
 
 
+def estimate_machine_cost(args):
+    machine_type = args.machine_type
+    zone = args.zone
+    spot = args.spot
+
+    cost = inductiva.resources.estimate_machine_cost(
+        machine_type=machine_type,
+        zone=zone,
+        spot=spot,
+    )
+    print(f"Estimated cost of machine: {cost} $/h.")
+
+
 def register_resources_cli(parser):
     _cli.utils.show_help_msg(parser)
     subparsers = parser.add_subparsers()
@@ -16,5 +29,23 @@ def register_resources_cli(parser):
     list_subparser = subparsers.add_parser(
         "list", help="List currently active resources")
 
+    cost_subparser = subparsers.add_parser(
+        "cost",
+        help="Estimate cost of a machine in the cloud",
+    )
+
+    cost_subparser.add_argument(
+        "machine_type",
+        type=str, help="Type of machine to launch")
+    cost_subparser.add_argument(
+        "-z", "--zone",
+        default="europe-west1-b",
+        type=str, help="Type of machine to launch")
+    cost_subparser.add_argument(
+        "--spot",
+        default=False,
+        type=bool, help="Type of machine to launch")
+
     # Register function to call when this subcommand is used
     list_subparser.set_defaults(func=list_resources)
+    cost_subparser.set_defaults(func=estimate_machine_cost)

--- a/inductiva/resources/__init__.py
+++ b/inductiva/resources/__init__.py
@@ -2,3 +2,4 @@
 from .machines import MachineGroup, ElasticMachineGroup
 from . import machines_base
 from . import machine_groups
+from .machine_groups import estimate_machine_cost

--- a/inductiva/resources/machine_groups.py
+++ b/inductiva/resources/machine_groups.py
@@ -6,6 +6,34 @@ from inductiva.utils import format_utils
 from inductiva import resources
 
 
+def estimate_machine_cost(machine_type: str,
+                          zone: str = "europe-west1-b",
+                          spot: bool = False):
+    """Estimate the cloud cost of one machine per hour in US dollars.
+    
+    Args:
+        machine_type: The type of GC machine to launch. Ex: "e2-standard-4".
+            Check https://cloud.google.com/compute/docs/machine-resource for
+            more information about machine types.
+        zone: The zone where the machines will be launched.
+        spot: Whether to use spot machines.
+    """
+
+    api = compute_api.ComputeApi(inductiva.api.get_client())
+
+    instance_price = api.get_instance_price({
+        "machine_type": machine_type,
+        "zone": zone,
+    })
+
+    if spot:
+        estimated_cost = instance_price.body["preemptible_price"]
+    else:
+        estimated_cost = instance_price.body["on_demand_price"]
+
+    return round(float(estimated_cost), 5)
+
+
 def _machine_group_list_to_str(machine_group_list) -> str:
     """Returns a string representation of a list of machine groups."""
     columns = [

--- a/inductiva/resources/machines.py
+++ b/inductiva/resources/machines.py
@@ -1,7 +1,7 @@
 """Classes to manage different Google Cloud machine group types."""
 from absl import logging
 
-from inductiva.resources import machines_base, machine_groups
+from inductiva.resources import machines_base
 
 
 class MachineGroup(machines_base.BaseMachineGroup):

--- a/inductiva/resources/machines.py
+++ b/inductiva/resources/machines.py
@@ -1,7 +1,7 @@
 """Classes to manage different Google Cloud machine group types."""
 from absl import logging
 
-from inductiva.resources import machines_base
+from inductiva.resources import machines_base, machine_groups
 
 
 class MachineGroup(machines_base.BaseMachineGroup):
@@ -77,8 +77,7 @@ class MachineGroup(machines_base.BaseMachineGroup):
             The estimated cost per hour of the machine group in US
               dollars ($/h)."""
         #TODO: Contemplate disk size in the price.
-        estimated_cost = round(
-            float(super()._get_estimated_cost() * self.num_machines), 3)
+        estimated_cost = super()._get_estimated_cost() * self.num_machines
         logging.info("Estimated cloud cost per hour for all machines : %s $/h",
                      estimated_cost)
         return estimated_cost
@@ -179,10 +178,10 @@ class ElasticMachineGroup(machines_base.BaseMachineGroup):
         depending on the total usage of the machines."""
         cost = super()._get_estimated_cost()
         logging.info(
-            "Note: these are the estimted costs of having minimum and the "
+            "Note: these are the estimated costs of having minimum and the "
             "maximum number of machines up in the cloud. The final cost will "
             "vary depending on the total usage of the machines.")
         logging.info("Minimum estimated cloud cost: "
-                     "%s $/h.", round(float(cost * self.min_machines), 3))
+                     "%s $/h.", cost * self.min_machines)
         logging.info("Maximum estimated cloud cost: "
-                     "%s $/h.", round(float(cost * self.max_machines), 3))
+                     "%s $/h.", cost * self.max_machines)

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -162,18 +162,21 @@ class BaseMachineGroup():
             raise api_exception
 
     def _get_estimated_cost(self) -> float:
+        """Returns estimate cost of a single machine in the group.
+        
+        This method is an overlay of the more general method, but
+        it verifies if the cost has already been estimated and returns
+        it immediately if it has.
+        """
         if self._estimated_cost is not None:
             return self._estimated_cost
-        instance_price = self._api.get_instance_price({
-            "machine_type": self.machine_type,
-            "zone": self.zone,
-        })
-        if self.spot:
-            estimated_cost = instance_price.body["preemptible_price"]
-        else:
-            estimated_cost = instance_price.body["on_demand_price"]
 
-        self._estimated_cost = estimated_cost
+        self._estimated_cost = inductiva.resources.estimate_machine_cost(
+            self.machine_type,
+            self.zone,
+            self.spot,
+        )
+
         return self._estimated_cost
 
     def status(self):


### PR DESCRIPTION
This PR moves the computation of the cloud cost to an upper layer, i.e., users don't need to register a machine group or create the object, just to get the cost of that said machine.

In this way, we pass the core of the cost computation - an api request - to the `machine_groups.py` and call it as well inside the MachineGroup class for the estimation of the MachineGroup cost.

The advantage is that now users can do: 
```python
inductiva.resources.estimate_machine_cost(machine_type="c2-standard-60", zone="europe-west1-b", spot=False)
```

To get the cost of a single machine of that type. Accordingly, and to facilitate the usage, we add a method to the CLI.