### PR TITLE
Use makedirs with exist_ok=True when creating logs dir

### DIFF
--- a/inductiva/logs/log.py
+++ b/inductiva/logs/log.py
@@ -61,8 +61,7 @@ def setup(level=logging.INFO):
 
     logs_file_path = get_logs_file_path()
     logs_file_dir = logs_file_path.parent
-    if not os.path.exists(logs_file_dir):
-        os.mkdir(logs_file_dir)
+    os.makedirs(logs_file_dir, exist_ok=True)
 
     handlers = [
         logging.handlers.RotatingFileHandler(logs_file_path,


### PR DESCRIPTION
Avoid race conditions if multiple processes using the inductiva package are launched concurrently.