### PR TITLE
Fix bug of `argument of type "NoneType" is not iterable` detected on Windows

### DIFF
--- a/inductiva/localization/localization.py
+++ b/inductiva/localization/localization.py
@@ -77,19 +77,21 @@ class Translator:
             if lang in self._translations:
                 return
 
-            self._load(lang)
-            self._lang = lang
+            if self._load(lang):
+                self._lang = lang
 
-    def _load(self, lang: str) -> None:
+    def _load(self, lang: str) -> bool:
         """Load the translation file for the given language.
 
+        Returns True if the language file was successfully
+        loaded, False otherwise.
         NOTE: This method is not thread-safe.
 
         Args:
             lang (str): Name of the language to load.
         """
         if not lang:
-            return
+            return False
 
         lang = lang.lower()
         pathname = self.TRANSLATIONS_DIR / f"{lang}.json"
@@ -101,7 +103,7 @@ class Translator:
                 "Translation file not available for language '%s'. "
                 "Will use '%s' as default language.", lang,
                 _INDUCTIVA_DEFAULT_LANG)
-            return
+            return False
 
         with open(pathname, "r", encoding="utf-8") as f:
             translations = json.load(f)
@@ -111,6 +113,7 @@ class Translator:
                 translations[key] = "\n".join(translation)
 
         self._translations[lang] = translations
+        return True
 
     def __call__(self, key, *args, **kwargs) -> Template:
         """Return a Template object with the translation for the given key as

--- a/inductiva/localization/localization.py
+++ b/inductiva/localization/localization.py
@@ -141,7 +141,7 @@ class Translator:
             key (str): Key for the translation to get.
         """
         translations = self._translations.get(self._lang)
-        if key not in translations:
+        if translations is None or key not in translations:
             translations = self._translations.get(_INDUCTIVA_DEFAULT_LANG)
         return translations.get(key, key)
 


### PR DESCRIPTION
This PR addresses issue inductiva/tasks#144 where Windows machines were not being able to terminate their resources or kill their tasks from the CLI.

This bug arises from the usage of the `localization` module only on the CLI and just being prompted in Windows machines.

The reason was that when `translations` had a None value, we were still checking if a key was inside a NoneType.
Apparently, if I understood correctly, Windows doesn't handle this cases properly and throws the error to the user. At least according to this: https://stackoverflow.com/questions/6762446/typeerror-argument-of-type-nonetype-is-not-iterable-in-python.

Check first if it is None fixes the bug.