### PR TITLE
Preserve CNAME file between re-builds

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -50,6 +50,10 @@ jobs:
         working-directory: build
         run: touch .nojekyll
 
+      - name: create subdomain CNAME file
+        working-directory: build
+        run: echo docs.inductiva.ai > CNAME
+
       - name: configure client side redirection
         working-directory: source/docs
         run: cp redirect.html ../../build/index.html

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,6 +28,10 @@ jobs:
           ref: gh-pages
           path: build
 
+      - name: remove all files on the build folder
+        working-directory: build
+        run: rm -vfr *
+
       - uses: nicholasphair/sphinx-action@7.0.0
         with:
           docs-folder: "source/docs/"


### PR DESCRIPTION
This PR ensures that the CNAME file required for DNS routing to the documentation site is not removed between rebuilds.