### PR TITLE
Add the option to download tasks from the cli

### DIFF
--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -1,30 +1,32 @@
-"""Downloads a tasks by id via CLI."""
+"""Download the outputs of a task by ID via CLI."""
+import pathlib
 import argparse
+
 import inductiva
 
 
-def download_task(args):
-    """Downloads a task by id."""
-    ids = args.id
+def download_outputs(args):
+    """Download the outputs of a task by ID."""
+    task_ids = args.id
     filenames = args.filenames
     output_dir = args.output_dir
 
-    if not ids:
-        print("No id(s) specified.\n"
+    if not task_ids:
+        print("No ID(s) specified.\n"
               "> Use `inductiva tasks download -h` for help.")
         return 1
 
-    ids = set(ids)
+    task_ids = set(task_ids)
 
-    if len(ids) > 1 and output_dir is not None:
-        print("Cannot specify `output_dir` for more than one download")
-        return 1
-
-    for task_id in ids:
+    for task_id in task_ids:
+        if output_dir is not None:
+            output_dir_task = pathlib.Path(output_dir) / task_id
+        else:
+            output_dir_task = None
         try:
             inductiva.tasks.Task(task_id).download_outputs(
-                filenames=filenames, output_dir=output_dir)
-        except RuntimeError as exc:
+                filenames=filenames, output_dir=output_dir_task)
+        except inductiva.client.exceptions.ApiException as exc:
             print(f"Error for task {task_id}:", exc)
     return 0
 
@@ -37,9 +39,10 @@ def register(parser):
                                   formatter_class=argparse.RawTextHelpFormatter)
 
     subparser.description = (
-        "The `inductiva tasks download` command downloads specified tasks "
+        "The `inductiva tasks download` command allows to download the outputs"
+        " of specified tasks "
         "on the platform.\n"
-        "You can download multiple tasks by passive multiple ids.\n")
+        "You can download multiple tasks by passing multiple ids.\n")
 
     subparser.add_argument("id",
                            type=str,
@@ -51,6 +54,6 @@ def register(parser):
                            nargs="*")
     subparser.add_argument("--output_dir",
                            type=str,
-                           help="Where to download the task to.")
+                           help="Path of where to download the task outputs.")
 
-    subparser.set_defaults(func=download_task)
+    subparser.set_defaults(func=download_outputs)

--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -41,13 +41,13 @@ def register(parser):
                                   formatter_class=argparse.RawTextHelpFormatter)
 
     subparser.description = (
-        "Download the output files produced in the context of the tasks with "
-        "the given ID(s).\nAll files are downloaded unless the --filenames"
-        " list is given, in which case only\n the indicated files for each task"
+        "Download the output files produced in the context of the tasks with\n"
+        "the given ID(s). All files are downloaded unless the --filenames\n"
+        "list is given, in which case only the indicated files for each task\n"
         " are downloaded.\n"
-        "The name of the output folder can be configured "
-        "through the --output_dir option.\nFiles are downloaded to a "
-        "subdirectory named after the ID of the corresponding task.")
+        "The name of the output folder can be configured through the\n"
+        "--output_dir option. Files are downloaded to a subdirectory\n"
+        "named after the ID of the corresponding task.")
 
     subparser.add_argument("id",
                            type=str,

--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -24,8 +24,9 @@ def download_outputs(args):
         else:
             output_dir_task = None
         try:
-            inductiva.tasks.Task(task_id).download_outputs(
-                filenames=filenames, output_dir=output_dir_task)
+            task = inductiva.tasks.Task(task_id)
+            task.download_outputs(filenames=filenames,
+                                  output_dir=output_dir_task)
         except inductiva.client.exceptions.ApiException as exc:
             print(f"Error for task {task_id}:", exc)
     return 0
@@ -39,10 +40,13 @@ def register(parser):
                                   formatter_class=argparse.RawTextHelpFormatter)
 
     subparser.description = (
-        "The `inductiva tasks download` command allows to download the outputs"
-        " of specified tasks "
-        "on the platform.\n"
-        "You can download multiple tasks by passing multiple ids.\n")
+        "Download the output files produced in the context of the tasks with "
+        "the given ID(s).\nAll files are downloaded unless the --filenames"
+        " list is given, in which case only\n the indicated files for each task"
+        " are downloaded.\n"
+        "The name of the output folder can be configured "
+        "through the --output_dir option.\nFiles are downloaded to a "
+        "subdirectory named after the ID of the corresponding task.")
 
     subparser.add_argument("id",
                            type=str,

--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -1,5 +1,4 @@
 """Download the outputs of a task by ID via CLI."""
-import pathlib
 import argparse
 
 import inductiva

--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -1,0 +1,56 @@
+"""Downloads a tasks by id via CLI."""
+import argparse
+import inductiva
+
+
+def download_task(args):
+    """Downloads a task by id."""
+    ids = args.id
+    filenames = args.filenames
+    output_dir = args.output_dir
+
+    if not ids:
+        print("No id(s) specified.\n"
+              "> Use `inductiva tasks download -h` for help.")
+        return 1
+
+    ids = set(ids)
+
+    if len(ids) > 1 and output_dir is not None:
+        print("Cannot specify `output_dir` for more than one download")
+        return 1
+
+    for task_id in ids:
+        try:
+            inductiva.tasks.Task(task_id).download_outputs(
+                filenames=filenames, output_dir=output_dir)
+        except RuntimeError as exc:
+            print(f"Error for task {task_id}:", exc)
+    return 0
+
+
+def register(parser):
+    """Register the download task command."""
+
+    subparser = parser.add_parser("download",
+                                  help="Download tasks.",
+                                  formatter_class=argparse.RawTextHelpFormatter)
+
+    subparser.description = (
+        "The `inductiva tasks download` command downloads specified tasks "
+        "on the platform.\n"
+        "You can download multiple tasks by passive multiple ids.\n")
+
+    subparser.add_argument("id",
+                           type=str,
+                           help="ID(s) of the task(s) to download.",
+                           nargs="*")
+    subparser.add_argument("--filenames",
+                           type=str,
+                           help="Names of the files to download.",
+                           nargs="*")
+    subparser.add_argument("--output_dir",
+                           type=str,
+                           help="Where to download the task to.")
+
+    subparser.set_defaults(func=download_task)

--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -11,6 +11,9 @@ def download_outputs(args):
     filenames = args.filenames
     output_dir = args.output_dir
 
+    if output_dir is not None:
+        inductiva.set_output_dir(output_dir)
+
     if not task_ids:
         print("No ID(s) specified.\n"
               "> Use `inductiva tasks download -h` for help.")
@@ -19,14 +22,9 @@ def download_outputs(args):
     task_ids = set(task_ids)
 
     for task_id in task_ids:
-        if output_dir is not None:
-            output_dir_task = pathlib.Path(output_dir) / task_id
-        else:
-            output_dir_task = None
         try:
             task = inductiva.tasks.Task(task_id)
-            task.download_outputs(filenames=filenames,
-                                  output_dir=output_dir_task)
+            task.download_outputs(filenames=filenames)
         except inductiva.client.exceptions.ApiException as exc:
             print(f"Error for task {task_id}:", exc)
     return 0

--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -13,6 +13,10 @@ def download_outputs(args):
     if output_dir is not None:
         inductiva.set_output_dir(output_dir)
 
+    if output_dir == "":
+        print("`ouput_dir` must not be an empty string.")
+        return 1
+
     if not task_ids:
         print("No ID(s) specified.\n"
               "> Use `inductiva tasks download -h` for help.")


### PR DESCRIPTION
Adds the option to download tasks from the cli.

Usage examples:

* `inductiva tasks download id_1 id_2 --filenames stderr.txt stdout.txt`
* `inductiva tasks download id`
* `inductiva tasks download id --output_dir some_output_dir`
* `inductiva tasks download id_1 id_2 --output_dir some_output_dir` -> This will fail