### PR TITLE
Refactor scenario to reduce entropy and bring clarity

### DIFF
--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -2,6 +2,7 @@
 import os
 import time
 import pathlib
+import shutil
 from typing import Optional
 import urllib.error
 import urllib.request
@@ -66,6 +67,27 @@ def resolve_path(path: Optional[types.Path]) -> pathlib.Path:
         resolved_path = pathlib.Path(resolved_path, path)
 
     return resolved_path
+
+
+def copy_files(input_paths=None, output_paths=None):
+    """Copy files, list of files or directories.
+
+    These method is meant to handle the case where the input_paths
+    and output_paths are lists of paths, or a single path. Moreover,
+    the input_paths and output_paths can be a mix of files and
+    directories. The method will copy the files and directories
+    to the output_paths, by order of appearance in the List.
+    """
+
+    if not len(input_paths) == len(output_paths):
+        raise ValueError("Input and output paths must "
+                         "have the same number paths")
+
+    for input_path, output_path in zip(input_paths, output_paths):
+        if os.path.isfile(input_path):
+            shutil.copy(input_path, output_path)
+        elif os.path.isdir(input_path):
+            shutil.copytree(input_path, output_path, dirs_exist_ok=True)
 
 
 def get_sorted_files(data_dir: str,

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -84,10 +84,15 @@ def copy_files(input_paths=None, output_paths=None):
                          "have the same number paths")
 
     for input_path, output_path in zip(input_paths, output_paths):
+        if os.path.isdir(input_path):
+            shutil.copytree(input_path,
+                            output_path,
+                            symlinks=True,
+                            dirs_exist_ok=True)
         if os.path.isfile(input_path):
+            # Create the directory structure of the input_path in output_path
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
             shutil.copy(input_path, output_path)
-        elif os.path.isdir(input_path):
-            shutil.copytree(input_path, output_path, dirs_exist_ok=True)
 
 
 def get_sorted_files(data_dir: str,

--- a/inductiva/utils/misc.py
+++ b/inductiva/utils/misc.py
@@ -1,8 +1,18 @@
 # pylint: disable=missing-module-docstring
+import random
 import re
+import string
 
 
 def split_camel_case(s):
     """Split a camel case string into a list of strings."""
     return re.sub("([A-Z][a-z]+)", r" \1", re.sub("([A-Z]+)", r" \1",
                                                   s)).split()
+
+
+def create_random_tag(size: int = 4):
+
+    samples = [random.choice(string.ascii_lowercase) for _ in range(size)]
+    tag = "".join(samples)
+
+    return tag


### PR DESCRIPTION
This is a draft PR to start verifying the refactor of the scenario class in order to simplify is workflow for users.

The main things that were changed:
- Addition of an input directory which is created, instead of a temporary directory;
- Addition of a `pre_simulate_hook` method which allows "devs" to play with the parameters or add new files, before the simulation starts.
- Remove the support for multiple simulators. Users are left to their own imagination if they want to do it.
- Remove necessity for users to have their template files inside a specific directory.

**Current Problems:**
- The `commands.json.jinja` file is also passed to the input directory at the moment. It will be also changed with the creation of input files. However, users will still need to pass the `self.get_commands()` which templates the commands in the file and then passes them to a list (all outside the input_dir). This still bring entropy. For me the right solution is for us to assume that the commands are passed from the backend as a file in the input dir.