### PR TITLE
Remove level from logging config that affects all packages

### DIFF
--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -27,8 +27,7 @@ api_key = os.environ.get("INDUCTIVA_API_KEY")
 working_dir = None
 
 absl.logging.set_verbosity(absl.logging.INFO)
-logging.basicConfig(level=absl.logging.INFO,
-                    format="%(asctime)s %(levelname)s %(message)s",
+logging.basicConfig(format="%(asctime)s %(levelname)s %(message)s",
                     datefmt="%Y-%m-%d %H:%M:%S")
 
 # Disable urllib3 warnings.


### PR DESCRIPTION
This PR closes the issue #929 to remove the excess logging from all the dependencies in Inductiva.

The excess logging was unintended behaviour and affects the user experience to run any visualisations, even if they weren't using any from `inductiva` package. With this change, the intended behaviour for now is to keep the logging from `absl` to the INFO level and the general logging be the default one, but just keep the format of the message and data as we wish.