### PR TITLE
Validate the task is running before streaming the logs

### DIFF
--- a/inductiva/tasks/streams.py
+++ b/inductiva/tasks/streams.py
@@ -89,6 +89,6 @@ class TaskStreamConsumer:
         else:
             raise RuntimeError(
                 f"Task {self.task_id} has terminated running and the simulation"
-                 " logs are no longer available for streaming. \n Check the "
-                 "task status with \n\t inductiva tasks list --task-id "
+                " logs are no longer available for streaming. \n Check the "
+                "task status with \n\t inductiva tasks list --task-id "
                 f"{self.task_id}")

--- a/inductiva/tasks/streams.py
+++ b/inductiva/tasks/streams.py
@@ -10,7 +10,7 @@ import inductiva
 from inductiva import constants
 
 logger = logging.getLogger("websocket")
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 
 
 class TaskStreamConsumer:
@@ -82,6 +82,13 @@ class TaskStreamConsumer:
     def run_forever(self):
         """Stream the STDOUT & STDERR of a task through the websocket."""
 
-        self.ws.run_forever(reconnect=self.RECONNECT_DELAY_SEC,
-                            ping_interval=self.PING_INTERVAL_SEC,
-                            ping_timeout=self.PING_TIMEOUT_SEC)
+        if inductiva.tasks.Task(self.task_id).is_running():
+            self.ws.run_forever(reconnect=self.RECONNECT_DELAY_SEC,
+                                ping_interval=self.PING_INTERVAL_SEC,
+                                ping_timeout=self.PING_TIMEOUT_SEC)
+        else:
+            raise RuntimeError(
+                f"Task {self.task_id} has terminated running and the simulation"
+                 " logs are no longer available for streaming. \n Check the "
+                 "task status with \n\t inductiva tasks list --task-id "
+                f"{self.task_id}")

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -177,6 +177,11 @@ class Task:
 
             time.sleep(polling_period)
 
+    def is_running(self) -> bool:
+        """Validate if the task is running."""
+
+        return self.get_status() == models.TaskStatusCode.STARTED
+
     def _is_terminal_status(self) -> bool:
         """Check if the task is in a terminal status.
 


### PR DESCRIPTION
This PR validates the task is running before starting the logs stream.

# QA

Try to check a task that is not yours: `inductiva logs pineapple`.
Try to check a task that has finished: `inductiva logs <task_id_of_terminal_task>`.
Try to check a task that is running: `inductiva logs <task_id_running>`