### PR TITLE
Update Inductiva package version from 0.5.0 to 0.7.1

### DIFF
--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -45,10 +45,10 @@ Both options are shown below and both output the same version:
 ```console
 # using the CLI tool ($ is the shell prompt):
 $ inductiva --version
-inductiva 0.5.0
+inductiva 0.7.1
 # programmatically through direct python invocation:
 $ python -c 'import inductiva; print(inductiva.__version__)'
-0.5.0
+0.7.1
 ```
 
 


### PR DESCRIPTION
Version 0.7.1 has been released yesterday and the documentation should be updated accordingly. 