### PR TITLE
Remove all files on build folder before building and committing

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,6 +28,10 @@ jobs:
           ref: gh-pages
           path: build
 
+      - name: remove all files on the build folder
+        working-directory: build
+        run: rm -vfr *
+
       - uses: nicholasphair/sphinx-action@7.0.0
         with:
           docs-folder: "source/docs/"


### PR DESCRIPTION
This PR removes all files from the build folder before running the build and committing to the repository.

One of the GitHub action steps is to checkout the `gh-pages` branch to `build/`. This means that `build/` now contains all the files from the previous build (the ones currently deployed to production).

After that we execute `sphinx-build` that builds the static files and places them under `build/`.

If this new build removed files or folders they would still be present because we didn't clear them before executing `sphinx-build`. This PR fixes that.
