### PR TITLE
controls the verbosity of killing tasks

### DIFF
--- a/inductiva/_cli/cmd_tasks/kill.py
+++ b/inductiva/_cli/cmd_tasks/kill.py
@@ -44,7 +44,7 @@ def kill_task(args):
     if not confirm:
         return 1
 
-    verbosity_level = 0 if len(ids) > 1 else 1
+    verbosity_level = 1 if kill_all else 2
 
     for task_id in ids:
         try:

--- a/inductiva/_cli/cmd_tasks/kill.py
+++ b/inductiva/_cli/cmd_tasks/kill.py
@@ -44,9 +44,12 @@ def kill_task(args):
     if not confirm:
         return 1
 
+    verbosity_level = 0 if len(ids) > 1 else 1
+
     for task_id in ids:
         try:
-            inductiva.tasks.Task(task_id).kill(wait_timeout=args.wait_timeout)
+            inductiva.tasks.Task(task_id).kill(wait_timeout=args.wait_timeout,
+                                               verbosity_level=verbosity_level)
         except RuntimeError as exc:
             print(f"Error for task {task_id}:", exc)
 

--- a/inductiva/localization/translations/en.json
+++ b/inductiva/localization/translations/en.json
@@ -8,11 +8,12 @@
         "Unable to check for available updates for the 'inductiva' package.",
         "The following error occurred:\n  {0}"
     ],
-    "task-kill-request-sent-1":["Successfully sent kill request for task {0}.",
+    "task-kill-request-sent-2":["Successfully sent kill request for task {0}.",
         "> Consider tracking the task status by calling task.get_status()",
         "> or via the CLI using 'inductiva tasks -id {0}'."
     ],
-    "task-kill-request-sent-0":["Successfully sent kill request for {0}."],
+    "task-kill-request-sent-1":["Successfully sent kill request for {0}."],
+    "task-kill-request-sent-0":[""],
     "user-prompt-confirmation": 
         "Are you sure you want to proceed (y/[N])? "
     ,

--- a/inductiva/localization/translations/en.json
+++ b/inductiva/localization/translations/en.json
@@ -8,10 +8,11 @@
         "Unable to check for available updates for the 'inductiva' package.",
         "The following error occurred:\n  {0}"
     ],
-    "task-kill-request-sent":["Successfully sent kill request for task {0}.",
+    "task-kill-request-sent-1":["Successfully sent kill request for task {0}.",
         "> Consider tracking the task status by calling task.get_status()",
         "> or via the CLI using 'inductiva tasks -id {0}'."
     ],
+    "task-kill-request-sent-0":["Successfully sent kill request for {0}."],
     "user-prompt-confirmation": 
         "Are you sure you want to proceed (y/[N])? "
     ,

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -53,7 +53,7 @@ class Task:
     KILLABLE_STATUSES = {models.TaskStatusCode.SUBMITTED
                         }.union(RUNNING_STATUSES)
 
-    TASK_KILL_VERBOSITY_LEVELS = [0, 1, 2]
+    KILL_VERBOSITY_LEVELS = [0, 1, 2]
 
     def __init__(self, task_id: str):
         """Initialize the instance from a task ID."""
@@ -275,7 +275,9 @@ class Task:
             wait_timeout (int, float): Optional - number of seconds to wait
             for the kill command or None if only the request is to be sent.
             verbosity_level (int): Optional. the verbosity of the logs when the
-            task signal is sent and when the task is killed.
+            task signal is sent and when the task is killed. Verbosity 0
+            produces no outputs, 1 produces minimal outputs, and 2 (Default)
+            produces extensive outputs.
         Returns:
             - None if `wait_timeout` is None and the kill request was
               successfully sent;
@@ -291,9 +293,9 @@ class Task:
             if wait_timeout <= 0.0:
                 raise ValueError("Wait timeout must be a positive number.")
 
-        if verbosity_level not in self.TASK_KILL_VERBOSITY_LEVELS:
+        if verbosity_level not in self.KILL_VERBOSITY_LEVELS:
             raise ValueError(f"Verbosity {verbosity_level} level not allowed. "
-                             f"Choose from {self.TASK_KILL_VERBOSITY_LEVELS}")
+                             f"Choose from {self.KILL_VERBOSITY_LEVELS}")
 
         self._send_kill_request(constants.TASK_KILL_MAX_API_REQUESTS)
 

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -53,7 +53,7 @@ class Task:
     KILLABLE_STATUSES = {models.TaskStatusCode.SUBMITTED
                         }.union(RUNNING_STATUSES)
 
-    TASK_KILL_VERBOSITY_LEVELS = [0, 1]
+    TASK_KILL_VERBOSITY_LEVELS = [0, 1, 2]
 
     def __init__(self, task_id: str):
         """Initialize the instance from a task ID."""
@@ -263,7 +263,7 @@ class Task:
 
     def kill(self,
              wait_timeout: Optional[Union[float, int]] = None,
-             verbosity_level: int = 1) -> Union[bool, None]:
+             verbosity_level: int = 2) -> Union[bool, None]:
         """Request a task to be killed.
         
         This method requests that the current task is remotely killed.
@@ -274,6 +274,8 @@ class Task:
         Args:
             wait_timeout (int, float): Optional - number of seconds to wait
             for the kill command or None if only the request is to be sent.
+            verbosity_level (int): Optional. the verbosity of the logs when the
+            task signal is sent and when the task is killed.
         Returns:
             - None if `wait_timeout` is None and the kill request was
               successfully sent;
@@ -310,7 +312,10 @@ class Task:
                 "The status of the task is %s", self.id, wait_timeout, status)
 
         if success:
-            logging.info("Successfully killed task %s.", self.id)
+            if verbosity_level == 2:
+                logging.info("Successfully killed task %s.", self.id)
+            elif verbosity_level == 1:
+                logging.info("%s killed.")
 
         return success
 


### PR DESCRIPTION
This pull request addresses: https://github.com/inductiva/tasks/issues/109

## Contents

When killing several the output was too verbose:

```
augustoperes@Augustos-Air inductiva % inductiva tasks kill --all                                              
You are about to kill ALL tasks.
Are you sure you want to proceed (y/[N])? y
Successfully sent kill request for task g7ic65a4iy15ifnecn7p1g6r8.
> Consider tracking the task status by calling task.get_status()
> or via the CLI using 'inductiva tasks -id g7ic65a4iy15ifnecn7p1g6r8'.
Successfully sent kill request for task k8g5z9q8b0pieeojkua4zmue3.
> Consider tracking the task status by calling task.get_status()
> or via the CLI using 'inductiva tasks -id k8g5z9q8b0pieeojkua4zmue3'.
Successfully sent kill request for task 0k0oamoo0q84ugzfhney2k0zd.
> Consider tracking the task status by calling task.get_status()
> or via the CLI using 'inductiva tasks -id 0k0oamoo0q84ugzfhney2k0zd'.
Successfully sent kill request for task dnzznpsmq3c99arfnfrmtb4zi.
> Consider tracking the task status by calling task.get_status()
> or via the CLI using 'inductiva tasks -id dnzznpsmq3c99arfnfrmtb4zi'.
Successfully sent kill request for task k04dbctvvqc7d5cri64a2o651.
> Consider tracking the task status by calling task.get_status()
> or via the CLI using 'inductiva tasks -id k04dbctvvqc7d5cri64a2o651'.
Successfully sent kill request for task 1697107060966412965.
> Consider tracking the task status by calling task.get_status()
> or via the CLI using 'inductiva tasks -id 1697107060966412965'.
Successfully sent kill request for task 0jnzq8tc88r584pz6uzmdfydt.
> Consider tracking the task status by calling task.get_status()
> or via the CLI using 'inductiva tasks -id 0jnzq8tc88r584pz6uzmdfydt'.
Successfully sent kill request for task 1695999258293624322.
> Consider tracking the task status by calling task.get_status()
> or via the CLI using 'inductiva tasks -id 1695999258293624322'.
```

This pull request adds a new verbosity level to `task.kill()` that displays a shorter message:

```
augustoperes@Augustos-Air inductiva % inductiva tasks  kill --all
You are about to kill ALL tasks.
Are you sure you want to proceed (y/[N])? y
Successfully sent kill request for m04agmt0w2mn5awoyibvn14qi.
Successfully sent kill request for bou80b3fgg0k4g6o7r1s93z0b.
Successfully sent kill request for 5h269fxwjgz3fgzr0xgnn1sf3.
Successfully sent kill request for cnm8kjta57d58a7jo20mdsbwk.
Successfully sent kill request for 5nr2df41uiepwcv32po8nm03s.
Successfully sent kill request for nn76e1fas9dpkyxiazf551fra.
Successfully sent kill request for 6a3kaqmio0th5f3t3jngokjwq.
Successfully sent kill request for tzhorjdhvgur9fmncc29hjbvz.
Successfully sent kill request for q1mo3i64a0oix69srrauze1mi.
```

## Behaviour

Instead of adding this new behaviour only when the user kills all tasks I added it when the user kill more than one task. Please give you opinion on when we should trigger lower verbosity:

```
augustoperes@Augustos-Air inductiva % inductiva tasks kill 9m2pv45cir3vho5k8swxfywcb
You are about to kill the following tasks:
  - 9m2pv45cir3vho5k8swxfywcb
Are you sure you want to proceed (y/[N])? y
Successfully sent kill request for task 9m2pv45cir3vho5k8swxfywcb.
> Consider tracking the task status by calling task.get_status()
> or via the CLI using 'inductiva tasks -id 9m2pv45cir3vho5k8swxfywcb'.

augustoperes@Augustos-Air inductiva % inductiva tasks kill q9dca5g4yo0m0qzywa5ktvuzr b7zcxip8ur1aod1gc8b8zq22k
You are about to kill the following tasks:
  - b7zcxip8ur1aod1gc8b8zq22k
  - q9dca5g4yo0m0qzywa5ktvuzr
Are you sure you want to proceed (y/[N])? y
Successfully sent kill request for b7zcxip8ur1aod1gc8b8zq22k.
Successfully sent kill request for q9dca5g4yo0m0qzywa5ktvuzr.
```