### PR TITLE
Links to benchmarks

### DIFF
--- a/docs/simulators/AmrWind.md
+++ b/docs/simulators/AmrWind.md
@@ -1,14 +1,16 @@
 # Amr-Wind
 
-[Amr-Wind](https://github.com/Exawind/amr-wind) stands as a robustly parallel,
+[AMR-Wind](https://github.com/Exawind/amr-wind) stands as a robustly parallel,
 block-structured adaptive-mesh solver tailored for simulating incompressible
 flows in wind turbines and wind farms. Derived from incflo, its codebase
 emphasizes wind-related computations. The solver harnesses the power of the
-AMReX library, which furnishes essential components such as mesh data structures,
-adaptivity features, and linear solvers crucial for tackling the governing equations.
+AMReX library, which furnishes essential components such as mesh data
+structures, adaptivity features, and linear solvers crucial for tackling the
+governing equations.
 
-Amr-Wind has been built using OpenMPI 4.1.2. We're currently operating on Amr-Wind
-version 1.4.0 for CPU, with a GPU version slated for release in the near future.
+AMR-Wind has been built using OpenMPI 4.1.2. We're currently operating on 
+AMR-Wind version 1.4.0 for CPU, with a GPU version slated for release in the
+near future.
 
 ## Example
 
@@ -33,3 +35,11 @@ task.wait()
 task.download_outputs()
 
 ```
+
+## What to read next
+
+If you are interested in AMR-Wind, you may also be interested in checking the
+following related simulators that are also avaiable via Inductiva API:
+
+* [OpenFAST](OpenFAST.md)
+* [OpenFOAM](OpenFOAM.md)

--- a/docs/simulators/CaNS.md
+++ b/docs/simulators/CaNS.md
@@ -1,17 +1,16 @@
 # CaNS
 
-[CaNS](https://github.com/CaNS-World/CaNS) (Canonical Navier-Stokes) is a simulator
-for massively-parallel numerical simulations of fluid flows. It aims at solving
-any fluid flow of an incompressible, Newtonian fluid that can benefit from a
-FFT-based solver for the second-order finite-difference Poisson equation in a 3D
-Cartesian grid.
+[CaNS](https://github.com/CaNS-World/CaNS) (Canonical Navier-Stokes) is a
+simulator for massively-parallel numerical simulations of fluid flows. It aims
+at solving any fluid flow of an incompressible, Newtonian fluid that can benefit
+from a FFT-based solver for the second-order finite-difference Poisson equation
+in a 3D Cartesian grid.
 
-CaNS has been built using OpenMPI 4.1.2 and FFTW 3.3.8. We're currently operating
-on CaNS version 2.3.4 for CPU, with a GPU version slated for release in the near
-future.
+CaNS has been built using OpenMPI 4.1.2 and FFTW 3.3.8. We're currently
+operating on CaNS version 2.3.4 for CPU, with a GPU version slated for release
+in the near future.
 
 ## Example
-
 
 ```python
 import inductiva
@@ -34,5 +33,14 @@ task.download_outputs()
 
 ```
 
-**Closing Notes**: CaNS requires input files to include a designated 'data' folder
-for storing simulation outputs.
+**Closing Notes**: CaNS requires input files to include a designated 'data'
+folder for storing simulation outputs.
+
+## What to read next
+
+If you are interested in CaNS, you may also be interested in checking
+the following related simulators that are also avaiable via Inductiva API:
+
+* [DualSPHysics](DualSPHysics.md)
+* [OpenFOAM](OpenFOAM.md)
+* [SPlisHSPlasH](SPlisHSPlasH.md)

--- a/docs/simulators/DualSPHysics.md
+++ b/docs/simulators/DualSPHysics.md
@@ -47,3 +47,12 @@ task.wait()
 task.download_outputs()
 
 ```
+
+## What to read next
+
+If you are interested in DualSPHysics, you may also be interested in checking
+the following related simulators that are also avaiable via Inductiva API:
+
+* [CaNS](CaNS.md)
+* [OpenFOAM](OpenFOAM.md)
+* [SPlisHSPlasH](SPlisHSPlasH.md)

--- a/docs/simulators/FDS.md
+++ b/docs/simulators/FDS.md
@@ -1,28 +1,26 @@
 # FDS
 
 Fire Dynamics Simulator (FDS), is a computational fluid dynamics (CFD) model of 
-fire-driven fluid flow. FDS solves numerically a form of the Navier-Stokes equations
-appropriate for low-speed (Ma1 < 0.3), thermally-driven flow with an emphasis on 
-smoke and heat transport
-from fires. The applications of FDS include the design of smoke handling systems 
-and sprinkler/detector activation studies, as well as reconstruction of residential 
-and industrial fires.
+fire-driven fluid flow. FDS solves numerically a form of the Navier-Stokes
+equations appropriate for low-speed (Ma1 < 0.3), thermally-driven flow with an
+emphasis on smoke and heat transport from fires. The applications of FDS include
+the design of smoke handling systems and sprinkler/detector activation studies,
+as well as reconstruction of residential and industrial fires.
 
 FDS conteplates in its model an hydrodynamics model, a combustion model and a 
-radiation transport model. All are configured by a single input file `input_file.fds`.
+radiation transport model. All are configured by a single input file
+`input_file.fds`.
 
 **Hydrodynamic Model:** solves numerically a form of the Navier-Stokes equations 
-appropriate for lowspeed, thermally-driven flow with an emphasis on smoke and heat 
-transport from fires. 
+appropriate for lowspeed, thermally-driven flow with an emphasis on smoke and
+heat  transport from fires. 
 
-**Combustion Model:** For most applications, FDS uses a single step, mixing-controlled 
-chemical reaction
-which uses three lumped species (a species representing a group of species). These 
-lumped species are
-air, fuel, and products. By default the last two lumped species are explicitly 
-computed. Options are
-available to include multiple reactions and reactions that are not necessarily 
-mixing-controlled.
+**Combustion Model:** For most applications, FDS uses a single step,
+mixing-controlled chemical reaction which uses three lumped species (a species
+representing a group of species). These lumped species are air, fuel, and
+products. By default the last two lumped species are explicitly computed.
+Options are available to include multiple reactions and reactions that are not
+necessarily mixing-controlled.
 
 Since FDS requires the setting of separate meshes that are attributed to the 
 processors, the user needs to provide the number of cores required to run the 

--- a/docs/simulators/GROMACS.md
+++ b/docs/simulators/GROMACS.md
@@ -1,22 +1,22 @@
 # GROMACS
 
 GROMACS is a versatile simulator to perform molecular dynamics simulations. It 
-is primarily designed for biochemical molecules like proteins, lipids and nucleic 
-acids that have a lot of complicated bonded interactions, but since GROMACS is 
-extremely fast at calculating the nonbonded interactions (that usually dominate 
-simulations) many groups are also using it for research on non-biological systems, 
-e.g. polymers and fluid dynamics.
+is primarily designed for biochemical molecules like proteins, lipids and
+nucleic acids that have a lot of complicated bonded interactions, but since
+GROMACS is extremely fast at calculating the nonbonded interactions (that
+usually dominate simulations) many groups are also using it for research on
+non-biological systems, e.g. polymers and fluid dynamics.
 
-A single simulation of GROMACS via Inductiva API can comprise several steps - e.g., 
-preparing the molecules, minimizing the energy of the system, running the simulation 
-and post-processing. Hence, to configure a simulation of GROMACS the user may require 
-several files. Moreover, GROMACS has specific commands to run certain tasks that 
-already use the files in your input directory. 
+A single simulation of GROMACS via Inductiva API can comprise several steps - 
+e.g., preparing the molecules, minimizing the energy of the system, running the
+simulation and post-processing. Hence, to configure a simulation of GROMACS the
+user may require several files. Moreover, GROMACS has specific commands to run
+certain tasks that already use the files in your input directory. 
 
 ## Example
 
-This example runs a simple case of the molecular dynamics of water molecules inside 
-a small box.
+This example runs a simple case of the molecular dynamics of water molecules
+inside a small box.
 
 ```python
 import inductiva

--- a/docs/simulators/OpenFAST.md
+++ b/docs/simulators/OpenFAST.md
@@ -80,10 +80,9 @@ simulations, facilitating the modeling of interactions between multiple turbines
 within wind farms, accounting for factors like wake effects, turbulence, and
 terrain complexity.
 
-## Benchmarks
+## Inductiva Benchmarks
 
-The following Inductiva benchmarks are currently available for the OpenFAST
-suite:
+The following benchmarks are currently available for the OpenFAST suite:
 
 * [5MW Land](https://benchmarks.inductiva.ai/OpenFAST/OpenFAST_Land/):
 land based NREL 5-MW turbine simulation using BeamDyn as the structural module.
@@ -96,4 +95,12 @@ FAST.Farm is an multiphysics engineering software designed to forecast the
 power performance and structural loads of wind turbines within a wind farm. It
 operates using OpenFAST and it is what allows our simulations to run in
 parallel.
+
+## What to read next
+
+If you are interested in OpenFast, you may also be interested in checking the
+following related simulators that are also avaiable via Inductiva API:
+
+* [AMR-Wind](AmrWind.md)
+* [OpenFOAM](OpenFOAM.md)
 

--- a/docs/simulators/OpenFAST.md
+++ b/docs/simulators/OpenFAST.md
@@ -2,16 +2,16 @@
 
 [OpenFAST](https://www.nrel.gov/wind/nwtc/openfast.html) is an open-source 
 engineering toolset developed by the National Renewable Energy Laboratory (NREL)
-for simulating wind turbine dynamics. It provides a modular framework for designing
-and analyzing wind turbines, allowing engineers to model various components such
-as blades, towers, and control systems.
+for simulating wind turbine dynamics. It provides a modular framework for
+designing and analyzing wind turbines, allowing engineers to model various
+components such as blades, towers, and control systems.
 
 OpenFAST has been compiled with FAST.Farm, an extension tailored for large-scale
-wind farm simulations. FAST.Farm facilitates the modeling of interactions between
-multiple turbines within wind farms, accounting for factors like wake effects,
-turbulence, and terrain complexity. FAST.Farm's capabilities are indispensable
-for the design and planning of wind energy projects, unlocking the full potential
-of wind resources for renewable energy generation.
+wind farm simulations. FAST.Farm facilitates the modeling of interactions
+between multiple turbines within wind farms, accounting for factors like wake
+effects, turbulence, and terrain complexity. FAST.Farm's capabilities are
+indispensable for the design and planning of wind energy projects, unlocking the
+full potential of wind resources for renewable energy generation.
 
 Moreover, both OpenFAST and FAST.Farm were compiled with OpenMP enabled, further
 optimizing their performance and scalability. This integration of parallel
@@ -20,7 +20,6 @@ empowering researchers and developers to tackle complex wind energy challenges
 with greater precision and accuracy.
 
 ## Example
-
 
 ```python
 import inductiva
@@ -51,31 +50,50 @@ task.download_outputs()
 
 - `aerodyn_driver`: Utilized for aerodynamic analysis, this binary focuses on 
 airflow dynamics around wind turbine blades.
-- `beamdyn_driver`: Primarily used for structural analysis, this binary focuses on
-the dynamic response of wind turbine blades and towers.
-- `feam_driver`: This binary is employed for finite element analysis, focusing on
-detailed structural modeling and simulation.
-- `hydrodyn_driver`: Specifically designed for hydrodynamic analysis, this binary
-simulates the interaction between wind turbine support structures and water
-bodies.
+- `beamdyn_driver`: Primarily used for structural analysis, this binary focuses
+on the dynamic response of wind turbine blades and towers.
+- `feam_driver`: This binary is employed for finite element analysis, focusing
+on detailed structural modeling and simulation.
+- `hydrodyn_driver`: Specifically designed for hydrodynamic analysis, this
+binary simulates the interaction between wind turbine support structures and
+water bodies.
 - `inflowwind_driver`: Used for inflow wind modeling, this binary simulates
 atmospheric conditions and their effects on wind turbine performance.
-- `moordyn_driver`: Focused on mooring dynamics, this binary analyzes the behavior
-of floating wind turbines and their mooring systems.
+- `moordyn_driver`: Focused on mooring dynamics, this binary analyzes the
+behavior of floating wind turbines and their mooring systems.
 - `openfast`: The main OpenFAST executable, orchestrating the integration and
 execution of various modules for comprehensive wind turbine simulation.
 - `orca_driver`: Employed for aero-elastic and hydrodynamic coupled simulations,
 this binary enables advanced analysis of wind turbine behavior in complex 
 environments.
-- `servodyn_driver`: This binary specializes in control system analysis, simulating
-the response of wind turbine control systems to varying conditions.
-- `subdyn_driver`: Utilized for substructure dynamics analysis, this binary focuses
-on the interaction between wind turbine components and their support structures.
-- `turbsim`: A standalone tool for simulating atmospheric turbulence and its effects
-on wind turbine performance.
+- `servodyn_driver`: This binary specializes in control system analysis,
+simulating the response of wind turbine control systems to varying conditions.
+- `subdyn_driver`: Utilized for substructure dynamics analysis, this binary
+focuses on the interaction between wind turbine components and their support
+structures.
+- `turbsim`: A standalone tool for simulating atmospheric turbulence and its
+effects on wind turbine performance.
 - `unsteadyaero_driver`: This binary is used for unsteady aerodynamics analysis,
 focusing on time-varying airflow around wind turbine blades.
 - `FAST.Farm`: An extension of OpenFAST tailored for large-scale wind farm
 simulations, facilitating the modeling of interactions between multiple turbines
 within wind farms, accounting for factors like wake effects, turbulence, and
 terrain complexity.
+
+## Benchmarks
+
+The following Inductiva benchmarks are currently available for the OpenFAST
+suite:
+
+* [5MW Land](https://benchmarks.inductiva.ai/OpenFAST/OpenFAST_Land/):
+land based NREL 5-MW turbine simulation using BeamDyn as the structural module.
+It simulates 20 seconds with a time step size of 0.001.
+* [5MW OC4](https://benchmarks.inductiva.ai/OpenFAST/OpenFAST_OC4/): simulates
+an offshore, fixed-bottom NREL 5-MW turbine. The computational emphasis is
+placed on the intricate HydroDyn wave-dynamics calculation.
+* [FAST.Farm](https://benchmarks.inductiva.ai/OpenFAST/OpenFAST_FAST.Farm/): 
+FAST.Farm is an multiphysics engineering software designed to forecast the
+power performance and structural loads of wind turbines within a wind farm. It
+operates using OpenFAST and it is what allows our simulations to run in
+parallel.
+

--- a/docs/simulators/OpenFOAM.md
+++ b/docs/simulators/OpenFOAM.md
@@ -6,39 +6,43 @@ extensive
 range of features to solve anything from complex fluid flows involving chemical 
 reactions, turbulence and heat transfer, to solid dynamics and electromagnetics.
 
-There are two main open-source versions of OpenFOAM, one developed by [OpenFOAM foundation](https://openfoam.org/) and another by the [ESI Group](https://www.openfoam.com/). Inductiva API supports 
-both versions, and you can choose which one you want to use by setting the `version` 
-parameter when initializing the simulator. The default version is the one developed 
-by the OpenFOAM foundation.
+There are two main open-source versions of OpenFOAM, one developed by
+[OpenFOAM foundation](https://openfoam.org/) and another by the
+[ESI Group](https://www.openfoam.com/). Inductiva API supports both versions,
+and you can choose which one you want to use by setting the `version` parameter
+when initializing the simulator. The default version is the one developed by
+the OpenFOAM foundation.
 
 A single simulation via Inductiva API comprises several steps done via OpenFOAM 
 - e.g., partitioning the domain, meshing, solvers and post-processing. Hence, to 
-configure a simulation for OpenFOAM the user will need a set of configuration files 
-that are organized in three folders:
-- `time`: containing individual files of data for particular fields, like initial 
-values and boundary conditions that the user must specify. For example, for an 
-initial condition at $, the initial conditions will be stored in the directory `0`.
+configure a simulation for OpenFOAM the user will need a set of configuration
+files that are organized in three folders:
+- `time`: containing individual files of data for particular fields, like
+initial values and boundary conditions that the user must specify. For example,
+for an initial condition at $, the initial conditions will be stored in the
+directory `0`.
 - `constant`: contains files that describe the objects in the simulation and the 
 physical properties of the application we are concerned.
-- `system`: contains all of the files that describe the simulation, including the 
-solvers, the numerical parameters, and the output files. It must contain at least 
-3 files: `controlDict` where run control parameters are set including start/end time, 
-time step and parameters for data output; `fvSchemes` where discretization schemes 
-used in the solution may be selected at run-time; and `fvSolution` where the equation 
-solvers, tolerances and other algorithm controls are set for the run.
+- `system`: contains all of the files that describe the simulation, including
+the solvers, the numerical parameters, and the output files. It must contain at
+least 3 files: `controlDict` where run control parameters are set including
+start/end time, time step and parameters for data output; `fvSchemes` where
+discretization schemes used in the solution may be selected at run-time; and
+`fvSolution` where the equation solvers, tolerances and other algorithm controls
+are set for the run.
 
 All of these folders should be inside an input directory. Finally, to run a 
-simulation the user needs to configure a list of dictionaries specifying the commands 
-they want to execute on the backend. Below, we run the [motorbike tutorial](https://github.com/OpenFOAM/OpenFOAM-8/tree/master/tutorials/incompressible/simpleFoam/motorBike) from OpenFOAM and show 
-how this is done in practice.
+simulation the user needs to configure a list of dictionaries specifying the
+commands they want to execute on the backend. Below, we run the
+[motorbike tutorial](https://github.com/OpenFOAM/OpenFOAM-8/tree/master/tutorials/incompressible/simpleFoam/motorBike) from OpenFOAM and show how this is done in practice.
 
 The commands passed to the simulator follow the structure of OpenFOAM, that is, 
 using the prefix `runApplication` the command will execute sequentially and with
- `runParallel` the command will use the maximum number of cores the machine has 
- available. Hence, you don't need to set the specific number of processes, the 
- simulator will do that for you automatically. In particular, the decomposeParDict 
- will be configured automatically and, at the moment, only the scotch decomposition 
- method is available.
+`runParallel` the command will use the maximum number of cores the machine has 
+available. Hence, you don't need to set the specific number of processes, the 
+simulator will do that for you automatically. In particular, the
+decomposeParDict will be configured automatically and, at the moment, only the 
+scotch decomposition method is available.
 
 ## Example 
 
@@ -71,3 +75,17 @@ task = openfoam.run(input_dir=input_dir, commands=commands, n_vcpus=4)
 task.wait()
 task.download_outputs()
 ````
+
+## What to read next
+
+If you are interested in OpenFOAM, you may also be interested in checking
+the following related simulators that are also avaiable via Inductiva API:
+
+* [CaNS](CaNS.md)
+* [DualSPHysics](DualSPHysics.md)
+* [SPlisHSPlasH](SPlisHSPlasH.md)
+
+You may also be interested in reading our blog post
+[The 3D Mesh Resolution Threshold - 5k Points is All You Need!](https://inductiva.ai/blog/article/5k-points-is-all-you-need), where we investigate the impact of reducing the
+level of detail of a 3D object in the accuracy of aerodynamic metrics obtain
+using a (virtual) wind tunnel implemented using OpenFOAM.

--- a/docs/simulators/Reef3D.md
+++ b/docs/simulators/Reef3D.md
@@ -69,3 +69,13 @@ task = reef3d.run(input_dir=input_dir)
 task.wait()
 task.download_outputs()
 ```
+
+## What to read next
+
+If you are interested in Reef3D, you may also be interested in checking the
+following related simulators that are also avaiable via Inductiva API:
+
+* [SCHISM](SCHISM.md)
+* [SWAN](SWAN.md)
+* [SWASH](SWASH.md)
+* [XBeach](XBeach.md)

--- a/docs/simulators/SCHISM.md
+++ b/docs/simulators/SCHISM.md
@@ -26,3 +26,20 @@ task = schism.run(input_dir=input_dir,
 task.wait()
 task.download_outputs()
 ```
+
+## Benchmarks
+
+The following benchmarks are currently available for SCHISM:
+
+* [Test_Inun_NWaves_2D](https://benchmarks.inductiva.ai/SCHISM/schism/):
+The `Test_Inun_NWaves_2D` example from the SCHISM official test suite.
+
+## What to read next
+
+If you are interested in SCHISM, you may also be interested in checking the
+following related simulators that are also avaiable via Inductiva API:
+
+* [Reef3D](Reef3D.md)
+* [SWAN](SWAN.md)
+* [SWASH](SWASH.md)
+* [XBeach](XBeach.md)

--- a/docs/simulators/SPlisHSPlasH.md
+++ b/docs/simulators/SPlisHSPlasH.md
@@ -4,8 +4,8 @@ SPlisHSPlasH is a Smoothed-Particle Hydrodynamics (SPH) simulator that covers a
 wide range of applications. The simulator is usually configured by a single file 
 with the extension `.json`. This file contains all the information about the 
 simulation, including the geometry, the physical properties of the fluids, the 
-boundary conditions, the numerical parameters, and the output files. Sometimes the 
-configuration can also use extra geometry files.
+boundary conditions, the numerical parameters, and the output files. Sometimes
+the  configuration can also use extra geometry files.
 
 ## Example
 
@@ -25,3 +25,27 @@ task = splishsplash.run(input_dir=input_dir,
 task.wait()
 task.download_outputs()
 ```
+
+## Inductiva Benchmarks
+
+The following benchmarks are currently available for SPlisHSPlasH:
+
+* [Three-Dimensional Currents](https://benchmarks.inductiva.ai/SWASH/SWASH_Currents/):
+This benchmark replicates the S1 simulation as outlined in the paper 
+"Modeled Three-Dimensional Currents and Eddies on an Alongshore-Variable Barred
+Beach", authored by Christine M. Baker, Melissa Moulton, Britt Raubenheimer, 
+Steve Elgar, and Nirnimesh Kumar (2021).
+
+## What to read next
+
+If you are interested in SPlisHSPlasH, you may also be interested in checking
+the following related simulators that are also avaiable via Inductiva API:
+
+* [CaNS](CaNS.md)
+* [DualSPHysics](DualSPHysics.md)
+* [OpenFOAM](OpenFOAM.md)
+
+You may also want read the following tutorial, where we exemplify the creation
+of synthetic data for training a Physics-ML model using SPlisHSPlasH:
+
+ * [Generating Synthetic Data for training Physics-ML models](https://tutorials.inductiva.ai/generating-synthetic-data/synthetic-data-generation-1.html)

--- a/docs/simulators/SWAN.md
+++ b/docs/simulators/SWAN.md
@@ -31,3 +31,20 @@ task.download_outputs()
 
 Check the [official documentation](https://swanmodel.sourceforge.io/) of SWAN to know 
 more about the configuration details specific of the simulator.
+
+## Inductiva Benchmarks
+
+The following benchmark is currently available for SWAN:
+
+* [Ring](https://benchmarks.inductiva.ai/SWAN/ring/): The "Ring" example from 
+SWAN's site.
+
+## What to read next
+
+If you are interested in SWAN, you may also be interested in checking the
+following related simulators that are also avaiable via Inductiva API:
+
+* [Reef3D](Reef3D.md)
+* [SCHISM](SCHISM.md)
+* [SWASH](SWASH.md)
+* [XBeach](XBeach.md)

--- a/docs/simulators/SWASH.md
+++ b/docs/simulators/SWASH.md
@@ -2,10 +2,11 @@
 
 SWASH is a simulator that solves shallow water equations and is used to simulate 
 waves and currents in coastal waters and harbors, long waves in coastal regions 
-and tidal inlets, and rapidly varied flows around coastal structures. The simulator 
-is configured using a single file with the `.sws` extension, and additional files 
-containing information about the domain and the ocean floor, such as a bathymetry 
-file with a `.bot` extension, are necessary for the simulation to run.
+and tidal inlets, and rapidly varied flows around coastal structures. The
+simulator  is configured using a single file with the `.sws` extension, and
+additional files containing information about the domain and the ocean floor,
+such as a bathymetry file with a `.bot` extension, are necessary for the
+simulation to run.
 
 ## Example
 
@@ -27,3 +28,28 @@ task = swash.run(input_dir=input_dir,
 task.wait()
 task.download_outputs()
 ```
+
+## Inductiva Benchmarks
+
+The following benchmark is currently available for SWASH:
+
+* [Three-Dimensional Currents](https://benchmarks.inductiva.ai/SWASH/SWASH_Currents/):
+This benchmark replicates the S1 simulation as outlined in the paper 
+"Modeled Three-Dimensional Currents and Eddies on an Alongshore-Variable Barred
+Beach", authored by Christine M. Baker, Melissa Moulton, Britt Raubenheimer, 
+Steve Elgar, and Nirnimesh Kumar (2021).
+
+## What to read next
+
+If you are interested in SWASH, you may also be interested in checking the
+following related simulators that are also avaiable via Inductiva API:
+
+* [Reef3D](Reef3D.md)
+* [SCHISM](SCHISM.md)
+* [SWAN](SWAN.md)
+* [XBeach](XBeach.md)
+
+You may also want to check the following blog post, where we illustrate a 
+practical use of SWASH:
+
+ * [Scaling coastal engineering projects with Inductiva API](https://inductiva.ai/blog/article/scaling-coastal-engineering-projects-inductiva-api)

--- a/docs/simulators/XBeach.md
+++ b/docs/simulators/XBeach.md
@@ -1,17 +1,17 @@
 # XBeach
 
-XBeach is a simulator with a two-dimensional model for wave propagation, sediment 
-transport and morphological changes in the nearshore area. The simulator is configured 
-with a `params.txt` file that contains grid and bathymetry info, wave input, flow input, 
-morphological input, etc. in the form of keyword/value pairs. If a `params.txt` 
-cannot be found then XBeach will not run. Other files are used to configure the 
-grid and bathymetry profile, like `bed.dep` for example, and other files with extra 
-information that can be used inside the `params.txt` to configure the simulator 
-further.
+XBeach is a simulator with a two-dimensional model for wave propagation,
+sediment transport and morphological changes in the nearshore area. The
+simulator is configured with a `params.txt` file that contains grid and
+bathymetry info, wave input, flow input, morphological input, etc. in the form
+of keyword/value pairs. If a `params.txt` cannot be found then XBeach will not
+run. Other files are used to configure the grid and bathymetry profile, like
+`bed.dep` for example, and other files with extra information that can be used
+inside the `params.txt` to configure the simulator further.
 
 We advise to always set the `mpiboundary` argument in the `params.txt` file, 
-since we handle automatically the parallelization of the simulation, based on the 
-number of cores available in the machine.
+since we handle automatically the parallelization of the simulation, based on
+the number of cores available in the machine.
 
 ## Example
 
@@ -33,3 +33,13 @@ task = xbeach.run(input_dir=input_dir,
 task.wait()
 task.download_outputs()
 ```
+
+## What to read next
+
+If you are interested in XBeach, you may also be interested in checking the
+following related simulators that are also avaiable via Inductiva API:
+
+* [Reef3D](Reef3D.md)
+* [SCHISM](SCHISM.md)
+* [SWASH](SWASH.md)
+* [SWAN](SWAN.md)

--- a/docs/simulators/overview.md
+++ b/docs/simulators/overview.md
@@ -1,17 +1,13 @@
 # Overview
 
-Inductiva API has available several open-source simulators ready to use. Users 
+Inductiva API has available several ready-to-use open-source simulators. Users 
 who are familiar with the simulators can easily start running simulations with 
-their previously prepared simulation configuration files. 
+their previously prepared simulation configuration files, and directly scale
+them up on [last-generation hardware](https://tutorials.staging.inductiva.ai/intro_to_api/computational-infrastructure.html#available-computational-resources) 
+avaialble on the cloud via Inductiva API.
 
-As described in our [Tutorial](https://tutorials.inductiva.ai/intro_to_api/configuring-simulators.html)
-typical usage patterns involve:
-- [Single executable simulator;](https://tutorials.inductiva.ai/intro_to_api/configuring-simulators.html#the-simple-cases)
-- [Pre-defined executables running in sequence;](https://tutorials.inductiva.ai/intro_to_api/configuring-simulators.html#a-slightly-more-complex-case)
-- [Choose the executables as wished to run in sequence.](https://tutorials.inductiva.ai/intro_to_api/configuring-simulators.html#running-long-simulation-pipelines)
-
-The simulators available in the current version of the API (0.7) are:
-- [Amr-Wind](../simulators/AmrWind.md)
+The simulators available in the current version of the API (0.6) are:
+- [AMR-Wind](../simulators/AmrWind.md)
 - [CaNS](../simulators/CaNS.md)
 - [DualSPHysics](../simulators/DualSPHysics.md)
 - [FDS](../simulators/FDS.md)
@@ -25,11 +21,19 @@ The simulators available in the current version of the API (0.7) are:
 - [SWASH](../simulators/SWASH.md)
 - [XBeach](../simulators/XBeach.md)
 
-Check the documentation of each simulator to learn about the specifics
-of how to configure them and launch your simulations via the API.
+## Typical Usage Patterns
+As described in our [Tutorial](https://tutorials.inductiva.ai/intro_to_api/configuring-simulators.html)
+typical usage patterns involve:
+- [Single executable simulator;](https://tutorials.inductiva.ai/intro_to_api/configuring-simulators.html#the-simple-cases)
+- [Pre-defined executables running in sequence;](https://tutorials.inductiva.ai/intro_to_api/configuring-simulators.html#a-slightly-more-complex-case)
+- [Choose the executables as wished to run in sequence.](https://tutorials.inductiva.ai/intro_to_api/configuring-simulators.html#running-long-simulation-pipelines)
 
+Check the documentation of each simulator to learn about the specifics of how
+to configure them and launch your simulations via the API.
+
+## Your favourite open-source simulator is not in the list above?
 If you have any questions or suggestions about other open-source simulation
-packages that you would like to see available via Inductiva API, please
-open an issue on our [GitHub repository](https://github.com/inductiva/inductiva/issues),
+packages that you would like to see available via Inductiva API, please open an
+issue on our [GitHub repository](https://github.com/inductiva/inductiva/issues),
 or contact us via [support@inductiva.ai](mailto:support@inductiva.ai).
     


### PR DESCRIPTION
This PR is intended to improve the narrative of our docs pages, and make sure there are clear follow up actions for users who land on our doc pages for each simulator. This is especially important since we are finally getting some traction from google search, with users starting to land on our website directly to these docs pages.

I added:

* Links to benchmarks, when they are available for that simulator
* Links to related simulators, when it makes sense to do so)
* Links to existing content, when related to the simulator at stake.

There are a number of other inefficiencies that we will need to address later (such as there is no obvious way to go back to inductiva's mais website), but this is already a good step for now.

