### PR TITLE
Reduce the level of download_from_url

### DIFF
--- a/inductiva/utils/__init__.py
+++ b/inductiva/utils/__init__.py
@@ -1,3 +1,4 @@
 # pylint: disable=missing-module-docstring
 from . import files
+from .files import download_from_url
 from . import flags


### PR DESCRIPTION
This allows to call `inductiva.utils.download_from_url(url, unzip=True)`.