### PR TITLE
104 Add mypy as static type checker

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         sudo apt-get install -y libglu1-mesa ca-certificates
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install yapf coverage coverage-badge pylint pytest pytest-custom_exit_code toml pytest-markdown-docs
+        python -m pip install mypy yapf coverage coverage-badge pylint pytest pytest-custom_exit_code toml pytest-markdown-docs
         if [[ -f requirements.txt ]]; then python -m pip install -r requirements.txt; fi
     - name: Check formatting with yapf
       if: ${{ always() }}
@@ -77,4 +77,23 @@ jobs:
           git add ./badges/cov.svg && \
           git commit -m "Update coverage badge for commit ${GITHUB_SHA}")
         git push origin Inductiva-badges
-
+    - name: Mypy type checking
+      continue-on-error: true
+      if: ${{ always() }}
+      run: |
+        mypy . | nl > mypy_output.txt
+        
+        cat mypy_output.txt
+        echo "###############"
+        
+        : # Argument passed to a function has the wrong type
+        echo "--- Errors arg-type ---"
+        grep arg-type mypy_output.txt
+        grep arg-type mypy_output.txt | wc -l
+        echo "###############"
+        
+        : # function defenitions without types or missing types
+        echo "--- Errors no-untyped-def ---"
+        grep no-untyped-def mypy_output.txt
+        grep no-untyped-def mypy_output.txt | wc -l
+        echo "###############"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+# Global options:
+[mypy]
+
+exclude = inductiva/client/
+follow_imports = skip
+
+disallow_untyped_defs = True
+disallow_incomplete_defs = True


### PR DESCRIPTION
With this PR we run a Mypy check on all our code.
Mypy is a static type checker. With this we can ensure that you're using variables and functions correctly.

Mypy can be a bit strict for our use case. So, I made the action continue on error to more as a report and not a blocking step.
With time we can pick at error and decrease them with time.

The output of the report follows this structure:
-All errors-
#########
-arg type errors-
#########
-no untyped def errors-
#########