### PR TITLE
[CLI] Add Login subcommand

### DIFF
--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -66,15 +66,6 @@ def _check_for_available_package_update():
         print(msg, file=sys.stderr)
 
 
-def _check_key():
-    global _checked_key
-
-    if not _checked_key and utils.format_utils.getenv_bool(
-            "GITHUB_ACTIONS", False) is not True:
-        api.methods.validate_api_key(api_key)
-        _checked_key = True
-
-
 _check_for_available_package_update()
 
 
@@ -90,5 +81,3 @@ def _supports_ansi():
 
 
 _ansi_enabled = _supports_ansi()
-
-_check_key()

--- a/inductiva/_cli/cmd_login/__init__.py
+++ b/inductiva/_cli/cmd_login/__init__.py
@@ -1,0 +1,42 @@
+"""Register CLI commands for Login in Inductiva API."""
+import subprocess
+import argparse
+import platform
+
+from .. import utils
+from ... import constants
+
+
+def api_login(unused_args):
+    """Open the Inductiva API console to perform login."""
+
+    url = constants.CONSOLE_URL
+
+    system = platform.system()
+    if system == "Darwin":
+        cmd = ["open", url]
+    elif system == "Linux":
+        cmd = ["xdg-open", url]
+    elif system == "Windows":
+        cmd = ["cmd", "/c", "start", url.replace("&", "^&")]
+    else:
+        raise RuntimeError(f"Unsupported system: {system}")
+    subprocess.run(cmd, check=True)
+
+
+def register(root_parser):
+    parser = root_parser.add_parser(
+        "login",
+        help="Login to get an Inductiva API Key.",
+        formatter_class=argparse.RawTextHelpFormatter)
+
+    parser.description = (
+        "Login into the Inductiva console to register in the platform and "
+        "obtain\nyour API key. Currently, this method requires an Google "
+        "email.\nFurther, you can login to generate a new API key when needed."
+        "\n\nTo use the API set the key as an environment variable:\n "
+        "\texport INDUCTIVA_API_KEY=<your_api_key>")
+
+    utils.show_help_msg(parser)
+
+    parser.set_defaults(func=api_login)

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -33,7 +33,7 @@ def validate_api_key(api_key: Optional[str]) -> Configuration:
             "No API Key specified. "
             "Please set the INDUCTIVA_API_KEY environment variable.\n"
             "More infomation at:"
-            "https://inductiva-research-labs-inductiva.readthedocs-hosted.com/en/latest/Getting%20Started.html"
+            "https://inductiva-research-labs-inductiva.readthedocs-hosted.com/en/latest/"
         )
     # pylint: enable=line-too-long
 

--- a/inductiva/constants.py
+++ b/inductiva/constants.py
@@ -4,6 +4,9 @@ import os
 LOGS_WEBSOCKET_URL = os.environ.get("INDUCTIVA_TASK_LOGS_URL",
                                     "wss://logs.inductiva.ai")
 
+CONSOLE_URL = os.environ.get("INDUCTIVA_CONSOLE_URL",
+                             "https://console.inductiva.ai")
+
 DEFAULT_QUEUE_MACHINE_TYPE = "c2-standard-4"
 
 TASK_KILL_MAX_API_REQUESTS = 5


### PR DESCRIPTION
TLDR: Add a subcommand to CLI to allow for login/sign-in into Inductiva API.

## Description

With the purpose of facilitating getting an API key, this PR introduces a new subcommand to the CLI that allows to login into the console to register yourself in the platform, get an API Key and allow to regenerate it.

## Implications

The name attributed to the subcommand is `login` because it allows for much more functionality than just register ourselves in the platform. For example, we can use `inductiva login` to login into the console and fetch the API key, or regenerate it.

Still not completely sure, this is the correct name, but I didn't like `register` either due to the above implications.