### PR TITLE
[Bug fix] Simplify fetching the spot attribute on the list method of machine groups

### DIFF
--- a/inductiva/resources/machine_groups.py
+++ b/inductiva/resources/machine_groups.py
@@ -51,6 +51,7 @@ def _machine_group_list_to_str(machine_group_list) -> str:
     for machine_group in machine_group_list:
         is_elastic = False
         resource_type = machines_base.ResourceType.STANDARD.value
+        spot = machine_group.spot if hasattr(machine_group, "spot") else False
 
         if isinstance(machine_group, resources.ElasticMachineGroup):
             num_active_machines = machine_group.num_active_machines
@@ -65,7 +66,7 @@ def _machine_group_list_to_str(machine_group_list) -> str:
         rows.append([
             machine_group.name, machine_group.machine_type, is_elastic,
             resource_type, num_active_machines, machine_group.disk_size_gb,
-            machine_group.spot, machine_group.create_time
+            spot, machine_group.create_time
         ])
 
     formatters = {"Started at (UTC)": format_utils.datetime_formatter}


### PR DESCRIPTION
This PR tackles the bug encountered in inductiva/tasks#39, where the spot attribute was being fetched for MPICluster machines, which it doesn't have.

Correct it, with a quick check.

## QA Test:

To validate if this error was fixed, users could launch some MPI machines and do, both:
- `inductiva machines list` in the terminal;
- `inductiva.machine_groups.list()` in Python.