### PR TITLE
Set up nicholasphair/sphinx-action@7.0.0 in order to use myst-parser version pinned to commit hash

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -31,11 +31,15 @@ jobs:
       - uses: nicholasphair/sphinx-action@7.0.0
         with:
           docs-folder: "source/docs/"
+          # required by #1291
+          pre-build-command: "apt-get update -y && apt-get install -y git"
           build-command: "sphinx-build . ../../build/en/latest"
 
       - uses: nicholasphair/sphinx-action@7.0.0
         with:
           docs-folder: "source-dev/docs/"
+          # required by #1291
+          pre-build-command: "apt-get update -y && apt-get install -y git"
           build-command: "sphinx-build . ../../build/en/development"
 
       - name: disable jekyll


### PR DESCRIPTION
#1291 introduced the generation of external links but broke the build since `nicholasphair/sphinx-action@7.0.0` action requires an additional configuration in order to make use of Git based package versions.

Relevant error: https://github.com/inductiva/inductiva/actions/runs/8524764950/job/23351713615#step:6:10

See [nicholasphair/sphinx-action@7.0.0](https://github.com/ammaraskar/sphinx-action/issues/13) for reference.

Closes #1291 