### PR TITLE
Fix logging traceback to `rotated.log`

### DIFF
--- a/inductiva/logs/log.py
+++ b/inductiva/logs/log.py
@@ -1,9 +1,29 @@
 """Custom logging functions"""
+import os
+
 import logging.handlers
 import logging
 import sys
 
+import pathlib
+import platform
+
 root_logger = logging.getLogger()
+
+system = platform.system()
+logs_name = "inductiva.log"
+
+if system == "Windows":
+    logs_dir = pathlib.Path.home() / "AppData" / "inductiva"
+    LOGS_FILE = logs_dir / logs_name
+elif system in ["Linux", "Darwin"]:
+    logs_dir = pathlib.Path.home() / ".inductiva"
+    LOGS_FILE = logs_dir / logs_name
+else:
+    raise RuntimeError(f"Current operating system {system} not supported.")
+
+if not os.path.exists(logs_dir):
+    os.mkdir(logs_dir)
 
 
 class NoExceptionFormatter(logging.Formatter):
@@ -40,7 +60,7 @@ def setup(level=logging.INFO):
     ]
 
     handlers = [
-        logging.handlers.RotatingFileHandler("rotated.log",
+        logging.handlers.RotatingFileHandler(LOGS_FILE,
                                              encoding="utf8",
                                              maxBytes=1e6,
                                              backupCount=10),

--- a/inductiva/logs/log.py
+++ b/inductiva/logs/log.py
@@ -10,20 +10,18 @@ import platform
 
 root_logger = logging.getLogger()
 
-system = platform.system()
-logs_name = "inductiva.log"
 
-if system == "Windows":
-    logs_dir = pathlib.Path.home() / "AppData" / "inductiva"
-    LOGS_FILE = logs_dir / logs_name
-elif system in ["Linux", "Darwin"]:
-    logs_dir = pathlib.Path.home() / ".inductiva"
-    LOGS_FILE = logs_dir / logs_name
-else:
-    raise RuntimeError(f"Current operating system {system} not supported.")
-
-if not os.path.exists(logs_dir):
-    os.mkdir(logs_dir)
+def get_logs_file_path():
+    system = platform.system()
+    logs_name = "inductiva.log"
+    if system.lower() == "windows":
+        logs_file_path = pathlib.Path.home(
+        ) / "AppData" / "inductiva" / logs_name
+    elif system.lower() in ["linux", "darwin"]:
+        logs_file_path = pathlib.Path.home() / ".inductiva" / logs_name
+    else:
+        raise RuntimeError(f"Current operating system {system} not supported.")
+    return logs_file_path
 
 
 class NoExceptionFormatter(logging.Formatter):
@@ -59,8 +57,13 @@ def setup(level=logging.INFO):
         NoExceptionFormatter(fmt="%(message)s")
     ]
 
+    logs_file_path = get_logs_file_path()
+    logs_file_dir = logs_file_path.parent
+    if not os.path.exists(logs_file_dir):
+        os.mkdir(logs_file_dir)
+
     handlers = [
-        logging.handlers.RotatingFileHandler(LOGS_FILE,
+        logging.handlers.RotatingFileHandler(logs_file_path,
                                              encoding="utf8",
                                              maxBytes=1e6,
                                              backupCount=10),

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -83,10 +83,12 @@ class BaseMachineGroup:
         try:
             resp = self._api.register_vm_group(body=instance_group_config)
         except (exceptions.ApiValueError, exceptions.ApiException) as e:
-            logs.log_and_exit(logging.getLogger(), logging.ERROR,
-                              "Registering machine group failed"\
-                              " with exception %s", e,
-                              exc_info=e)
+            logs.log_and_exit(
+                logging.getLogger(),
+                logging.ERROR,
+                "Registering machine group failed with exception %s",
+                e,
+                exc_info=e)
 
         self._id = resp.body["id"]
         self._name = resp.body["name"]
@@ -147,8 +149,8 @@ class BaseMachineGroup:
             self._api.start_vm_group(body=request_body)
         except inductiva.client.ApiException as e:
             logs.log_and_exit(logging.getLogger(),
-                              logging.ERROR, "Starting machine group failed"
-                              " with exception %s",
+                              logging.ERROR,
+                              "Starting machine group failed with exception %s",
                               e,
                               exc_info=e)
         creation_time = format_utils.seconds_formatter(time.time() - start_time)

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -11,7 +11,6 @@ from inductiva import api
 from inductiva.utils import format_utils
 from inductiva.client.apis.tags import compute_api
 from inductiva.client import exceptions
-
 from inductiva import logs
 
 
@@ -85,8 +84,9 @@ class BaseMachineGroup:
             resp = self._api.register_vm_group(body=instance_group_config)
         except (exceptions.ApiValueError, exceptions.ApiException) as e:
             logs.log_and_exit(logging.getLogger(), logging.ERROR,
-                              "Resource registering failed with exception %s",
-                              e)
+                              "Registering machine group failed"\
+                              " with exception %s", e,
+                              exc_info=e)
 
         self._id = resp.body["id"]
         self._name = resp.body["name"]
@@ -146,9 +146,11 @@ class BaseMachineGroup:
         try:
             self._api.start_vm_group(body=request_body)
         except inductiva.client.ApiException as e:
-            logs.log_and_exit(logging.getLogger(), logging.ERROR,
-                              "Starting machine group failed" 
-                              " with exception %s", e)
+            logs.log_and_exit(logging.getLogger(),
+                              logging.ERROR, "Starting machine group failed"
+                              " with exception %s",
+                              e,
+                              exc_info=e)
         creation_time = format_utils.seconds_formatter(time.time() - start_time)
         self._started = True
         logging.info("%s successfully started in %s.", self, creation_time)
@@ -206,7 +208,7 @@ class BaseMachineGroup:
         if self.name is None:
             logging.info(
                 "Attempting to get the status of an unregistered machine group."
-                )
+            )
             return
 
         response = self._api.get_group_status({"name": self.name})

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -86,8 +86,9 @@ def run_simulation(
     logging.info(
         "Consider tracking the status of the task via CLI:"
         "\n\tinductiva tasks list --task-id %s", task_id)
-    logging.info("Or, tracking the logs of the task via CLI:"
-                 "\n\tinductiva logs %s", task_id)
+    logging.info(
+        "Or, tracking the logs of the task via CLI:"
+        "\n\tinductiva logs %s", task_id)
 
     return task
 


### PR DESCRIPTION
This pull request ensures that the traceback of the exception is written to the `rotated.log` file.

## QA

Try to launch more machines that you have access to:

```
import inductiva

mg = inductiva.resources.ElasticMachineGroup(machine_type="c2-standard-16",
                                             max_machines=80,
                                             disk_size_gb=70,
                                             register=True)
mg.start()


# make sure that if it passes the machine group is terminated
mg.terminate()
```

In your terminal you should see the logs:

```
Registering ElasticMachineGroup configurations:
Registering machine group failed with exception (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'content-type': 'application/json', 'X-Cloud-Trace-Context': 'c5437753569ab6cbd777cc4fcec416d1', 'Date': 'Mon, 29 Jan 2024 10:38:47 GMT', 'Server': 'Google Frontend', 'Content-Length': '96'})
HTTP response body: b'{"detail":"Maximum allowed number of machines is exceeded. Maximum allowed: 10. Requested: 80."}'
```

And on the rotated file you should see:

```
2024-01-29 10:40:06|INFO|absl|machines.py:160 Registering ElasticMachineGroup configurations:
2024-01-29 10:40:06|ERROR|root|log.py:17 Registering machine group failed with exception (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'content-type': 'application/json', 'X-Cloud-Trace-Context': 'b168b0008aeadd8fb37024f109d189a2', 'Date': 'Mon, 29 Jan 2024 10:40:06 GMT', 'Server': 'Google Frontend', 'Content-Length': '96'})
HTTP response body: b'{"detail":"Maximum allowed number of machines is exceeded. Maximum allowed: 10. Requested: 80."}'
Traceback (most recent call last):
  File "/Users/augustoperes/Documents/inductiva/inductiva/resources/machines_base.py", line 84, in _register_machine_group
    resp = self._api.register_vm_group(body=instance_group_config)
  File "/Users/augustoperes/Documents/inductiva/inductiva/client/paths/compute_group/post.py", line 303, in register_vm_group
    return self._register_vm_group_oapg(
  File "/Users/augustoperes/Documents/inductiva/inductiva/client/paths/compute_group/post.py", line 219, in _register_vm_group_oapg
    raise exceptions.ApiException(status=response.status,
inductiva.client.exceptions.ApiException: (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'content-type': 'application/json', 'X-Cloud-Trace-Context': 'b168b0008aeadd8fb37024f109d189a2', 'Date': 'Mon, 29 Jan 2024 10:40:06 GMT', 'Server': 'Google Frontend', 'Content-Length': '96'})
HTTP response body: b'{"detail":"Maximum allowed number of machines is exceeded. Maximum allowed: 10. Requested: 80."}'
```