### PR TITLE
Fix broken links and anchors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.md]
+max_line_length = 80
+

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -11,17 +11,17 @@ on state-of-the-art hardware. This allows scientists and engineers to focus thei
 time and energy on what matters: running simulations that solve real problems.
 
 This documentation includes:
-- A [Getting started](get_started/installation.md) guide that will help you set up the Inductiva
+- A [Getting started](/get_started/installation.md) guide that will help you set up the Inductiva
 API client, and run your first simulation within only a few minutes;
-- An [Explore the API section](explore_api/how_it_works.md) where we will give
+- An [Explore the API section](/explore_api/how_it_works.md) where we will give
 you a comprehensive overview of how the API works, explaining key concepts and how
 different components play together;
-- A [How-To section](how_to/run-parallel_simulations.md) where we will guide you through several common tasks, and which
+- A [How-To section](/how_to/run-parallel_simulations.md) where we will guide you through several common tasks, and which
 provides practical examples for you to try;
 - A [list of the various open-source simulation packages](simulators/index.md) that you can invoke via the
 API (if you have suggestions for adding more simulation packages, please let us know
 by [opening a GitHub issue](https://github.com/inductiva/inductiva/issues));
-- A guide on [Inductiva’s Command Line Interface (CLI)](cli/cli-overview.md), which
+- A guide on [Inductiva’s Command Line Interface (CLI)](/cli/cli-overview.md), which
 allows you to perform many tasks from your terminal, including listing available
 computational resources and checking the status of tasks;
 - A [User Reference](/api_reference/computational_resources/index.md) section 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,9 @@ exclude_patterns = [
     'task_state_diagram.md',
 ]
 
+# Auto generate header anchors
+myst_heading_anchors = 3
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/explore_api/configuring-simulators.md
+++ b/docs/explore_api/configuring-simulators.md
@@ -19,6 +19,7 @@ Obviously, there is a lot more happening under the hood. For starters, how do we
 with the fact that not all simulation software packages work in the same way and, 
 therefore, having a fully general formulation for a simulation task is not trivial? 
 
+(the-simple-cases)=
 ## The simple cases
 
 Some simulation packages offer a single executable that takes as input a single 
@@ -80,6 +81,7 @@ As you can see, besides the input directory we pass one additional parameter to
 the `run()` method: `sim_config_filename`. This refers to the main configuration
 file that the simulator executable expects and for which there is no standard name is expected.
 
+(a-slightly-more-complex-case)=
 ## A slightly more complex case
 
 Some simulators require running more than one executable to perform a simulation, 
@@ -116,6 +118,7 @@ configuration files used by each executable. So, as you can see above, there is
 no requirement to pass the `sim_config_filename` parameter. All REEF3D needs is a
 pointer to the folder containing all the assets required for the simulation.
 
+(running-long-simulation-pipelines)=
 ## Running long simulation pipelines
 
 In other simulation packages, a single simulation is more configurable and different

--- a/docs/explore_api/how_it_works.md
+++ b/docs/explore_api/how_it_works.md
@@ -26,7 +26,7 @@ nuances and additional options available, which we'll explore in detail througho
 this section. More specifically, you'll become familiarized with how the API 
 works:
 
-- [Tasks](./tasks): Learn about tasks, the API's core computational object, which 
+- [Tasks](./tasks.md): Learn about tasks, the API's core computational object, which 
 gets created when you submit your simulation request, enabling you to track its 
 progress and access its outputs in real-time.
 

--- a/docs/explore_api/tasks.md
+++ b/docs/explore_api/tasks.md
@@ -108,6 +108,8 @@ with task.sync_context():
     task.wait()  # <- The remote simulation WILL DIE if the local session is
                  #     interrupted while waiting for the wait() call to return
 ```
+
+(task-lifecyle)=
 ## Task Lifecycle
 
 The status of a task changes as it progresses through its lifecycle. Understanding 

--- a/docs/how_to/manage_and_retrieve_results.md
+++ b/docs/how_to/manage_and_retrieve_results.md
@@ -12,7 +12,7 @@ will cover the following topics:
    of a task and control where the files are downloaded to.
 
 Most of the topics that follow rely on the `Task` class. Please refer to the
-[Task documentation](../introduction/tasks.md) for more information about it.
+[Task documentation](../explore_api/tasks.md) for more information about it.
 
 ## Saving simulation outputs
 
@@ -70,7 +70,7 @@ accomplished programmatically using the `inductiva.storage.listdir` function:
 inductiva.storage.listdir(max_results=10, order_by="creation_time", sort_order="desc")
 ```
 
-Refer to the [Storage how-to documentation](storage.md) for more information
+Refer to the [Storage how-to documentation](manage-remote-storage.md) for more information
 on how to manage the user's remote storage space.
 
 

--- a/docs/how_to/manage_tasks.md
+++ b/docs/how_to/manage_tasks.md
@@ -17,7 +17,7 @@ In this section, we will cover the following topics:
 The `Task` class provides mechanisms to track and manage the status of a task.
 With a `Task` object at hand, the user can:
  * Get the status, i.e., whether the task is started, succeeded, failed, etc
- (see the section about [task lifecycle](../explore_api/tasks#task-lifecycle.md)
+ (see the section about [task lifecycle](../explore_api/tasks.md#task-lifecycle)
  for more details);
  * Get the machine type where it ran/is running;
  * Get the execution time.
@@ -70,9 +70,9 @@ running simulation has gone rogue, or simply because there is no other reason
 to allow a task to proceed, the user can kill a task. The `Task` class provides
 a method to kill a task that hasn't been completed yet. Tasks in the
 `PENDING INPUT`, `SUBMITTED` and `STARTED` states can be killed (see the section
-on [task lifecycle](../introduction/tasks#task-lifecycle)).
+on [task lifecycle](../explore_api/tasks.md#task-lifecycle)).
 
-To kill a task programmatically, one has 2 options at hand: by declaratively
+To kill a task programmatically, one has 2 options at hand: by declarative
 calling the `kill` method or interrupting the python session/script
 when a task is being waited in the context of a `sync_context` call:
 

--- a/docs/simulators/SCHISM.md
+++ b/docs/simulators/SCHISM.md
@@ -1,6 +1,6 @@
 # SCHISM
 
-The [SCHISM](http://ccrm.vims.edu/schismweb/) simulator is an open
+The [SCHISM](https://ccrm.vims.edu/schismweb/) simulator is an open
 source simulator for the simulation of 3D baroclinic circulation
 across creek-lake-river-estuary-shelf-ocean scales.
 


### PR DESCRIPTION
This PR fixes a number of broken links and anchors.

For links pointing to headers I've defined [explicit targets](https://myst-parser.readthedocs.io/en/latest/syntax/cross-referencing.html#creating-explicit-targets). This required setting auto generated header anchors. See MyST parser [docs](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#auto-generated-header-anchors) for extra details.

[Implicit targets](https://myst-parser.readthedocs.io/en/latest/syntax/cross-referencing.html#implicit-targets) that don't required setting a `(target)=` annotation can be used but are discouraged since they are prone to accidental breakage.

Closes #1275 