### PR TITLE
Machine group started now comes from the back end

### DIFF
--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -135,7 +135,7 @@ class BaseMachineGroup:
         machine_group.provider = resp["provider_id"]
         machine_group._name = resp["name"]
         machine_group.create_time = resp["creation_timestamp"]
-        machine_group._started = True
+        machine_group._started = bool(resp["started"])
 
         return machine_group
 

--- a/inductiva/tests/resources/test_machine_groups.py
+++ b/inductiva/tests/resources/test_machine_groups.py
@@ -14,6 +14,7 @@ BASE_RESPONSE = {
     "num_vms": 2,
     "min_vms": 1,
     "provider_id": "GCP",
+    "started": False,
 }
 
 RESPONSE_1 = {**BASE_RESPONSE, **{"type": "standard", "is_elastic": False}}


### PR DESCRIPTION
Previously we were putting the machine group _started attribute always True. With this PR we use the started value that the back end sends.