### PR TITLE
Quick fix resolve path on mixins

### DIFF
--- a/inductiva/mixins/file_manager.py
+++ b/inductiva/mixins/file_manager.py
@@ -46,7 +46,6 @@ class FileManager:
                 If None, an error is raised.
         """
 
-
         if root_dir is None:
             raise ValueError("Given root directory cannot be None")
 

--- a/inductiva/mixins/file_manager.py
+++ b/inductiva/mixins/file_manager.py
@@ -46,22 +46,24 @@ class FileManager:
                 If None, an error is raised.
         """
 
+
         if root_dir is None:
             raise ValueError("Given root directory cannot be None")
-        elif os.path.isdir(root_dir):
+
+        root_dir = files.resolve_path(root_dir)
+        if os.path.isdir(root_dir):
             if format_utils.getenv_bool(
                     "INDUCTIVA_DISABLE_FILEMANAGER_AUTOSUFFIX", False):
                 raise FileExistsError(f"Directory {root_dir} already exists.")
-            generated_root_dir = _gen_unique_name(root_dir)
+            generated_root_dir = _gen_unique_name(str(root_dir))
             logging.info(
                 "Directory %s already exists."
                 " Setting root folder to %s.", root_dir, generated_root_dir)
             root_dir = generated_root_dir
 
         logging.info("Setting root folder to %s.", root_dir)
-        root_dir = files.resolve_path(root_dir)
         os.makedirs(root_dir)
-        self.__root_dir = root_dir
+        self.__root_dir = pathlib.Path(root_dir)
 
     def get_root_dir(self):
         """Get the active root directory for the file manager."""

--- a/inductiva/tests/mixins/test_file_manager.py
+++ b/inductiva/tests/mixins/test_file_manager.py
@@ -77,7 +77,7 @@ def test_set_root_dir__valid_input__creates_folder():
     created_root_dir = file_manager.get_root_dir()
     assert os.path.isdir(created_root_dir)
     assert root_dir in created_root_dir.name
-    assert pathlib.Path(os.getcwd()) == created_root_dir.parent
+    assert pathlib.Path.cwd() == created_root_dir.parent
 
 
 def test_set_root_dir_null_input__raises_error():


### PR DESCRIPTION
This fixes a bug that wasn't thought of which occurs when setting `inductiva.working_dir` to be a path outside the current working directory. For example,
`inductiva.working_dir = "../some_path"`. 

With this setting, the if to check if the directory name already existed was not working inside this new working directory, and was checking inside the local directory where python was being run. 

By setting before the `files.resolve_path(root_directory)` before that if this bug is fixed. 