### PR TITLE
Adds task.wait()

### DIFF
--- a/docs/simulators/DualSPHysics.md
+++ b/docs/simulators/DualSPHysics.md
@@ -33,6 +33,7 @@ dualsphysics = inductiva.simulators.DualSPHysics()
 task = dualsphysics.run(input_dir=input_dir,
                      commands=commands)
 
+task.wait()
 task.download_outputs()
 
 ```

--- a/docs/simulators/FDS.md
+++ b/docs/simulators/FDS.md
@@ -31,5 +31,6 @@ task = fds.run(input_dir=input_dir,
                post_processing_filename="mccaffrey.ssf",
                n_cores=1)
 
+task.wait()
 task.download_outputs()
 ```

--- a/docs/simulators/GROMACS.md
+++ b/docs/simulators/GROMACS.md
@@ -30,5 +30,6 @@ gromacs = inductiva.simulators.GROMACS()
 task = gromacs.run(input_dir=input_dir,
                    commands=commands)
 
+task.wait()
 task.download_outputs()
 ```

--- a/docs/simulators/OpenFOAM.md
+++ b/docs/simulators/OpenFOAM.md
@@ -42,5 +42,6 @@ openfoam = inductiva.simulators.OpenFOAM(version="foundation")
 # Run simulation with config files in the input directory
 task = openfoam.run(input_dir=input_dir, commands=commands)
 
+task.wait()
 task.download_outputs()
 ````

--- a/docs/simulators/Reef3D.md
+++ b/docs/simulators/Reef3D.md
@@ -40,5 +40,6 @@ reef3d = inductiva.simulators.REEF3D()
 
 task = reef3d.run(input_dir=input_dir)
 
+task.wait()
 task.download_outputs()
 ```

--- a/docs/simulators/SPlisHSPlasH.md
+++ b/docs/simulators/SPlisHSPlasH.md
@@ -17,5 +17,6 @@ splishsplash = inductiva.simulators.SplishSplash()
 task = splishsplash.run(input_dir=input_dir,
                      sim_config_filename="config.json")
 
+task.wait()
 task.download_outputs()
 ```

--- a/docs/simulators/SWASH.md
+++ b/docs/simulators/SWASH.md
@@ -19,5 +19,6 @@ swash = inductiva.simulators.SWASH()
 task = swash.run(input_dir=input_dir, 
                  sim_config_filename="input.sws")
 
+task.wait()
 task.download_outputs()
 ```

--- a/docs/simulators/XBeach.md
+++ b/docs/simulators/XBeach.md
@@ -21,5 +21,6 @@ xbeach = inductiva.simulators.XBeach()
 task = xbeach.run(input_dir=input_dir,
                   sim_config_filename="params.txt")
 
+task.wait()
 task.download_outputs()
 ```


### PR DESCRIPTION
This pull request adds `task.wait()` to the examples. This prevents an error when trying to access outputs of unfinished tasks.
