### PR TITLE
Adds command abstraction

### DIFF
--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -10,6 +10,7 @@ from . import resources
 from . import storage
 from . import utils
 from . import tasks
+from . import commands
 
 api_url = os.environ.get("INDUCTIVA_API_URL", "https://api.inductiva.ai")
 output_dir = os.environ.get("INDUCTIVA_OUTPUT_DIR", "inductiva_output")

--- a/inductiva/commands/__init__.py
+++ b/inductiva/commands/__init__.py
@@ -1,0 +1,2 @@
+# pylint: disable=missing-module-docstring
+from .commands import Command

--- a/inductiva/commands/commands.py
+++ b/inductiva/commands/commands.py
@@ -1,0 +1,10 @@
+"""Wrapper class for simulator commands."""
+
+
+class Command(dict):
+    """Abstraction class for commands."""
+
+    def __init__(self, cmd, *prompts):
+        super(Command, self).__init__(cmd=cmd)
+        if prompts:
+            self['prompts'] = list(prompts)

--- a/inductiva/commands/commands.py
+++ b/inductiva/commands/commands.py
@@ -5,6 +5,4 @@ class Command(dict):
     """Abstraction class for commands."""
 
     def __init__(self, cmd, *prompts):
-        super(Command, self).__init__(cmd=cmd)
-        if prompts:
-            self['prompts'] = list(prompts)
+        super(Command, self).__init__(cmd=cmd, prompts=prompts)


### PR DESCRIPTION
Addresses inductiva/tasks#16.

Not yet updated the READMEs as I want feed back before that.
Example usage:

```python
commands = [
    inductiva.commands.Command("gencase config flow_cylinder -save:all"),
    inductiva.commands.Command(
        "dualsphysics flow_cylinder flow_cylinder -dirdataout data -svres"),
    inductiva.commands.Command(
        "partvtk -dirin flow_cylinder/data -savevtk flow_cylinder/PartFluid -onlytype:-all,+fluid"
    )
]

# Initialize the Simulator
dualsphysics = inductiva.simulators.DualSPHysics()

# Run simulation with config files in the input directory
task = dualsphysics.run(input_dir=input_dir, commands=commands)

```