### PR TITLE
Bugfix - kill all was expecting list of tasks but was getting list of dicts

### DIFF
--- a/inductiva/_cli/cmd_tasks/kill.py
+++ b/inductiva/_cli/cmd_tasks/kill.py
@@ -26,7 +26,7 @@ def kill_task(args):
         for status in inductiva.tasks.Task.KILLABLE_STATUSES:
             tasks.extend(get_all(status=status))
 
-    ids = [task.id for task in tasks]
+    ids = [task["task_id"] for task in tasks]
 
     confirm = args.yes or \
         user_confirmation_prompt(ids,

--- a/inductiva/tasks/methods.py
+++ b/inductiva/tasks/methods.py
@@ -146,8 +146,8 @@ def get(
 
 
 def get_all(
-    status: Optional[Union[str, models.TaskStatusCode]] = None
-) -> List["inductiva.tasks.Task"]:
+        status: Optional[Union[str,
+                               models.TaskStatusCode]] = None) -> List[Dict]:
     """Get all tasks of a user.
 
     This function fetches all tasks of a user, sorted by submission
@@ -157,7 +157,7 @@ def get_all(
         status: The status of the tasks to get. If None, tasks with any status
             will be returned.
     Returns:
-        List of Task objects.
+        List of dictionaries with information about the tasks.
     """
     status = models.TaskStatusCode(status) if status is not None else None
 


### PR DESCRIPTION
Kill all was returning list of dicts but our code was expecting list of Tasks. Changed our code to work with list of dicts.