### PR TITLE
ToC structure

### DIFF
--- a/docs/api_reference/best-practices.md
+++ b/docs/api_reference/best-practices.md
@@ -1,0 +1,1 @@
+# Best Practices

--- a/docs/api_reference/change-log.md
+++ b/docs/api_reference/change-log.md
@@ -1,0 +1,1 @@
+# Change Log and Versioning

--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -1,4 +1,4 @@
-# Overview
+# How it works
 
 Walking side by side with the Python client, the Inductiva CLI provides 
 a quick and simple interface to interact and perform the most common tasks from

--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -1,4 +1,4 @@
-# How it works
+# CLI Overview and Functionalities
 
 Walking side by side with the Python client, the Inductiva CLI provides 
 a quick and simple interface to interact and perform the most common tasks from

--- a/docs/cli/using-cli.md
+++ b/docs/cli/using-cli.md
@@ -1,4 +1,4 @@
-# Using the CLI
+# CLI Usage Guide
 
 While a task is running, one of the main concerns for scientists and engineers is
 to understand if the simulation is progressing as expected and/or if there are any errors.

--- a/docs/cli/using-cli.md
+++ b/docs/cli/using-cli.md
@@ -1,0 +1,81 @@
+# Using the CLI
+
+While a task is running, one of the main concerns for scientists and engineers is
+to understand if the simulation is progressing as expected and/or if there are any errors.
+
+To help with this, the CLI provides a `logs` subcommand that allows users to stream
+the logs of a running task in real time. In this way, running a simulation in a
+powerful remote machine will feel exactly like running in your local computer.
+
+Example:
+
+```bash
+$ inductiva logs f0bnqgf4fcr4asgi4e21tcsqa
+Websocket connected
+Opening socket connection to logs of task f0bnqgf4fcr4asgi4e21tcsqa ...
+timestep: 0.0226
+t/T: 12.2
+breaking: 0
+Fi_iter: 4 Final_residual: 3.73e-09  Fi_time: 0.00174
+breaking: 0
+Fi_iter: 4 Final_residual: 3.08e-09  Fi_time: 0.00172
+breaking: 0
+Fi_iter: 5 Final_residual: 1.68e-11  Fi_time: 0.00167
+umax: 0.102
+vmax: 0
+wmax: 0.0941
+dt: 0.0226
+wavegentime: 2.49e-05
+reinitime: 0
+gctime: 0.000539         average gctime: 0.0005
+Xtime: 0.000126  average Xtime: 0.000641
+total time: 7.62451   average time: 0.00878
+timer per step: 0.00885
+------------------------------------
+869
+simtime: 19.6
+timestep: 0.0226
+t/T: 12.2
+breaking: 0
+Fi_iter: 4 Final_residual: 2.68e-09  Fi_time: 0.00187
+breaking: 0
+Fi_iter: 4 Final_residual: 5.84e-09  Fi_time: 0.00187
+breaking: 0
+Fi_iter: 4 Final_residual: 9.24e-09  Fi_time: 0.00145
+umax: 0.101
+vmax: 0
+wmax: 0.0984
+dt: 0.0226
+wavegentime: 2.06e-05
+reinitime: 0
+gctime: 0.000429         average gctime: 0.0005
+Xtime: 0.000979  average Xtime: 0.000641
+total time: 7.63317   average time: 0.00878
+timer per step: 0.00865
+------------------------------------
+870
+simtime: 19.6
+timestep: 0.0226
+t/T: 12.2
+breaking: 0
+Fi_iter: 4 Final_residual: 2.3e-09  Fi_time: 0.00165
+breaking: 0
+Fi_iter: 5 Final_residual: 5.82e-12  Fi_time: 0.00194
+breaking: 0
+Fi_iter: 4 Final_residual: 3.39e-09  Fi_time: 0.00143
+umax: 0.101
+vmax: 0
+wmax: 0.109
+dt: 0.0226
+wavegentime: 2.39e-05
+reinitime: 0
+gctime: 0.00056  average gctime: 0.0005
+Xtime: 0.00019   average Xtime: 0.000641
+total time: 7.64189   average time: 0.00878
+timer per step: 0.00873
+------------------------------------
+```
+
+This combined with the kill method, allows a quick iteration to stabilize the simulation and achieve the desired configuration.
+
+At the end of the simulation, the logs will be hanging with no messages being logged. In this case, the user can stop the logs by pressing `Ctrl+C`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,5 @@ api_reference/user_quotas
 api_reference/troubleshooting
 api_reference/faq
 api_reference/glossary
-api_reference/best-practices
-api_reference/change-log
 uninstall_inductiva
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,17 @@ introduction/templating
 
 ```{toctree}
 ---
-caption: How-To Guides
+caption: Command Line Interface (CLI)
+maxdepth: 1
+hidden: true
+---
+cli/overview
+cli/using-cli
+```
+
+```{toctree}
+---
+caption: Guides
 maxdepth: 1
 hidden: true
 ---
@@ -64,18 +74,6 @@ simulators/FDS
 
 ```{toctree}
 ---
-caption: Command Line Interface (CLI)
-maxdepth: 1
-hidden: true
----
-cli/overview
-cli/resources
-cli/tasks
-cli/storage
-```
-
-```{toctree}
----
 caption: User Reference
 maxdepth: 1
 hidden: true
@@ -85,5 +83,7 @@ api_reference/user_quotas
 api_reference/troubleshooting
 api_reference/faq
 api_reference/glossary
+api_reference/best-practices
+api_reference/change-log
 uninstall_inductiva
 ```


### PR DESCRIPTION
This PR addresses:
- Additions/omissions from ToC
- Moving around sections

I moved CLI to the top, as it is an essential tool and should come right after "explore the api". I also suggest explaining what it is, and then merging everything it does under "using the CLI"

I also added two new sections to the user reference, optional, but might be helpful:
- Best Practices
- Releases