### PR TITLE
142 Add use cases to logs markdown file

### DIFF
--- a/docs/cli/streaming-logs.md
+++ b/docs/cli/streaming-logs.md
@@ -83,7 +83,38 @@ timer per step: 0.00873
 Combining both subcommand `log` and `kill` will allow you to quickly adjust or 
 terminate simulations to achieve the desired simulation configurations.
 
-At the end of the simulation, the log stream will pause without new messages. In 
-this case, you can exit the log stream by simply using `Ctrl+C`, which stops the 
-log monitoring without affecting the simulation or its outputs.
+At the end of the simulation, the log stream will automatically close, indicating
+that there are no new messages. This automatic closure of the stream does not 
+affect the simulation or its outputs, and no further action is required from the
+user.
 
+In addition to the automatic closure of the log stream, the `inductiva logs`
+command supports several modes for redirecting output:
+
+- **Redirect stdout to a file**: You can redirect stdout to a file using the 
+`1>` operator. For example:
+
+```bash
+$ inductiva logs TASK_ID 1>out.txt
+```
+
+- **Redirect stderr to a file**: You can redirect stderr to a file using the 
+`2>` operator. For example:
+
+```bash
+$ inductiva logs TASK_ID 2>err.txt
+```
+
+- **Redirect stdout and stderr to separate files**: You can redirect stdout and 
+stderr to separate files using the 1> and 2> operators. For example:
+
+```bash
+$ inductiva logs TASK_ID 1>out.txt 2>err.txt
+```
+
+- **Disable ANSI globally**: You can disable ANSI globally by setting the 
+ANSI_ENABLED environment variable to 0. For example:
+
+```bash
+$ ANSI_ENABLED=0 inductiva logs TASK_ID
+```

--- a/docs/cli/streaming-logs.md
+++ b/docs/cli/streaming-logs.md
@@ -8,6 +8,8 @@ you to stream the logs of a running task in **real time**.
 In this way, running a simulation on a powerful remote machine will feel exactly 
 like running it on your local computer!
 
+### Check the Log Stream
+
 Here's an example of how you can use the `logs` subcommand to stay updated on your simulation's 
 progress. This command connects you directly to the ongoing logs of the specified 
 task, displaying updates such as computation steps, residuals, and execution times as 
@@ -83,41 +85,39 @@ timer per step: 0.00873
 Combining both subcommand `log` and `kill` will allow you to quickly adjust or 
 terminate simulations to achieve the desired simulation configurations.
 
-At the end of the simulation, the log stream will automatically close, indicating
-that there are no new messages. The automatic shutdown of the stream consumer does not 
-affect the simulation or its outputs, and no further action is required from the
-user.
+### Save the Log Stream
 
-Both the content of the log stream, as well as the status of the stream consumer itself
-can be saved for latter inspection using file redirection:
+When the simulation ends, the log stream will automatically close, indicating
+that there are no new messages. The stream consumer's shutdown doesn't impact the 
+simulation or its outputs, and you don't need to take any further action.
 
-- **Redirect stdout to a file**: You can redirect stdout (file descriptor 1) to a file using the 
-redirection operator (`>`). This will redirect the entire content of the stream to a file. Example:
+You can save the log stream content and the stream consumer's status for later 
+inspection by redirecting them to a file:
 
-```bash
-$ inductiva logs TASK_ID 1>out.txt
-```
+- **Redirect stdout to a file**: You can redirect stdout (file descriptor 1) to 
+a file with the redirection operator (`>`) to save the entire log stream content. 
+For example:
 
-- **Redirect stderr to a file**: The status of the stream consumer is
-written to stderr (file descriptor 2). Redirect of stderr to a file can be
-accomplished as follows:
+    ```bash
+    $ inductiva logs TASK_ID 1>out.txt
+    ```
+- **Redirect stderr to a file**: You can redirect the status of the stream consumer, 
+outputted to stderr (file descriptor 2), to a file like this:
 
-```bash
-$ inductiva logs TASK_ID 2>err.txt
-```
+    ```bash
+    $ inductiva logs TASK_ID 2>err.txt
+    ```
+- **Redirect stdout and stderr to separate files**: You can redirect both stdout 
+and stderr simultaneously to separate files using:
 
-- **Redirect stdout and stderr to separate files**: both stdout and 
-stderr can be simultaneously redirected to separate files using:
+    ```bash
+    $ inductiva logs TASK_ID 1>out.txt 2>err.txt
+    ```
+- **Disable ANSI globally**: If you need to disable ANSI escape codes, which are 
+used to support the status bar at the bottom of the log stream, either export the 
+`ANSI_ENABLED` environment variable or set it locally:
 
-```bash
-$ inductiva logs TASK_ID 1>out.txt 2>err.txt
-```
-
-- **Disable ANSI globally**: To disable the use of ANSI escape codes
-that support the status bar located at the bottom of the log stream, either
-export or set locally the `ANSI_ENABLED` environment variable:
-
-```bash
-$ export ANSI_ENABLED=0 # valid for the entire shell session
-$ ANSI_ENABLED=0 inductiva logs TASK_ID. # only valid for the command 
-```
+    ```bash
+    $ export ANSI_ENABLED=0 # Applies to the entire shell session
+    $ ANSI_ENABLED=0 inductiva logs TASK_ID. # Applies only to this command
+    ```

--- a/docs/cli/streaming-logs.md
+++ b/docs/cli/streaming-logs.md
@@ -84,37 +84,40 @@ Combining both subcommand `log` and `kill` will allow you to quickly adjust or
 terminate simulations to achieve the desired simulation configurations.
 
 At the end of the simulation, the log stream will automatically close, indicating
-that there are no new messages. This automatic closure of the stream does not 
+that there are no new messages. The automatic shutdown of the stream consumer does not 
 affect the simulation or its outputs, and no further action is required from the
 user.
 
-In addition to the automatic closure of the log stream, the `inductiva logs`
-command supports several modes for redirecting output:
+Both the content of the log stream, as well as the status of the stream consumer itself
+can be saved for latter inspection using file redirection:
 
-- **Redirect stdout to a file**: You can redirect stdout to a file using the 
-`1>` operator. For example:
+- **Redirect stdout to a file**: You can redirect stdout (file descriptor 1) to a file using the 
+redirection operator (`>`). This will redirect the entire content of the stream to a file. Example:
 
 ```bash
 $ inductiva logs TASK_ID 1>out.txt
 ```
 
-- **Redirect stderr to a file**: You can redirect stderr to a file using the 
-`2>` operator. For example:
+- **Redirect stderr to a file**: The status of the stream consumer is
+written to stderr (file descriptor 2). Redirect of stderr to a file can be
+accomplished as follows:
 
 ```bash
 $ inductiva logs TASK_ID 2>err.txt
 ```
 
-- **Redirect stdout and stderr to separate files**: You can redirect stdout and 
-stderr to separate files using the 1> and 2> operators. For example:
+- **Redirect stdout and stderr to separate files**: both stdout and 
+stderr can be simultaneously redirected to separate files using:
 
 ```bash
 $ inductiva logs TASK_ID 1>out.txt 2>err.txt
 ```
 
-- **Disable ANSI globally**: You can disable ANSI globally by setting the 
-ANSI_ENABLED environment variable to 0. For example:
+- **Disable ANSI globally**: To disable the use of ANSI escape codes
+that support the status bar located at the bottom of the log stream, either
+export or set locally the `ANSI_ENABLED` environment variable:
 
 ```bash
-$ ANSI_ENABLED=0 inductiva logs TASK_ID
+$ export ANSI_ENABLED=0 # valid for the entire shell session
+$ ANSI_ENABLED=0 inductiva logs TASK_ID. # only valid for the command 
 ```


### PR DESCRIPTION
Our markdown file about the inductiva logs command was missing some functionalities about redirecting the output to files. 

This PR adds a small description about redirecting stdout and errors to files.

