### PR TITLE
Handle warnings as errors

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -33,14 +33,14 @@ jobs:
           docs-folder: "source/docs/"
           # required by #1291
           pre-build-command: "apt-get update -y && apt-get install -y git"
-          build-command: "sphinx-build . ../../build/en/latest -D version=latest"
+          build-command: "sphinx-build . ../../build/en/latest -W -D version=latest"
 
       - uses: nicholasphair/sphinx-action@7.0.0
         with:
           docs-folder: "source-dev/docs/"
           # required by #1291
           pre-build-command: "apt-get update -y && apt-get install -y git"
-          build-command: "sphinx-build . ../../build/en/development -D version=development"
+          build-command: "sphinx-build . ../../build/en/development -W -D version=development"
 
       - name: disable jekyll
         working-directory: build

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# Inductiva Documentation
+
+## Documentation build tips
+
+When working on the documentation it can be rather useful to run a local
+build of the static site and have it reload when any changes are detected.
+
+This can be performed in a very straightforward way using [sphinx-autobuild](https://github.com/sphinx-doc/sphinx-autobuild#readme)
+
+### Set Python 3.8 as the local Python version for the build
+
+We'll be using [PyEnv](https://github.com/pyenv/pyenv) for this first step but
+feel free to use any other Python version manager.
+
+```console
+brew update
+brew install pyenv
+cd docs
+pyenv install 3.8
+pyenv local 3.8
+```
+
+### Install `sphinx-autobuild`
+
+```console
+pip install sphinx-autobuild
+```
+
+### Launch a local documentation build and monitor it for changes
+
+```console
+sphinx-autobuild . /tmp/inductiva-docs -W
+```
+
+* `sphinx-autobuild . /tmp/inductiva-docs` will build the docs and watch for
+changes
+* `-W` will handle [warnings as errors](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-W)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ main_doc = 'index'
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
+    'README.md',
     'markdown_sample.md',
     'task_state_diagram.md',
 ]


### PR DESCRIPTION
This ensures that **any warning will break the build** thus preventing issues like broken links, badly configured codeblocks or other quality reducing problems to be silently introduced into the generated site.

A `docs/README.md` with build tips was also added.

## Screenshots

![image](https://github.com/inductiva/inductiva/assets/8961441/06b99dab-1e29-45d6-b021-57a554e6af26)


Closes #1315 