### PR TITLE
Add ice to client

### DIFF
--- a/inductiva/_cli/cmd_resources/list.py
+++ b/inductiva/_cli/cmd_resources/list.py
@@ -58,7 +58,7 @@ def register(parser):
                            "--provider",
                            type=str,
                            default="gcp",
-                           choices=["gcp"],
+                           choices=["ice", "gcp"],
                            help="Filter the available types by provider.")
     subparser.add_argument("-s",
                            "--series",

--- a/inductiva/resources/machine_types.py
+++ b/inductiva/resources/machine_types.py
@@ -20,25 +20,22 @@ def get_available():
     return machine_types
 
 
-def list_available_machines():
+def list_available_machines(provider: str):
     """List all available machines types."""
 
     resources_available = get_available()
-
+    provider_resources = resources_available[provider]
     machine_types = []
 
-    # Fetch the provider information
-    for _, provider_resources in resources_available.items():
-        # Fetch the available machine CPU series
-        for cpu_series, series_info in provider_resources["cpu-series"].items():
-            # Fetch the available RAM types and vCPUs info
-            for ram_type, type_info in series_info["types"].items():
-                vcpus = type_info["vcpus"]
-                machine_types.extend(
-                    [f"{cpu_series}-{ram_type}-{vcpu}" for vcpu in vcpus])
-                if type_info["lssd"]:
-                    for vcpu in vcpus:
-                        machine_types.append(
-                            f"{cpu_series}-{ram_type}-{vcpu}-lssd")
+    # Fetch the available CPU series for the given provider
+    for cpu_series, series_info in provider_resources["cpu-series"].items():
+        # Fetch the available RAM types and vCPUs info
+        for ram_type, type_info in series_info["types"].items():
+            vcpus = type_info["vcpus"]
+            machine_types.extend(
+                [f"{cpu_series}-{ram_type}-{vcpu}" for vcpu in vcpus])
+            if type_info["lssd"]:
+                for vcpu in vcpus:
+                    machine_types.append(f"{cpu_series}-{ram_type}-{vcpu}-lssd")
 
     return tuple(machine_types)

--- a/inductiva/resources/machine_types.yaml
+++ b/inductiva/resources/machine_types.yaml
@@ -1,3 +1,20 @@
+ice: 
+  description: Machine types provided in ICE cloud.
+  cpu-series:
+    c2:
+      description: Intel Core (12th Gen) i9 processor.
+      types:
+        highmem:
+          vcpus: [4, 8]
+          lssd: False
+          description: 8 GB of memory per vCPU.
+    g2:
+      description: Nvidia 4090 GPU combined with Intel Core (12th Gen) i9 processor.
+      types: 
+        standard:
+          vcpus: [4]
+          lssd: False
+          description: 4 GB of memory per vCPU.
 gcp: 
   description: Machine types provided in Google Cloud
   cpu-series:
@@ -12,17 +29,17 @@ gcp:
       description: Intel Xeon Sapphire Rapids (4th Gen) processor.
       types:
         highcpu:
-            vcpus: &c3_vcpus [4, 8, 22, 44, 88, 176]
-            lssd: False
-            description: 2 GB of memory per vCPU.
+          vcpus: &c3_vcpus [4, 8, 22, 44, 88, 176]
+          lssd: False
+          description: 2 GB of memory per vCPU.
         standard:
-            vcpus: *c3_vcpus
-            lssd: True
-            description: 4 GB of memory per vCPU and possible local ssd integration.
+          vcpus: *c3_vcpus
+          lssd: True
+          description: 4 GB of memory per vCPU and possible local ssd integration.
         highmem:
-            vcpus: *c3_vcpus
-            lssd: False
-            description: 8 GB of RAM memory per vCPU.
+          vcpus: *c3_vcpus
+          lssd: False
+          description: 8 GB of RAM memory per vCPU.
     h3:
       description: |-
         (Available Soon) Intel Xeon Sapphire Rapids (4th Gen) processor.

--- a/inductiva/resources/machines.py
+++ b/inductiva/resources/machines.py
@@ -4,6 +4,7 @@ from absl import logging
 from typing import Literal
 from inductiva.resources import machines_base
 
+
 def _check_ice_args(num_machines: int, spot: bool):
 
     if num_machines > 1:

--- a/inductiva/resources/machines.py
+++ b/inductiva/resources/machines.py
@@ -51,7 +51,6 @@ class MachineGroup(machines_base.BaseMachineGroup):
             spot: Whether to use spot machines.
             data_disk_gb: The size of the disk for user data (in GB).
         """
-        provider = machines_base.ProviderType(provider)
 
         if num_machines < 1:
             raise ValueError(

--- a/inductiva/resources/machines.py
+++ b/inductiva/resources/machines.py
@@ -1,7 +1,7 @@
 """Classes to manage different Google Cloud machine group types."""
 from absl import logging
 
-from typing import Literal
+from typing import Union
 from inductiva.resources import machines_base
 
 
@@ -27,7 +27,7 @@ class MachineGroup(machines_base.BaseMachineGroup):
     def __init__(
         self,
         machine_type: str,
-        provider: Literal["GCP", "ICE"] = "GCP",
+        provider: Union[str, machines_base.ProviderType] = "GCP",
         num_machines: int = 1,
         spot: bool = False,
         data_disk_gb: int = 10,
@@ -51,6 +51,8 @@ class MachineGroup(machines_base.BaseMachineGroup):
             spot: Whether to use spot machines.
             data_disk_gb: The size of the disk for user data (in GB).
         """
+        provider = machines_base.ProviderType(provider)
+
         if num_machines < 1:
             raise ValueError(
                 "`num_machines` should be a number greater than 0.")

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -1,6 +1,7 @@
 """Base class for machine groups."""
 import time
 import enum
+from typing import Literal
 from abc import abstractmethod
 
 import logging
@@ -26,6 +27,7 @@ class BaseMachineGroup:
 
     def __init__(self,
                  machine_type: str,
+                 provider: Literal["GCP", "ICE"] = "GCP",
                  data_disk_gb: int = 10,
                  register: bool = True) -> None:
         """Create a BaseMachineGroup object.
@@ -43,13 +45,15 @@ class BaseMachineGroup:
                 example, when retrieving with the `machines_groups.get` method.
                 Users should not set this argument in anyway.
         """
-        if machine_type not in inductiva.resources.list_available_machines():
-            raise ValueError("Machine type not supported")
+        if machine_type not in inductiva.resources.list_available_machines(
+                provider.lower()):
+            raise ValueError(f"Machine type not supported in {provider}")
 
         if data_disk_gb <= 0:
             raise ValueError("`data_disk_gb` must be positive.")
 
         self.machine_type = machine_type
+        self.provider = provider
         self.data_disk_gb = data_disk_gb
         self._id = None
         self._name = None
@@ -80,8 +84,9 @@ class BaseMachineGroup:
         Returns:
             The unique ID and name identifying the machine on the API."""
 
-        instance_group_config = inductiva.client.models.GCPVMGroup(
+        instance_group_config = inductiva.client.models.VMGroupConfig(
             machine_type=self.machine_type,
+            provider_id=self.provider,
             disk_size_gb=self.data_disk_gb,
             **kwargs,
         )
@@ -117,6 +122,7 @@ class BaseMachineGroup:
         machine_group = cls(
             machine_type=resp["machine_type"],
             data_disk_gb=resp["disk_size_gb"],
+            provider=resp["provider_id"],
             register=False,
         )
         machine_group._id = resp["id"]
@@ -144,10 +150,11 @@ class BaseMachineGroup:
             return
 
         request_body = \
-            inductiva.client.models.GCPVMGroup(
+            inductiva.client.models.VMGroupConfig(
                 id=self.id,
                 name=self.name,
                 machine_type=self.machine_type,
+                provider_id=self.provider,
                 disk_size_gb=self.data_disk_gb,
                 **kwargs,
             )
@@ -180,10 +187,11 @@ class BaseMachineGroup:
             start_time = time.time()
 
             request_body = \
-                inductiva.client.models.GCPVMGroup(
+                inductiva.client.models.VMGroupConfig(
                     id=self.id,
                     name=self.name,
                     machine_type=self.machine_type,
+                    provider_id=self.provider,
                     disk_size_gb=self.data_disk_gb,
                     **kwargs,
                 )
@@ -204,6 +212,9 @@ class BaseMachineGroup:
         it verifies if the cost has already been estimated and returns
         it immediately if it has.
         """
+        if self.provider == "ICE":
+            return 0
+
         if self._estimated_cost is not None:
             return self._estimated_cost
 

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -1,7 +1,7 @@
 """Base class for machine groups."""
 import time
 import enum
-from typing import Literal
+from typing import Union
 from abc import abstractmethod
 
 import logging
@@ -14,6 +14,8 @@ from inductiva.client.apis.tags import compute_api
 from inductiva.client import exceptions
 from inductiva import logs
 
+from .machine_types import list_available_machines
+
 
 class ResourceType(enum.Enum):
     """Enum to represent the type of machine to be launched."""
@@ -22,12 +24,18 @@ class ResourceType(enum.Enum):
     MPI = "mpi"
 
 
+class ProviderType(enum.Enum):
+    """Enum to represent the provider of the machine to be launched."""
+    GCP = "GCP"
+    ICE = "ICE"
+
+
 class BaseMachineGroup:
     """Base class to manage Google Cloud resources."""
 
     def __init__(self,
                  machine_type: str,
-                 provider: Literal["GCP", "ICE"] = "GCP",
+                 provider: Union[ProviderType, str] = "GCP",
                  data_disk_gb: int = 10,
                  register: bool = True) -> None:
         """Create a BaseMachineGroup object.
@@ -45,15 +53,17 @@ class BaseMachineGroup:
                 example, when retrieving with the `machines_groups.get` method.
                 Users should not set this argument in anyway.
         """
-        if machine_type not in inductiva.resources.list_available_machines(
-                provider.lower()):
+
+        provider = ProviderType(provider)
+
+        if machine_type not in list_available_machines(provider.value.lower()):
             raise ValueError(f"Machine type not supported in {provider}")
 
         if data_disk_gb <= 0:
             raise ValueError("`data_disk_gb` must be positive.")
 
         self.machine_type = machine_type
-        self.provider = provider
+        self.provider = provider.value
         self.data_disk_gb = data_disk_gb
         self._id = None
         self._name = None

--- a/inductiva/tasks/methods.py
+++ b/inductiva/tasks/methods.py
@@ -45,7 +45,7 @@ def to_dict(list_of_tasks: Iterable[Task]) -> Mapping[str, List[Any]]:
         if executer is None:
             resource_type = None
         else:
-            resource_type = executer["vm_type"]
+            resource_type = executer["host_type"] + " " + executer["vm_type"]
             n_mpi_hosts = executer["n_mpi_hosts"]
             if n_mpi_hosts > 1:
                 resource_type += f" x{n_mpi_hosts}"

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -488,9 +488,8 @@ class Task:
             return None
 
         machine_info = info["executer"]
-        if "vm_type" not in machine_info:
-            return "inductiva-machine"
 
+        machine_provider = machine_info["host_type"]
         machine_type = machine_info["vm_type"].split("/")[-1]
 
-        return machine_type
+        return machine_provider + "-" + machine_type

--- a/inductiva/tests/resources/test_machines.py
+++ b/inductiva/tests/resources/test_machines.py
@@ -1,5 +1,7 @@
 """Unit tests for the Computational Resources classes."""
 from unittest import mock
+import pytest
+
 import inductiva
 
 
@@ -50,3 +52,52 @@ def test_machines__machine_group__register():
     assert cluster.num_machines == 2
     assert cluster.machine_type == "c2-standard-16"
     assert cluster.register is False
+
+
+@mock.patch.object(inductiva.resources.MachineGroup,
+                   attribute="_register_machine_group",
+                   new=fake_register)
+def test_machines__machine_group__ice_register():
+    """Check the registering of a MachineGroup with the ICE provider.
+    
+    Goal: Verify that the MachineGroup is initializating correctly based on a
+    mock registration and the ICE provider.
+    """
+
+    inductiva.api_key = "dummy"
+    machine = inductiva.resources.MachineGroup(machine_type="c2-highmem-4",
+                                               provider="ICE")
+
+    # Check that the cluster has been initialized correctly
+    assert machine.name == "name-resource"  # pylint: disable = protected-access
+    assert machine.id == "id-resource"  # pylint: disable = protected-access
+    assert machine.machine_type == "c2-highmem-4"
+    assert machine.register is False
+    assert machine.provider == "ICE"
+
+
+@mock.patch.object(inductiva.resources.MachineGroup,
+                   attribute="_register_machine_group",
+                   new=fake_register)
+def test_machines__ice_register__invalid_args():
+    """Check the registering of a MachineGroup with the ICE provider fails with
+    num_machines higher than one or spot True.
+    
+    Goal: Verify that the MachineGroup is initializating correctly based on a
+    mock registration and the ICE provider.
+    """
+
+    inductiva.api_key = "dummy"
+    with pytest.raises(ValueError) as exception:
+        inductiva.resources.MachineGroup(machine_type="c2-highmem-4",
+                                         num_machines=2,
+                                         provider="ICE")
+
+    assert "only supports launching one machine" in str(exception.value)
+
+    with pytest.raises(ValueError) as exception:
+        inductiva.resources.MachineGroup(machine_type="c2-highmem-4",
+                                         spot=True,
+                                         provider="ICE")
+
+    assert "only supports persistent machine" in str(exception.value)


### PR DESCRIPTION
This PR adds the ability to launch simulations in ICE (Inductiva Computing Cluster). There were a lot of small tweaks to be added, but in general the interface is super simple, one just needs to pass the provider on the `MachineGroup` class.

In general, I don't really like the current interface, because the ICE workflow is very different than GCP, that is, by launching a machine group in ICE, that machine is not reserved completely to me, and other people can submit to the same machine group.

Moreover, the names also don't seem appropriate at the moment, since in GCP `c2` refers to Intel Xeon, here it is Intel i9, and the vCPUs also break the logic of the GCP interface.