### PR TITLE
Fix remote tutorials path and create separate build and deploy actions

### DIFF
--- a/.github/workflows/build-tutorials.yml
+++ b/.github/workflows/build-tutorials.yml
@@ -48,12 +48,11 @@ jobs:
       #   working-directory: source/tutorials
       #   run: cp robots.txt ../../build/
 
-      - name: Deploy to staging webserver via rsync
-        uses: burnett01/rsync-deployments@7.0.0
-        with:
-          switches: -avzr --delete --no-perms --no-owner --no-group --omit-dir-times
-          path: build
-          remote_path: /var/www/tutorials.inductiva.ai/
-          remote_host: ${{secrets.STAGING_SERVER}}
-          remote_user: inductiva-bot
-          remote_key: ${{secrets.STAGING_WEB_SSH_KEY}}
+      - name: Commit and push changes to tutorials branch
+        working-directory: build
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git add .
+          git commit -m "Update Tutorials from Sphinx build for commit ${GITHUB_SHA}"
+          git push origin tutorials

--- a/.github/workflows/deploy-tutorials-to-staging.yml
+++ b/.github/workflows/deploy-tutorials-to-staging.yml
@@ -1,4 +1,4 @@
-name: Deploy Docs to Staging Server
+name: Deploy Tutorials to Staging Server
 
 on:
   workflow_dispatch:
@@ -10,14 +10,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: 'gh-pages' # Make sure this is the branch with your site's code
+        ref: 'tutorials' # Make sure this is the branch with your site's code
         
     - name: Deploy to staging webserver via rsync
       uses: burnett01/rsync-deployments@7.0.0
       with:
-        switches: -avzr --delete
+        switches: -avzr --delete --no-perms --no-owner --no-group --omit-dir-times
         path: .
-        remote_path: /var/www/${{ secrets.STAGING_SERVER }}/docs/
+        remote_path: /var/www/${{ secrets.STAGING_SERVER }}/tutorials/
         remote_host: ${{secrets.STAGING_SERVER}}
         remote_user: inductiva-bot
         remote_key: ${{secrets.STAGING_WEB_SSH_KEY}}


### PR DESCRIPTION
This PR:

* Fixes the rsync tutorials upload path
* Splits the previous build+deploy action separate build and deploy actions (same structure as we have for /docs)