### PR TITLE
Fix Windows OS bug on CLI

### DIFF
--- a/inductiva/_cli/main.py
+++ b/inductiva/_cli/main.py
@@ -9,7 +9,11 @@ import io
 import inductiva
 from inductiva import _cli
 from inductiva import constants, utils
-from . import loader, ansi_pager
+from . import loader
+try:
+    from . import ansi_pager
+except:
+    ansi_pager = None
 
 
 def get_main_parser():
@@ -84,8 +88,11 @@ def main():
     # Call the function associated with the subcommand
     try:
         if getattr(args, "watchable", False) and args.watch is not None:
-            cmd = " ".join(sys.argv[1:])
-            watch(args.func, args.watch, args, cmd)
+            if ansi_pager is None:
+                raise ImportError("watch module is not available.")
+            else:
+                cmd = " ".join(sys.argv[1:])
+                watch(args.func, args.watch, args, cmd)
         else:
             exit_code = args.func(args)
     except Exception as e:  # pylint: disable=broad-except

--- a/inductiva/_cli/utils.py
+++ b/inductiva/_cli/utils.py
@@ -6,7 +6,7 @@ import os
 import re
 
 import inductiva
-from inductiva import constants
+from inductiva import logs
 
 BEGIN_TAG = "# >>> INDUCTIVA BEGIN:"
 END_TAG = "# >>> INDUCTIVA END:"
@@ -45,7 +45,7 @@ def check_running_for_first_time():
 
     """
     version = inductiva.__version__
-    dir_name = constants.HOME_DIR / f"v{version}"
+    dir_name = logs.log.get_logs_file_path().parent / f"v{version}"
     if not os.path.exists(dir_name):
         os.mkdir(dir_name)
         return True
@@ -87,7 +87,7 @@ def setup_zsh_autocompletion():
 
     """
     version = inductiva.__version__
-    version_dir = constants.HOME_DIR / f"v{version}"
+    version_dir = logs.log.get_logs_file_path().parent / f"v{version}"
     assets_dir = pathlib.Path(inductiva.__path__[0]) / "assets"
     shutil.copytree(assets_dir, version_dir, dirs_exist_ok=True)
 


### PR DESCRIPTION
This PR fixes some bugs on the CLI for windows OS, due to the non-existence of the module `termios`. With these changes we verify if the module exists and if not, we don't allow to run watch method.