### PR TITLE
Exclude files from build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,10 @@ main_doc = 'index'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns = [
+    'markdown_sample.md',
+    'task_state_diagram.md',
+]
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
This PR excludes the following files from the build:

* `markdown_sample.md`
* `task_state_diagram.md`

Closes #1270 