### PR TITLE
Download std files after task.wait

### DIFF
--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -174,8 +174,8 @@ class Task:
 
         Args:
             polling_period: How often to poll the API for the task status.
-            download_std_on_completion: Whether to download the standard
-                                    files after the task completes.
+            download_std_on_completion: Request immediate download of the
+                standard files (stdout and stderr) after the task completes.
 
         Returns:
             The final status of the task.
@@ -436,6 +436,9 @@ class Task:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         download_message = "Downloading simulation outputs to %s"
+
+        if filenames is self.STANDARD_OUTPUT_FILES:
+            download_message = "Downloading stdout and stderr files to %s"
 
         if filenames:
             if file_server_available:

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -435,10 +435,10 @@ class Task:
             warnings.warn("Path already exists, files may be overwritten.")
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        download_message = "Downloading simulation outputs to %s"
+        download_message = "Downloading simulation outputs to %s..."
 
         if filenames is self.STANDARD_OUTPUT_FILES:
-            download_message = "Downloading stdout and stderr files to %s"
+            download_message = "Downloading stdout and stderr files to %s..."
 
         if filenames:
             if file_server_available:
@@ -482,7 +482,7 @@ class Task:
         data.download_file(response, zip_path)
 
         if uncompress:
-            logging.info("Uncompressing the outputs to %s", output_dir)
+            logging.info("Uncompressing the outputs to %s...", output_dir)
             data.uncompress_task_outputs(zip_path, output_dir)
             if rm_downloaded_zip_archive:
                 zip_path.unlink()

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -433,7 +433,7 @@ class Task:
         zip_path = output_dir.joinpath("output.zip")
 
         if filenames is self.STANDARD_OUTPUT_FILES:
-            logging.info("Downloading only stdout and stderr files...")
+            logging.info("Downloading stdout and stderr files")
         else:
             logging.info("Downloading simulation outputs to %s.", zip_path)
 


### PR DESCRIPTION
## Summary

This handles the download of the stdout and stderr files automatically after task.wait completes. This change ensures that std files are available immediately after the task's completion without requiring a separate call to download_outputs.

Closes [#199](https://github.com/inductiva/tasks/issues/199)

---

## Scenarios

### Only `wait`

If the task completes with just `task.wait()` this is the logs output:

```diff
Task *** has started and is now running remotely.
Task *** completed successfully.
+Downloading only stdout and stderr files...
100%|████| 45.1k/45.1k [00:00<00:00, 649kB/s]
Uncompressing the outputs to inductiva_output/***.
```

### `wait` and `download_outputs`

If the task completes with `task.wait()` and `task.download_outputs()` in sequence this is the logs outputs:

```diff
Task *** has started and is now running remotely.
Task *** completed successfully.
+Downloading only stdout and stderr files...
100%|████| 45.0k/45.0k [00:00<00:00, 783kB/s]
Uncompressing the outputs to inductiva_output/***.
+Downloading simulation outputs to inductiva_output/***/output.zip.
100%|████| 13.2M/13.2M [00:00<00:00, 29.4MB/s]
Uncompressing the outputs to inductiva_output/***.
```