### PR TITLE
Fix Input directory size

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -22,7 +22,7 @@ from inductiva.client.models import (BodyUploadTaskInput, TaskRequest,
 from inductiva import types, constants
 from inductiva.utils.data import (extract_output, get_validate_request_params,
                                   pack_input)
-from inductiva.utils import format_utils
+from inductiva.utils import format_utils, files
 
 
 def validate_api_key(api_key: Optional[str]) -> Configuration:
@@ -87,7 +87,7 @@ def upload_input(api_instance: TasksApi, task_id, original_params,
         type_annotations: Annotations of the params' types.
     """
 
-    inputs_size = os.path.getsize(original_params["sim_dir"])
+    inputs_size = files.get_path_size(original_params["sim_dir"])
     logging.info("Preparing upload of the local input directory %s (%s).",
                  original_params["sim_dir"],
                  format_utils.bytes_formatter(inputs_size))

--- a/inductiva/tests/utils/test_files_utils.py
+++ b/inductiva/tests/utils/test_files_utils.py
@@ -30,6 +30,38 @@ def test_get_timestamp_path(tmp_path: pathlib.Path):
     assert len(glob.glob(str(path.parent / "output-*"))) == n
 
 
+def test_get_path_size__input_file(tmp_path: pathlib.Path):
+    """Check if the size of a file is correctly calculated."""
+    path = tmp_path / "file.txt"
+    path.write_text("Hello, World!")
+
+    size = files.get_path_size(path)
+
+    assert pathlib.Path(path).stat().st_size == size
+
+
+def test_get_path_size__input_dir(tmp_path: pathlib.Path):
+    """Check if the size of a directory is correctly calculated."""
+    expected_size = 0
+    path_dir1 = tmp_path / "dir1"
+    path_dir1.mkdir(parents=True, exist_ok=True)
+
+    path_1 = path_dir1 / "file1.txt"
+    (path_1).write_text("Hello, World!")
+
+    path_2 = tmp_path / "file2.txt"
+    (path_2).write_text("I'm not a very long file at all!")
+
+    expected_size += tmp_path.stat().st_size
+    expected_size += path_dir1.stat().st_size
+    expected_size += path_1.stat().st_size
+    expected_size += path_2.stat().st_size
+
+    size = files.get_path_size(tmp_path)
+
+    assert size == expected_size
+
+
 def test_resolve_output_path():
     inductiva.set_output_dir(None)
     resolved_path = files.resolve_output_path("protein.pdb")

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -30,6 +30,35 @@ def get_timestamped_path(path: types.Path, sep: str = "-") -> pathlib.Path:
     return path.with_name(name + path.suffix)
 
 
+def get_path_size(path: types.Path) -> float:
+    """Return the size of a path in bytes.
+    
+    Args:
+        path: Path to a file or directory.
+    
+    Returns:
+        The size of the path in bytes.
+    """
+
+    path = pathlib.Path(path)
+
+    if not path.exists():
+        raise FileNotFoundError(f"Path '{path}' does not exist.")
+
+    if path.is_file():
+        return path.stat().st_size
+
+    size = 0
+
+    for root, _, files in os.walk(path):
+        root = pathlib.Path(root)
+        size += root.stat().st_size
+        for file in files:
+            fp = root / file
+            size += fp.stat().st_size
+    return size
+
+
 def resolve_output_path(path: Optional[types.Path]) -> pathlib.Path:
     """Resolve a path relative to the output_dir
 


### PR DESCRIPTION
This PR fixes the input directory size which is printed in the submission logs of a task.

The previous version was using `os.path.getsize()` which only gives the size of the path and not of subdirectories.
Now, we iterate over the directories and add the size of each folder.

Addresses issue inductiva/tasks#145.