### PR TITLE
Revert "Open external links on a new tab"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,8 +62,6 @@ exclude_patterns = [
     'task_state_diagram.md',
 ]
 
-myst_links_external_new_tab = True
-
 # Auto generate header anchors
 myst_heading_anchors = 3
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ sphinx
 sphinx_rtd_theme
 sphinx-book-theme
 sphinxcontrib-mermaid
-myst-parser @ git+https://github.com/executablebooks/MyST-Parser@fc64840b5f009021d64173d81c2f244fb0d8a43d
+myst-parser
 sphinx-copybutton
 sphinx-tabs
 sphinx-togglebutton


### PR DESCRIPTION
Previous 3bdb48093fbfd33d5b3c8747c427590a664d42bb commit broke the build since it requires additional configuration for `sphinx-action` GitHub action.