### PR TITLE
Add mpi enabled to cans and amr

### DIFF
--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from inductiva import types, tasks, simulators
 
+
 @simulators.simulator.mpi_enabled
 class AmrWind(simulators.Simulator):
     """Class to invoke a generic AmrWind simulation on the API.

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from inductiva import types, tasks, simulators
 
-
+@simulators.simulator.mpi_enabled
 class AmrWind(simulators.Simulator):
     """Class to invoke a generic AmrWind simulation on the API.
     """

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from inductiva import types, tasks, simulators
 
-
+@simulators.simulator.mpi_enabled
 class CaNS(simulators.Simulator):
     """Class to invoke a generic CaNS simulation on the API.
 

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from inductiva import types, tasks, simulators
 
+
 @simulators.simulator.mpi_enabled
 class CaNS(simulators.Simulator):
     """Class to invoke a generic CaNS simulation on the API.


### PR DESCRIPTION
This pr adds @simulators.simulator.mpi_enabled to the two new mpi simulators.