### PR TITLE
[FENICSX] Add family element

### DIFF
--- a/inductiva/simulators/fenicsx.py
+++ b/inductiva/simulators/fenicsx.py
@@ -21,6 +21,7 @@ class FEniCSx(simulators.Simulator):
         global_refinement_meshing_factor: float = 1.0,
         local_refinement_meshing_factor: float = 1.0,
         smoothing_meshing_parameter: float = 10.0,
+        mesh_element_family: str = "CG",
         mesh_element_order: int = 1,
         machine_group: Optional[resources.MachineGroup] = None,
         storage_dir: Optional[types.Path] = "",
@@ -49,6 +50,7 @@ class FEniCSx(simulators.Simulator):
               generation. It controls the amount of mesh smoothing applied to
               the generated mesh. Adjust this parameter for improved mesh
               quality.
+            mesh_element_family (str): The type of mesh element family.
             mesh_element_order (int): The (polynomial) order of the mesh
               element.
             machine_group: The machine group to use for the simulation.
@@ -65,5 +67,6 @@ class FEniCSx(simulators.Simulator):
             global_refinement_meshing_factor=global_refinement_meshing_factor,
             local_refinement_meshing_factor=local_refinement_meshing_factor,
             smoothing_meshing_parameter=smoothing_meshing_parameter,
+            mesh_element_family=mesh_element_family,
             mesh_element_order=mesh_element_order,
             storage_dir=storage_dir)

--- a/inductiva/structures/plate_linear_elastic/plate_linear_elastic.py
+++ b/inductiva/structures/plate_linear_elastic/plate_linear_elastic.py
@@ -56,6 +56,7 @@ class DeformablePlate(scenarios.Scenario):
                  global_refinement_meshing_factor: float = 1.0,
                  local_refinement_meshing_factor: float = 1.0,
                  smoothing_meshing_parameter: float = 10.0,
+                 mesh_element_family: str = "CG",
                  mesh_element_order: int = 1) -> tasks.Task:
         """Simulates the scenario.
 
@@ -82,9 +83,11 @@ class DeformablePlate(scenarios.Scenario):
               generation. It controls the amount of mesh smoothing applied to
               the generated mesh. Adjust this parameter for improved mesh
               quality.
+            mesh_element_family (str): The type of mesh element family.
             mesh_element_order (int): The (polynomial) order of the mesh
               element.
         """
+
         simulator.override_api_method_prefix("deformable_plate")
         task = super().simulate(
             simulator,
@@ -96,6 +99,7 @@ class DeformablePlate(scenarios.Scenario):
             global_refinement_meshing_factor=global_refinement_meshing_factor,
             local_refinement_meshing_factor=local_refinement_meshing_factor,
             smoothing_meshing_parameter=smoothing_meshing_parameter,
+            mesh_element_family=mesh_element_family,
             mesh_element_order=mesh_element_order)
 
         return task


### PR DESCRIPTION
In this pull request, I am introducing a feature that enables the customization of the 'family element' in the mesh, enhancing the flexibility in simulations. The term 'family element' refers to the type of polynomial basis used in finite element methods, which are crucial in defining how the simulation behaves and computes solutions.

Previously, the default setting was the Lagrange family ("CG" in Fenicsx). This update now provides users with the option to select different types of family elements. This is particularly interesting for benchmarking with commercial software, which often employs the Serendipity family ("S" in Fenicsx).

Find detailed changes in the inductiva-web-api repository: https://github.com/inductiva/inductiva-web-api/pull/493