### PR TITLE
Create GitHub Pages deploy workflow for documentation site

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,38 @@
+name: GH Pages Deploy
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - README.md
+
+jobs:
+  build-deploy:
+    name: Build and deploy
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+          path: source
+
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: build
+
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "docs/"
+          build-comand: "sphinx-build . ../build"
+
+      - name: Commit and push changes to gh-pages
+        working-directory: build
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git add .
+          git commit -m "Update GitHub pages from Sphinx build for commit ${GITHUB_SHA}"
+          git push origin gh-pages


### PR DESCRIPTION
This adds a GitHub workflow to build the documention site and push the static files to a `gh-pages` branch.

This is part of a larger effort of moving the documentation from ReadTheDocs to our own GitHub Pages based sites.