### PR TITLE
Changing titles for better SEO

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,6 +1,6 @@
 # Inductiva: a Python package for scaling simulations on the Cloud
 
-Welcome to the official Python library for the Inductiva API version 0.5 
+Welcome to the official Python library for the Inductiva API version 0.7 
 The Inductiva API allows running a set of open-source physical
 simulators on the cloud, easily parallelizing simulations, each running
 on hundreds of CPU cores.
@@ -15,7 +15,7 @@ This documentation includes:
 help you set up the Inductiva API client, and run your first simulation
 within only a few minutes;
 - A [Quick Recipes](./how_to/index.md) where we will guide you through
-several common tasks, and which provides practical examples for you to try;
+several common tasks and provides practical examples for you to try;
 - A [list of the various open-source simulation packages](./simulators/overview.md)
 that you can invoke via the API (if you have suggestions for adding more
 simulation packages, please let us know by

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,8 @@ html_static_path = ['_static']
 
 html_favicon = 'favicon.ico'
 
+html_title = 'Python API for Cloud-based Simulation'
+
 # Google Analytics
 googleanalytics_id = "UA-188572165-1"
 googleanalytics_enabled = True

--- a/tutorials/conf.py
+++ b/tutorials/conf.py
@@ -92,6 +92,8 @@ html_static_path = ['_static']
 
 html_favicon = 'favicon.ico'
 
+html_title = 'Python API for Cloud-based Simulation'
+
 # Google Analytics
 googleanalytics_id = "UA-188572165-1"
 googleanalytics_enabled = True


### PR DESCRIPTION
Currently we have this sort of titles being index in google

<img width="714" alt="Screenshot 2024-05-18 at 19 02 40" src="https://github.com/inductiva/inductiva/assets/1358685/c84ffd87-ce4f-42ce-92fe-cf40f66df006">

We want to make the second part of the title more informative for the user.
We removed Inductiva (it's already on the top and on the link) and we made it more explicit that this is about cloud-based simulation (for now), which is probably more catchy.

Obviously, we can iterate on this. This is just the first step.