### PR TITLE
[Simulator] Add SWAN client interface

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ simulators/GROMACS
 simulators/SWASH
 simulators/XBeach
 simulators/Reef3D
+simulators/SWAN
 simulators/FDS
 ```
 

--- a/docs/simulators/SWAN.md
+++ b/docs/simulators/SWAN.md
@@ -28,3 +28,6 @@ task = swash.run(
 task.wait()
 task.download_outputs()
 ```
+
+Check the [official documentation](https://swanmodel.sourceforge.io/) of SWAN to know 
+more about the configuration details specific of the simulator.

--- a/docs/simulators/SWAN.md
+++ b/docs/simulators/SWAN.md
@@ -1,0 +1,30 @@
+## SWAN
+
+SWAN is a simulator for obtaining realistic estimates of wave parameters in coastal
+areas, lakes and eastuaries from given wind, sea floor and current conditions.
+
+The simulator is configured using a single file with the `.swn` extension, and
+additional files containing information about the domain and the sea floor, and
+the conditions shall be saved in an input directory that is passed to the simulator.
+
+### Example
+
+```python
+import inductiva
+
+# Set simulation input directory
+input_dir = inductiva.utils.files.download_from_url(
+    "https://storage.googleapis.com/inductiva-api-demo-files/"
+    "swan-input-example.zip", True)
+
+# Initialize the Simulator
+swan = inductiva.simulators.SWAN()
+
+# Run simulation with config files in the input directory
+task = swash.run(
+    input_dir=input_dir, sim_config_filename="a11refr.swn")
+
+# Wait for the simulation to finish and download the results
+task.wait()
+task.download_outputs()
+```

--- a/docs/simulators/overview.md
+++ b/docs/simulators/overview.md
@@ -17,6 +17,7 @@ The simulators available in the current version of the API (0.4) are:
 - [SWASH](../simulators/SWASH.md)
 - [XBeach](../simulators/XBeach.md)
 - [Reef3D](../simulators/Reef3D.md)
+- [SWAN](../simulators/SWAN.md)
 - [FDS](../simulators/FDS.md)
 
 Check the documentation of each simulator to learn about the specifics of how to configure them and launch your simulations via the API.

--- a/inductiva/simulators/__init__.py
+++ b/inductiva/simulators/__init__.py
@@ -10,3 +10,4 @@ from .simsopt import SIMSOPT
 from .fenicsx import FEniCSx
 from .fds import FDS
 from .reef3d import REEF3D
+from .swan import SWAN

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -1,0 +1,36 @@
+"""SWAN module of the API."""
+from typing import Optional
+
+from inductiva import types, tasks, simulators
+
+
+@simulators.simulator.mpi_enabled
+class SWAN(simulators.Simulator):
+    """Class to invoke a generic SWAN simulation on the API."""
+
+    def __init__(self):
+        super().__init__()
+        self.api_method_name = "swan.swan.run_simulation"
+
+    def run(
+        self,
+        input_dir: types.Path,
+        sim_config_filename: str,
+        on: Optional[types.ComputationalResources] = None,
+        storage_dir: Optional[types.Path] = "",
+        extra_metadata: Optional[dict] = None,
+    ) -> tasks.Task:
+        """Run the simulation.
+
+        Args:
+            input_dir: Path to the directory of the simulation input files.
+            sim_config_filename: Name of the simulation configuration file.
+            on: The computational resource to launch the simulation on. If None
+                the simulation is submitted to a machine in the default pool.
+            storage_dir: Directory for storing simulation results.
+        """
+        return super().run(input_dir,
+                           on=on,
+                           input_filename=sim_config_filename,
+                           storage_dir=storage_dir,
+                           extra_metadata=extra_metadata)


### PR DESCRIPTION
TLDR: Adds the SWAN simulator to the client.

## Description

In this PR, we add the client interface to execute simulations with SWAN simulator that was added to the backend in the PR inductiva/inductiva-web-api#632.

This simulator runs exactly as SWASH with a single binary and MPI, so the user only needs to pass the input directory and the name of `sim_config_filename`. An example input dir was added to our respective cloud folder to allow for testing.

## Implications

The main application, that should be addressed soon and that here I was not strict is with the `api_method_name`. In a next PR, I will make sure to uniformize all of them together with the backend.

There are few threads open with SWAN, respectively the usage of OpenMP vs MPI when running the simulator. One discussion in the "literature" is that OpenMP is more effective in a single machine, while MPI is more effective over several. Here, we would need to separate images for each, since SWAN doesn't seem to allow for compilation of both at the same time. Due to our current structure and simplicity, I have followed with the implementation with MPI, and further conversations with users may decide our next steps.

A README will follow on a next iteration.

## Test

To test this simulator you can deploy the backend locally or wait for it to be merged into development. To do so, use the following script:

```python
import inductiva

# Set simulation input directory
input_dir = inductiva.utils.files.download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "swan-input-example.zip", True)

# Initialize the Simulator
swan = inductiva.simulators.SWAN()

# Run simulation with config files in the input directory
task = swash.run(
    input_dir=input_dir, sim_config_filename="a11refr.swn")
```