### PR TITLE
Open external links on a new tab

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,8 @@ exclude_patterns = [
     'task_state_diagram.md',
 ]
 
+myst_links_external_new_tab = True
+
 # Auto generate header anchors
 myst_heading_anchors = 3
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ sphinx
 sphinx_rtd_theme
 sphinx-book-theme
 sphinxcontrib-mermaid
-myst-parser
+myst-parser @ git+https://github.com/executablebooks/MyST-Parser@fc64840b5f009021d64173d81c2f244fb0d8a43d
 sphinx-copybutton
 sphinx-tabs
 sphinx-togglebutton


### PR DESCRIPTION
This improvement relies on an unreleased version of MystParser.

This means pointing to a specific Git commit hash instead of the latest version of myst-parser.

See https://github.com/executablebooks/MyST-Parser/issues/856

I've checked before/after versions of the whole site and the only changes this adds are indeed `target="_blank"` properties on HTML anchors pointing to external URLs.
