### PR TITLE
65 log task end after no more logs and logs pick up on the correct message when reconnecting from timeout

### DIFF
--- a/inductiva/tasks/streams.py
+++ b/inductiva/tasks/streams.py
@@ -58,6 +58,7 @@ class TaskStreamConsumer:
     PING_INTERVAL_SEC = 15.
     PING_TIMEOUT_SEC = 5.
     TICK_INTERVAL_SEC = 1.
+    END_OF_STREAM = "<<end_of_stream>>"
 
     def __init__(self,
                  task_id: str,
@@ -111,6 +112,9 @@ class TaskStreamConsumer:
         streams = data.get("streams")
         for stream in streams:
             msg = stream["values"][0][1]
+            if msg == self.END_OF_STREAM:
+                self.ws.close()
+                return
             self._write_message(msg)
 
     def _get_message_formatter(self):


### PR DESCRIPTION
Previously, our logs would hang connected forever after a task ended. The user had to use control+c to leave the logs.

Now the logs end when the stream ends. And when the user has a timeout, the logs pick up on the last line received by the client, preventing the user from losing important logs.

**The user can still lose logs because we have a limit of 100000 lines of logs to query. So, if the timeout was long enough that the stream generated more than 100000 lines the user would lose some.**

[inductiva/tasks#65](https://github.com/inductiva/tasks/issues/65)