### PR TITLE
Run build-docs action also on push to development

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,7 +2,7 @@ name: GH Pages Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [main, development]
     paths-ignore:
       - README.md
 


### PR DESCRIPTION
This ensures that `gh-pages` branch is updated when pushing to development branch as well as main.

Closes #1281 