### PR TITLE
Build docs latest and development versions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -20,17 +20,31 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
+          ref: development
+          path: source-dev
+
+      - uses: actions/checkout@v2
+        with:
           ref: gh-pages
           path: build
 
       - uses: nicholasphair/sphinx-action@7.0.0
         with:
           docs-folder: "source/docs/"
-          build-command: "sphinx-build . ../../build"
+          build-command: "sphinx-build . ../../build/en/latest"
+
+      - uses: nicholasphair/sphinx-action@7.0.0
+        with:
+          docs-folder: "source-dev/docs/"
+          build-command: "sphinx-build . ../../build/en/development"
 
       - name: disable jekyll
         working-directory: build
         run: touch .nojekyll
+
+      - name: redirect to latest
+        working-directory: build
+        run: echo "<meta http-equiv=\"Refresh\" content=\"0; url='/en/latest/'\" />" > "index.html"
 
       - name: Commit and push changes to gh-pages
         working-directory: build


### PR DESCRIPTION
These changes will:

* Build docs from main branch and place them under /en/latest/
* Build docs from development branch and place them under /en/development/
* Create an index.html file on the root folder that will redirect the user to /en/latest/

Closes #1240 