### PR TITLE
Handle when None passed as ram

### DIFF
--- a/inductiva/resources/machine_groups.py
+++ b/inductiva/resources/machine_groups.py
@@ -152,7 +152,8 @@ def get_cheapest_machine_type(num_cpus: int,
     """
     spot = "t" if spot else "f"
     api = compute_api.ComputeApi(inductiva.api.get_client())
-    body = {"num_cpus": num_cpus, "ram_gb": ram_gb, "spot": spot}
+    body = {"num_cpus": num_cpus, "spot": spot}
+    if ram_gb: body["ram_gb"] = ram_gb
     response = api.get_machine_type(body)
 
     logging.info("Machine type: %s", response.body["machine_type"])

--- a/inductiva/resources/machine_groups.py
+++ b/inductiva/resources/machine_groups.py
@@ -153,7 +153,8 @@ def get_cheapest_machine_type(num_cpus: int,
     spot = "t" if spot else "f"
     api = compute_api.ComputeApi(inductiva.api.get_client())
     body = {"num_cpus": num_cpus, "spot": spot}
-    if ram_gb: body["ram_gb"] = ram_gb
+    if ram_gb:
+        body["ram_gb"] = ram_gb
     response = api.get_machine_type(body)
 
     logging.info("Machine type: %s", response.body["machine_type"])


### PR DESCRIPTION
Apparently generated client cannot handle the Python None values, that's why I fixed it to only pass ram_gb when it's provided.