### PR TITLE
Submits the task to the current opened project

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -336,11 +336,22 @@ def submit_task(api_instance, method_name, request_params, resource_pool,
     if resource_pool is not None:
         resource_pool_id = resource_pool.id
 
-    task_request = TaskRequest(method=method_name,
-                               params=request_params,
-                               resource_pool=resource_pool_id,
-                               storage_path_prefix=storage_path_prefix,
-                               provider_id=provider_id.value)
+    current_project = inductiva.projects.get_current_project()
+    if current_project is not None:
+        if not current_project.append:
+            raise PermissionError(
+                "Trying to log task to project with `append=False`.")
+        current_project = current_project.name
+
+    task_request = TaskRequest(
+        method=method_name,
+        params=request_params,
+        resource_pool=resource_pool_id,
+        storage_path_prefix=storage_path_prefix,
+        provider_id=provider_id.value,
+        project=current_project,
+    )
+
     task = submit_request(
         api_instance=api_instance,
         request=task_request,

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -338,9 +338,8 @@ def submit_task(api_instance, method_name, request_params, resource_pool,
 
     current_project = inductiva.projects.get_current_project()
     if current_project is not None:
-        if not current_project.append:
-            raise PermissionError(
-                "Trying to log task to project with `append=False`.")
+        if not current_project.opened:
+            raise RuntimeError("Trying to submit a task to a closed project.")
         current_project = current_project.name
 
     task_request = TaskRequest(

--- a/inductiva/projects/project.py
+++ b/inductiva/projects/project.py
@@ -147,7 +147,7 @@ class Project:
         self._info = ProjectInfo(**model.get("task_status_overview"))
         self.created_at = model.get("created_at")
         self.num_tasks = model.get("num_tasks")
-        self.name = model.get("name")
+        self._name = model.get("name")
         self.id = model.get("id")
 
         return self
@@ -165,7 +165,10 @@ class Project:
             `get_current_project` returns something other than None.
 
         """
-        _logger.debug("Opening project %s", self.name)
+        if not self.append:
+            raise RuntimeError("Trying to open a project with `append=False`.")
+
+        _logger.debug("Opening project %s", self._name)
         current_project = get_current_project()
 
         if current_project is self:
@@ -191,6 +194,10 @@ class Project:
 
         _CURRENT_PROJECT.reset(self._token)
         self._token = None
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     @property
     def opened(self) -> bool:
@@ -219,13 +226,13 @@ class Project:
         suitable when up-to-date information is required.
 
         """
-        name = self.name
+        name = self._name
         model = self._get_model(name)
         self._update_from_api_response(model)
         return self._info
 
     def __str__(self) -> str:
-        return f"Project '{self.name}' with "\
+        return f"Project '{self._name}' with "\
                f"{self.num_tasks} tasks (id={self.id})"
 
     def desc(self) -> str:

--- a/inductiva/tests/api/test_methods.py
+++ b/inductiva/tests/api/test_methods.py
@@ -1,0 +1,26 @@
+"""Tests for inductiva/api/methods.py"""
+from unittest import mock
+import pytest
+
+import inductiva
+
+
+def test_submit_to_project_with_append_false_fails():
+    """Tests if submiting a task to a closed project fails"""
+    with mock.patch.object(inductiva.projects.Project,
+                           "_get_model") as mock_get_model, mock.patch.object(
+                               inductiva.projects.Project, "_create_model"):
+        mock_get_model.return_value = {
+            "task_status_overview": {},
+            "created_at": "today",
+            "num_tasks": 0,
+            "name": "test_project",
+            "id": "29034urjeoi49"
+        }
+
+        project = inductiva.projects.Project(name="test_project", append=False)
+
+        with project:
+            with pytest.raises(PermissionError):
+                inductiva.api.methods.submit_task(None, "dummy_method", {},
+                                                  None, "", None, "", "gcp")

--- a/inductiva/tests/api/test_methods.py
+++ b/inductiva/tests/api/test_methods.py
@@ -4,11 +4,15 @@ import pytest
 
 import inductiva
 
+MOCK_PATH_PROJECTS = "inductiva.projects.project.projects_api.ProjectsApi"
+MOCK_PATH_CLIENT = "inductiva.projects.project.inductiva.api.get_client"
+
 
 def test_submit_to_closed_project_fails():
     """Test if submitting to a closed project raises an exception."""
-    with mock.patch(
-            "inductiva.projects.get_current_project") as mock_get_project:
+    with mock.patch("inductiva.projects.get_current_project"
+                   ) as mock_get_project, mock.patch(
+                       MOCK_PATH_PROJECTS), mock.patch(MOCK_PATH_CLIENT):
         project = inductiva.projects.Project(name="test_project")
         mock_get_project.return_value = project
 

--- a/inductiva/tests/api/test_methods.py
+++ b/inductiva/tests/api/test_methods.py
@@ -5,22 +5,14 @@ import pytest
 import inductiva
 
 
-def test_submit_to_project_with_append_false_fails():
-    """Tests if submiting a task to a closed project fails"""
-    with mock.patch.object(inductiva.projects.Project,
-                           "_get_model") as mock_get_model, mock.patch.object(
-                               inductiva.projects.Project, "_create_model"):
-        mock_get_model.return_value = {
-            "task_status_overview": {},
-            "created_at": "today",
-            "num_tasks": 0,
-            "name": "test_project",
-            "id": "29034urjeoi49"
-        }
+def test_submit_to_closed_project_fails():
+    """Test if submitting to a closed project raises an exception."""
+    with mock.patch(
+            "inductiva.projects.get_current_project") as mock_get_project:
+        project = inductiva.projects.Project(name="test_project")
+        mock_get_project.return_value = project
 
-        project = inductiva.projects.Project(name="test_project", append=False)
-
-        with project:
-            with pytest.raises(PermissionError):
-                inductiva.api.methods.submit_task(None, "dummy_method", {},
-                                                  None, "", None, "", "gcp")
+        assert not project.opened
+        with pytest.raises(RuntimeError):
+            inductiva.api.methods.submit_task(None, "dummy_method", {}, None,
+                                              "", None, "", "gcp")

--- a/inductiva/tests/projects/test_projects.py
+++ b/inductiva/tests/projects/test_projects.py
@@ -14,14 +14,14 @@ def test_open_project_and_close():
     with mock.patch(MOCK_PATH_PROJECTS), mock.patch(MOCK_PATH_CLIENT):
         assert inductiva.projects.get_current_project() is None
 
-        with inductiva.projects.Project("test_project") as project:
+        with inductiva.projects.Project("test_project", append=True) as project:
             assert inductiva.projects.get_current_project() == project
             assert project.opened
 
         assert inductiva.projects.get_current_project() is None
         assert not project.opened
 
-        project = inductiva.projects.Project("test_project")
+        project = inductiva.projects.Project("test_project", append=True)
         project.open()
         assert inductiva.projects.get_current_project() == project
         assert project.opened
@@ -37,8 +37,8 @@ def test_open_project_without_closing():
         expected_message = "another is active."
 
         with pytest.raises(Exception) as exc_info:
-            project_1 = inductiva.projects.Project(name="p1")
-            project_2 = inductiva.projects.Project(name="p2")
+            project_1 = inductiva.projects.Project(name="p1", append=True)
+            project_2 = inductiva.projects.Project(name="p2", append=True)
             project_1.open()
             project_2.open()
         assert expected_message in str(exc_info.value)
@@ -47,8 +47,21 @@ def test_open_project_without_closing():
         project_1.close()
 
         with pytest.raises(Exception) as exc_info:
-            with inductiva.projects.Project(name="p1"):
-                with inductiva.projects.Project(name="p2"):
+            with inductiva.projects.Project(name="p1", append=True):
+                with inductiva.projects.Project(name="p2", append=True):
                     pass
         assert expected_message in str(exc_info.value)
         assert inductiva.projects.get_current_project() is None
+
+
+def test_open_project_with_append_raises_exception():
+    """Tests if opening a project with append=False raises an exception."""
+    with mock.patch(MOCK_PATH_PROJECTS), mock.patch(MOCK_PATH_CLIENT):
+        project = inductiva.projects.Project(name="project", append=False)
+
+        with pytest.raises(RuntimeError):
+            project.open()
+
+        with pytest.raises(RuntimeError):
+            with inductiva.projects.Project(name="project", append=False):
+                pass


### PR DESCRIPTION
This pull request adds the option to submit tasks to the current opened project.

Usage should look something like this:

```python
import inductiva

p = inductiva.projects.Project("my project", append=True)

input_dir = inductiva.utils.download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "splishsplash-input-example.zip",
    unzip=True)

simulator = inductiva.simulators.SplishSplash()

# Submitted to the default project
task = simulator.run(input_dir=input_dir, sim_config_filename="config.json")

with p:
    # Submitted to `"my project"`
    task = simulator.run(
        input_dir=input_dir,
        sim_config_filename="config.json",
    )

# Submitted to the default project
task = simulator.run(input_dir=input_dir, sim_config_filename="config.json")

```