### PR TITLE
Removed user confirmation when we have no resources.

### DIFF
--- a/inductiva/_cli/cmd_resources/terminate.py
+++ b/inductiva/_cli/cmd_resources/terminate.py
@@ -9,7 +9,6 @@ def terminate_machine_group(args):
     counter = 0
 
     if len(active_machines) == 0:
-        print("No active computational resources found.")
         return
 
     # Doesn't run in case --all is not passed.

--- a/inductiva/_cli/cmd_resources/terminate.py
+++ b/inductiva/_cli/cmd_resources/terminate.py
@@ -8,7 +8,7 @@ def terminate_machine_group(args):
     active_machines = resources.machine_groups.get()
     counter = 0
 
-    if len(active_machines) == 0:
+    if not active_machines:
         return
 
     # Doesn't run in case --all is not passed.

--- a/inductiva/_cli/cmd_resources/terminate.py
+++ b/inductiva/_cli/cmd_resources/terminate.py
@@ -8,7 +8,7 @@ def terminate_machine_group(args):
     active_machines = resources.machine_groups.get()
     counter = 0
 
-    if active_machines is None:
+    if len(active_machines) == 0:
         print("No active computational resources found.")
         return
 

--- a/inductiva/resources/machine_groups.py
+++ b/inductiva/resources/machine_groups.py
@@ -84,7 +84,7 @@ def _fetch_machine_groups_from_api():
         api = compute_api.ComputeApi(inductiva.api.get_client())
         response = api.list_active_user_instance_groups()
         if len(response.body) == 0:
-            print("No active machine groups found.")
+            print("No active computational resources found.")
             return response.body
 
         return response.body


### PR DESCRIPTION
We were checking if active_machines is none. But it's never None. machine_groups.get always return a list.