### PR TITLE
Add sub-dir check

### DIFF
--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -2,6 +2,8 @@
 from typing import Optional
 from abc import ABC
 
+import pathlib
+
 from inductiva import types, tasks, resources
 from inductiva.utils import files
 
@@ -54,6 +56,11 @@ class Simulator(ABC):
                 f"The provided path (\"{input_dir}\") is not a directory.")
         return input_dir
 
+    def _check_if_input_dir_is_not_parent(self, input_dir: types.Path):
+        input_dir = pathlib.Path(input_dir).resolve()
+        cwd = pathlib.Path().cwd()
+        return not cwd.is_relative_to(input_dir)
+
     def run(
         self,
         input_dir: types.Path,
@@ -76,6 +83,9 @@ class Simulator(ABC):
             **kwargs: Additional keyword arguments to be passed to the
                 simulation API method.
         """
+        assert self._check_if_input_dir_is_not_parent(
+            input_dir), "Input dir cannot be parent of current_dir"
+
         input_dir = self._setup_input_dir(input_dir)
 
         self.validate_computational_resources(on)

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -58,8 +58,10 @@ class Simulator(ABC):
 
     def _check_if_input_dir_is_not_parent(self, input_dir: types.Path):
         input_dir = pathlib.Path(input_dir).resolve()
-        cwd = pathlib.Path().cwd()
-        return not cwd.is_relative_to(input_dir)
+        cwd = pathlib.Path().cwd().resolve()
+        input_parts = input_dir.parts
+        cwd_parts = cwd.parts
+        return not input_parts == cwd_parts[:len(input_parts)]
 
     def run(
         self,


### PR DESCRIPTION
inductiva/tasks#24

This pull requests prevents the user from using `simulator.run(input_dir=some_dir)`when `some_dir` is a parent of the current working directory.