### PR TITLE
Add inspector gadget to valid types and conditions for arguments

### DIFF
--- a/inductiva/resources/machine_cluster.py
+++ b/inductiva/resources/machine_cluster.py
@@ -2,6 +2,7 @@
 from absl import logging
 
 from inductiva.resources import machines_base
+from inductiva.utils.inspector import precondition
 
 
 class MPICluster(machines_base.BaseMachineGroup):
@@ -12,6 +13,9 @@ class MPICluster(machines_base.BaseMachineGroup):
     Note: The cluster will be available only after calling 'start' method.
     The billing will start only after the machines are started."""
 
+    @precondition(
+        num_machines=lambda num_machines: num_machines > 0
+    )
     def __init__(self,
                  machine_type: str,
                  num_machines: int = 2,

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -3,6 +3,7 @@
 from typing import Optional
 
 from inductiva import types, tasks, simulators
+from inductiva.utils.inspector import precondition
 
 
 class DualSPHysics(simulators.Simulator):
@@ -12,6 +13,7 @@ class DualSPHysics(simulators.Simulator):
         super().__init__()
         self.api_method_name = "sph.dualsphysics.run_simulation"
 
+    @precondition()
     def run(
         self,
         input_dir: types.Path,

--- a/inductiva/utils/__init__.py
+++ b/inductiva/utils/__init__.py
@@ -1,3 +1,4 @@
 # pylint: disable=missing-module-docstring
 from . import files
 from .files import download_from_url
+from . import inspector

--- a/inductiva/utils/inspector.py
+++ b/inductiva/utils/inspector.py
@@ -1,0 +1,60 @@
+"""Utilities to inspect and validate function arguments."""
+
+import inspect
+from typeguard import check_type # Beefed-up isinstance
+
+
+def precondition(**conditions):
+    """Decorator to validate type and value of function arguments.
+    
+    This decorator checks if the values of the arguments of a function match
+    its respective annotations. Moreover, one can specify additional conditions
+    that the arguments must satisfy. If the conditions are not met, the
+    decorator raises a ValueError with the respective condition to be fulfilled.
+    
+    Each condition is based on a lambda function and shall be equalled to the
+    name of the argument. E.g.:
+
+        @precondition(y=lambda y: y == 10)
+        def fun(x:bool, y: bool):
+            return y and x
+    
+    Note that not all arguments need not have a condition.
+    Further, if no annotation is given to an argument, the decorator will not
+    check its type and/or raise any error.
+    """
+    def decorator(func):
+        """Wrapper function to validate the function arguments."""
+        signature = inspect.signature(func)
+        params = signature.parameters
+
+        def wrapper(*args, **kwargs):
+            """Wrapper to validate the function arguments."""
+
+            # Set mapping of arguments to the function's parameters.
+            values_to_params_map = signature.bind(*args, **kwargs)
+
+            # Iterate over each argument of the function
+            for arg, value in values_to_params_map.arguments.items():
+                # Check if each argument has an annotation
+                if params[arg].annotation is not inspect.Parameter.empty:
+                    # Validate the value passed conforms to annotation
+                    if not check_type(value, params[arg].annotation):
+                        raise TypeError(
+                            f"{arg}={value} is not an instance of "
+                            f"{params[arg].annotation}")
+                    
+                if arg in conditions and value is not None:
+                    # Validate that the condition is fulfilled. 
+                    if not conditions[arg](value):
+                        # Convert lambda function into a string and extract
+                        # the condition to be fulfilled.
+                        condition = inspect.getsourcelines(
+                            conditions[arg])[0][0]
+                        condition = condition.strip().split(":")[1]
+                        raise ValueError(
+                            f"{arg}={value} does not satisfy the condition"
+                            f"{condition}")
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator


### PR DESCRIPTION
This draft serves to validate the implementation of an inspector of the values passed to a function satisfy the annotation of the respective argument and to validate conditions the argument should fulfil to be valid.

The implementation uses a decorator where pre-conditions the arguments should pass can be set. These preconditions shall be lambda functions, but we can iterate on it to provide a clear view to the user. The ability of lambda functions is to simplify the flow for developers where the condition is more clearly stated.

This first implementation covers two cases: DualSPHysics() simulator and MPICluster()

## Example A - DualSPHysics

In this case we wrapped the `run` method of the DualSPHysics class without any preconditions. Note that, `DualSPHysics.run()` needs an `input_dir` and a list of commands, where each command can be a string or an object of a class defined by us `inductiva.commands.Comman()`.

With this in mind we have performed the following tests:
**Normal Run - Simulation is submmited to the API:**
```python
import inductiva

dual = inductiva.simulators.DualSPHysics()

task = dual.run("ananas", ["command1", "command2"])
```

**Run with `input_dir=1`**
```python
import inductiva

dual = inductiva.simulators.DualSPHysics()

task = dual.run(1, ["command1", "command2"])
```
User receives the following error:
```bash
int did not match any element in the union:
  os.PathLike: is not an instance of os.PathLike
  str: is not an instance of str
  Exiting with code 1.
```

**Run with `commands="str"`:**
```python
import inductiva

dual = inductiva.simulators.DualSPHysics()

task = dual.run("ananas", "ls")
```
```bash
System encountered the following unhandled exception:
str is not a list
  Exiting with code 1.
```

Problem here, not being able to capture the ForwardRef to `inductiva.commands.Command`.

## Example B - MPICluster

In this case, we wrap the `__init__` of the MPI cluster class with the precondition. In this case, we add a condition to the `num_machines` so that users cannot set a number lower than 1. This is set as follows:

```python
@precondition(
        num_machines=lambda num_machines: num_machines > 0
    )
    def __init__(self,
                 machine_type: str,
                 num_machines: int = 2,
                 data_disk_gb: int = 10,
                 register: bool = True) -> None:
```

We obtain the following runs:

**Normal run - Cluster is executed**
```python
import inductiva

cluster = inductiva.resources.MPICluster("e2-standard-4", 1, 10)
```

**Wrong type for `num_machines`**

```python
import inductiva

cluster = inductiva.resources.MPICluster("e2-standard-4", "g", 10)
```
```bash
System encountered the following unhandled exception:
str is not an instance of int
  Exiting with code 1.
```

**Invalid value with `num_machines=-1`:**

```python
import inductiva

cluster = inductiva.resources.MPICluster("e2-standard-4", -1, 10)
```
```bash
System encountered the following unhandled exception:
num_machines=-1 does not satisfy the condition num_machines > 0
  Exiting with code 1.
```
