### PR TITLE
Fix pager and watch bugs

### DIFF
--- a/inductiva/_cli/ansi_pager.py
+++ b/inductiva/_cli/ansi_pager.py
@@ -226,7 +226,8 @@ class PagedOutput(io.TextIOBase):
         of the text pad. The line is clamped to the range [0, line_count-1].
         """
         with self._lock:
-            self._scrolled_to = min(len(self._buffer) - 1, max(0, line))
+            scrolled_to = min(len(self._buffer) - 1, max(0, line))
+            self._scrolled_to = max(0, scrolled_to)
             self._render_body(self._scrolled_to)
             self._render_footer()
 
@@ -238,6 +239,7 @@ class PagedOutput(io.TextIOBase):
         with self._lock:
             self._scrolled_to = 0
             self._buffer.clear()
+            self._moveto(self._display.body)
             self._clear_screen()
             self._render_footer()
 

--- a/inductiva/_cli/ansi_pager.py
+++ b/inductiva/_cli/ansi_pager.py
@@ -105,6 +105,7 @@ class PagedOutput(io.TextIOBase):
         self.set_footer(footer)
 
         self._resizer = scheduler.StoppableScheduler(0.5, self._check_resize)
+        self._resizer.daemon = True
         self._resizer.start()
 
     def _check_resize(self) -> None:

--- a/inductiva/_cli/main.py
+++ b/inductiva/_cli/main.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 import os
 import re
+import io
 
 import inductiva
 from inductiva import _cli
@@ -52,16 +53,19 @@ def watch(func, every, args, cmd):
 
     def action(fout: TextIO = sys.stdout):
         fout.clear()
-        func(args, fout=fout)
+        buffer = io.StringIO()
+        func(args, fout=buffer)
+        fout.write(buffer.getvalue())
 
     with ansi_pager.PagedOutput(header) as pager:
         scheduler = utils.scheduler.StoppableScheduler(every,
                                                        action,
                                                        args=(pager,))
+        scheduler.daemon = True
         scheduler.start()
         pager.run()
         scheduler.stop()
-        scheduler.join()
+        scheduler.join(0.5)
 
 
 def main():


### PR DESCRIPTION
This PR:
- fixes a bug in the scrolling mechanism that allowed for negative lines when the buffer was empty;
- ensures that the body and footer are properly cleared when the `clear` method is called;
- ensures all threads run as daemon of the main thread and sets a timeout when joining the scheduler thread to allow for better user experience.