### PR TITLE
Added vcpus and use_hwthreads to swan

### DIFF
--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -16,6 +16,8 @@ class SWAN(simulators.Simulator):
         self,
         input_dir: types.Path,
         sim_config_filename: str,
+        n_vcpus: Optional[int] = None,
+        use_hwthread: bool = True,
         on: Optional[types.ComputationalResources] = None,
         storage_dir: Optional[types.Path] = "",
         extra_metadata: Optional[dict] = None,
@@ -25,6 +27,11 @@ class SWAN(simulators.Simulator):
         Args:
             input_dir: Path to the directory of the simulation input files.
             sim_config_filename: Name of the simulation configuration file.
+            n_vcpus: Number of vCPUs to use in the simulation. If not provided
+            (default), all vCPUs will be used.
+            use_hwthread: If specified Open MPI will attempt to discover the
+            number of hardware threads on the node, and use that as the
+            number of slots available.
             on: The computational resource to launch the simulation on. If None
                 the simulation is submitted to a machine in the default pool.
             storage_dir: Directory for storing simulation results.
@@ -33,4 +40,6 @@ class SWAN(simulators.Simulator):
                            on=on,
                            input_filename=sim_config_filename,
                            storage_dir=storage_dir,
+                           n_vcpus=n_vcpus,
+                           use_hwthread=use_hwthread,
                            extra_metadata=extra_metadata)


### PR DESCRIPTION
Added vcpus and use_hwthreads to swan

This allows users to control the number of vcpus the simulation uses.