### PR TITLE
Bugfix - tasks list prints 3 empty lines when we have no tasks

### DIFF
--- a/inductiva/_cli/cmd_tasks/list.py
+++ b/inductiva/_cli/cmd_tasks/list.py
@@ -19,6 +19,10 @@ def list_tasks(args):
         last_n = 5 if args.last_n is None else args.last_n
         task_list = tasks.get(last_n=last_n)
 
+    if not task_list:
+        print("No tasks found.")
+        return 1
+
     table_dict = tasks.to_dict(task_list)
 
     emph_formatter = utils.format_utils.get_ansi_formatter()
@@ -44,6 +48,7 @@ def list_tasks(args):
         utils.format_utils.get_tabular_str(table_dict,
                                            formatters=formatters,
                                            header_formatters=header_formatters))
+    return 0
 
 
 def register(parser):

--- a/inductiva/tasks/methods.py
+++ b/inductiva/tasks/methods.py
@@ -22,8 +22,11 @@ def to_dict(list_of_tasks: Iterable[Task]) -> Mapping[str, List[Any]]:
             all the tasks. Example: { "ID": [1, 2, 3], 
             "Simulator": ["reef3d", "reef3d", "reef3d"], ... }
     """
-
-    table = defaultdict(list)
+    column_names = [
+        "ID", "Simulator", "Status", "Submitted", "Started", "Computation Time",
+        "Resource Type"
+    ]
+    table = defaultdict(list, {key: [] for key in column_names})
 
     for task in list_of_tasks:
         info = task.get_info()


### PR DESCRIPTION
Problem:
When we have no tasks our list will give the wrong output
```
(inductiva-dev) paulobarbosa@Computador-portatil-de-Paulo inductiva % inductiva tasks list -n 10

    

(inductiva-dev) paulobarbosa@Computador-portatil-de-Paulo inductiva % 
```
Solution:
Now to_dict returns a dict with all keys with empty arrays if no tasks are found. If we decide that we want to print an empty table with only column names, we should be able to do that easily now.
inductiva tasks list now prints "no tasks" found if no tasks found