### PR TITLE
Set correct code blocks language

### DIFF
--- a/docs/cli/access-storage.md
+++ b/docs/cli/access-storage.md
@@ -9,10 +9,11 @@ simulation outputs.
 
 You can check how much storage space your simulations are currently occupying:
 
-```bash
+```console
 $ inductiva storage size
 Total user's remote storage in use: 2.79 GB
 ```
+
 ## List Storage Contents
 
 You can have a detailed view of what's in your storage, including sorting options 
@@ -43,7 +44,7 @@ Here's an example where you remove a path within your storage. Use this command
 with caution as it permanently deletes data from your remote 
 storage: 
 
-```bash
+```console
 $ inductiva storage remove hodbisrxjxhdbkknv60xmy6ti/
 # The CLI always prompts for confirmation to prevent accidental data loss
 You are about to remove the following paths from your remote storage space:

--- a/docs/how_to/manage-remote-storage.md
+++ b/docs/how_to/manage-remote-storage.md
@@ -103,7 +103,7 @@ inductiva.storage.rmdir(path="reef3d_simulation")
 
 **CLI**
 
-```bash
+```console
 $ inductiva storage rm reef3d_simulation
 You are about to remove the following paths from your remote storage space:
   - reef3d_simulation

--- a/docs/how_to/manage_and_retrieve_results.md
+++ b/docs/how_to/manage_and_retrieve_results.md
@@ -80,7 +80,7 @@ Downloading the outputs of a task is a common operation. In the following
 snippets, we show how to download the outputs of a finished task and how to
 control which files and where those files are downloaded to.
 
-```python
+```console
 # Download all the files produced by the task
 >>> output_dir = task.download_outputs()
 Downloading simulation outputs to inductiva_output/i4ir3kvv62odsfrhko4y8w2an/output.zip.
@@ -140,7 +140,7 @@ PosixPath('i4ir3kvv62odsfrhko4y8w2an')
 The `download_outputs` method of the `Task` class has the option to specify the
 name of the folder where the outputs are downloaded inside the parent directory.
 
-```python
+```console
 # reset the parent directory name to the default
 >>> inductiva.set_output_dir("inductiva_outputs")
 >>> output_dir = task.download_outputs(output_dir="my_outputs")
@@ -156,7 +156,7 @@ configure which files to download. By default, all files produced by the task ar
 downloaded. However, the user can select to retrieve only a subset of those files
 by specifying the filenames of interest:
 
-```python
+```console
 # Download only the files of interest
 >>> output_dir = task.download_outputs(filenames=["stdout.txt", "stderr.txt"]
                                        output_dir="my_outputs")


### PR DESCRIPTION
This PR sets the correct (or at the least the closest match to prevent warnings) syntax on code blocks.

Closes #1271 