### PR TITLE
Fix documentation how to section link

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -18,7 +18,7 @@ you a comprehensive overview of how the API works, explaining key concepts and h
 different components play together;
 - A [How-To section](/how_to/index.md) where we will guide you through several common tasks, and which
 provides practical examples for you to try;
-- A [list of the various open-source simulation packages](simulators/overview.md) that you can invoke via the
+- A [list of the various open-source simulation packages](/simulators/overview.md) that you can invoke via the
 API (if you have suggestions for adding more simulation packages, please let us know
 by [opening a GitHub issue](https://github.com/inductiva/inductiva/issues));
 - A guide on [Inductiva’s Command Line Interface (CLI)](/cli/cli-overview.md), which
@@ -27,7 +27,7 @@ computational resources and checking the status of tasks;
 - A [User Reference](/api_reference/computational_resources/index.md) section 
 that covers a wide variety of topics of interest, including information about
 some key classes available in the API Client, a troubleshooting guide, information
-about quotas and an [FAQ](api_reference/faq.md).
+about quotas and an [FAQ](/api_reference/faq.md).
 
 If you have any questions or suggestions about the API please [open an issue on the inductiva’s API Client GitHub repo](https://github.com/inductiva/inductiva/issues), or contact us via [support@inductiva.ai](mailto:support@inductiva.ai).
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -16,7 +16,7 @@ API client, and run your first simulation within only a few minutes;
 - An [Explore the API section](/explore_api/how_it_works.md) where we will give
 you a comprehensive overview of how the API works, explaining key concepts and how
 different components play together;
-- A [How-To section](/how_to/run-parallel_simulations.md) where we will guide you through several common tasks, and which
+- A [How-To section](/how_to/index.md) where we will guide you through several common tasks, and which
 provides practical examples for you to try;
 - A [list of the various open-source simulation packages](simulators/overview.md) that you can invoke via the
 API (if you have suggestions for adding more simulation packages, please let us know

--- a/docs/how_to/index.md
+++ b/docs/how_to/index.md
@@ -1,8 +1,14 @@
 # How to
 
 ```{toctree}
-computational_resources
-mpi_cluster
-storage
-templating
+---
+maxdepth: 1
+---
+manage_and_retrieve_results
+manage_computational_resources
+manage-remote-storage
+manage_tasks
+run-parallel_simulations
+set-up-elastic-machine-group
+set-up-mpi-cluster
 ```


### PR DESCRIPTION
This PR moves the Homepage "How-To section" link from

https://docs.inductiva.ai/en/latest/how_to/run-parallel_simulations.html

to

https://docs.inductiva.ai/en/latest/how_to/index.html

## Screenshots

![image](https://github.com/inductiva/inductiva/assets/8961441/081e72e5-30af-4bd9-85f3-dbaff2dd2212)

The How to section is very _lean_ right now but it gets the job done.