### PR TITLE
Avoid calling backend get status twice in `Task.wait()`

### DIFF
--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -261,7 +261,7 @@ class Task:
                 sys.stdout.flush()
                 prev_tasks_ahead = self._tasks_ahead
 
-            if self.is_terminal():
+            if status in self.TERMINAL_STATUSES:
                 sys.stdout.flush()
                 sys.stdout.write("\r\033[2K")
 


### PR DESCRIPTION
With the current implementation, two requests were being sent to the backend per iteration of the `Task.wait()` loop, which besides being unnecessary, was causing the `wait()` loop to sometimes not show the correct messages and returning the wrong final status code. 