### PR TITLE
[FENICSX]: Add mesh element order

### DIFF
--- a/inductiva/simulators/fenicsx.py
+++ b/inductiva/simulators/fenicsx.py
@@ -21,6 +21,7 @@ class FEniCSx(simulators.Simulator):
         global_refinement_meshing_factor: float = 1.0,
         local_refinement_meshing_factor: float = 1.0,
         smoothing_meshing_parameter: float = 10.0,
+        mesh_element_degree: int = 1,
         machine_group: Optional[resources.MachineGroup] = None,
         storage_dir: Optional[types.Path] = "",
     ) -> tasks.Task:
@@ -48,6 +49,8 @@ class FEniCSx(simulators.Simulator):
               generation. It controls the amount of mesh smoothing applied to
               the generated mesh. Adjust this parameter for improved mesh
               quality.
+            mesh_element_degree (int): The (polynomial) degree of the mesh
+              element.
             machine_group: The machine group to use for the simulation.
             storage_dir: Parent directory for storing simulation results.
             other arguments: See the documentation of the base class.
@@ -62,4 +65,5 @@ class FEniCSx(simulators.Simulator):
             global_refinement_meshing_factor=global_refinement_meshing_factor,
             local_refinement_meshing_factor=local_refinement_meshing_factor,
             smoothing_meshing_parameter=smoothing_meshing_parameter,
+            mesh_element_degree=mesh_element_degree,
             storage_dir=storage_dir)

--- a/inductiva/structures/plate_linear_elastic/plate_linear_elastic.py
+++ b/inductiva/structures/plate_linear_elastic/plate_linear_elastic.py
@@ -55,7 +55,8 @@ class DeformablePlate(scenarios.Scenario):
                  storage_dir: Optional[str] = "",
                  global_refinement_meshing_factor: float = 1.0,
                  local_refinement_meshing_factor: float = 1.0,
-                 smoothing_meshing_parameter: float = 10.0) -> tasks.Task:
+                 smoothing_meshing_parameter: float = 10.0,
+                 mesh_element_degree: int = 1) -> tasks.Task:
         """Simulates the scenario.
 
         Args:
@@ -81,6 +82,8 @@ class DeformablePlate(scenarios.Scenario):
               generation. It controls the amount of mesh smoothing applied to
               the generated mesh. Adjust this parameter for improved mesh
               quality.
+            mesh_element_degree (int): The (polynomial) degree of the mesh
+              element.
         """
         simulator.override_api_method_prefix("deformable_plate")
         task = super().simulate(
@@ -92,7 +95,8 @@ class DeformablePlate(scenarios.Scenario):
             material_filename=MATERIAL_FILENAME,
             global_refinement_meshing_factor=global_refinement_meshing_factor,
             local_refinement_meshing_factor=local_refinement_meshing_factor,
-            smoothing_meshing_parameter=smoothing_meshing_parameter)
+            smoothing_meshing_parameter=smoothing_meshing_parameter,
+            mesh_element_degree=mesh_element_degree)
 
         return task
 


### PR DESCRIPTION
In this pull request, I'm introducing the ability to customize the element order in the mesh, providing flexibility in simulations. 

Previously fixed at 1, this enhancement allows users to choose higher orders for more accurate solutions in complex scenarios. Higher orders capture intricate details but come with increased computational cost. 

Find detailed changes in the inductiva-web-api repository: https://github.com/inductiva/inductiva-web-api/pull/467