### PR TITLE
Fix file server available flag

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -98,7 +98,7 @@ def upload_input(api_instance: TasksApi, task_id, original_params,
 
         method = api_response.body["method"]
         url = api_response.body["url"]
-        file_server_available = api_response.body["file_server_available"]
+        file_server_available = bool(api_response.body["file_server_available"])
 
         headers = {"Content-Type": "application/octet-stream"}
 


### PR DESCRIPTION
Without the explicit cast the condition `if file_server_available is False:` was not being correctly verified. The line `file_server_available = api_response.body["file_server_available"]` retrieved `<DynamicSchema: False>`.