### PR TITLE
[CLI] Defaulting logs behavior

### DIFF
--- a/inductiva/_cli/cmd_logs/logs.py
+++ b/inductiva/_cli/cmd_logs/logs.py
@@ -49,13 +49,14 @@ def _check_if_task_is_running(task: tasks.Task) -> Tuple[bool, str]:
 
     is_running = False
     try:
-        is_running = task.is_running()
+        info = task.get_info()
+        is_running = info.is_running
     except ApiException as e:
         return False, f"{ json.loads(e.body)['detail']}"
 
     if not is_running:
         return False, (
-            f"The current status of task {task.id} is '{task.get_status()}'\n"
+            f"The current status of task {task.id} is '{info.status}'\n"
             "and the simulation logs are not available for streaming.\n"
             "For more information about the task status, use:\n\n"
             f"  inductiva tasks list --task-id {task.id}\n")

--- a/inductiva/_cli/cmd_logs/logs.py
+++ b/inductiva/_cli/cmd_logs/logs.py
@@ -13,9 +13,16 @@ def _get_task_id_from_mode(mode: str) -> Tuple[bool, str]:
     if not match:
         return False, f"Invalid mode format: {mode}"
 
-    status = match.group(1).lower()
-    offset = int(match.group(3)) if match.group(3) else 0
-    offset += 1
+    status_match = match.group(1)
+    offset_match = match.group(3)
+
+    status = status_match
+    offset = (int(offset_match) + 1) if offset_match else 1
+
+    # If the status is submitted, send None to the API to get all the tasks.
+    # The endpoint already returns the tasks in the submitted order by default
+    if status == "submitted":
+        status = None
 
     task_list = tasks.get(last_n=offset, status=status)
 

--- a/inductiva/_cli/cmd_logs/logs.py
+++ b/inductiva/_cli/cmd_logs/logs.py
@@ -14,10 +14,9 @@ def _get_task_id_from_mode(mode: str) -> Tuple[bool, str]:
     if not match:
         return False, f"Invalid mode format: {mode}"
 
-    status_match = match.group(1)
     offset_match = match.group(3)
 
-    status = status_match
+    status = match.group(1)
     offset = (int(offset_match) + 1) if offset_match else 1
 
     # If the status is submitted, send None to the API to get all the tasks.
@@ -93,11 +92,13 @@ def register(parser):
         type=str,
         nargs="?",
         default="SUBMITTED",
-        help=(
-            "Mode of log retrieval. "
-            "Use 'SUBMITTED[-n]' for the last submitted tasks, "
-            "'STARTED[-n]' for the last started tasks, "
-            "or a specific 'task_id' to retrieve logs for a particular task."))
+        help=
+        ("Mode of log retrieval. "
+         "Use 'SUBMITTED' for the last submitted task, "
+         "'SUBMITTED-1' for the second last submitted task, and so on. "
+         "'STARTED' and 'STARTED-n' follow the same pattern for started tasks. "
+         "Or, use a specific 'task_id' to retrieve logs for a particular task."
+        ))
 
     # Register function to call when this subcommand is used
     parser.set_defaults(func=stream_task_logs)

--- a/inductiva/_cli/cmd_logs/logs.py
+++ b/inductiva/_cli/cmd_logs/logs.py
@@ -38,9 +38,6 @@ def validate_mode_or_task_id(mode: str) -> Tuple[bool, str]:
     if mode.startswith("submitted") or mode.startswith("started"):
         return _get_task_id_from_mode(mode)
 
-    if not cli_utils.is_task_id_valid(mode):
-        return False, f"Invalid task_id: {mode}"
-
     return True, mode
 
 

--- a/inductiva/_cli/utils.py
+++ b/inductiva/_cli/utils.py
@@ -10,6 +10,7 @@ from inductiva import logs
 
 BEGIN_TAG = "# >>> INDUCTIVA BEGIN:"
 END_TAG = "# >>> INDUCTIVA END:"
+ALPHABET = "0123456789abcdefghijkmnopqrstuvwxyz"
 
 
 def positive_float(value):
@@ -112,3 +113,15 @@ def setup_zsh_autocompletion():
         lines_as_string = "".join(lines_to_append)
         content += f"\n{lines_as_string}\n"
         f.write(content)
+
+
+def is_task_id_valid(task_id: str):
+    """Validates the task id.
+
+    Args:
+        task_id: The task id to validate.
+    
+    Returns:
+        True if the task_id is valid, False otherwise.
+    """
+    return all(c in ALPHABET for c in task_id) and len(task_id) == 25

--- a/inductiva/_cli/utils.py
+++ b/inductiva/_cli/utils.py
@@ -10,7 +10,6 @@ from inductiva import logs
 
 BEGIN_TAG = "# >>> INDUCTIVA BEGIN:"
 END_TAG = "# >>> INDUCTIVA END:"
-ALPHABET = "0123456789abcdefghijkmnopqrstuvwxyz"
 
 
 def positive_float(value):
@@ -113,15 +112,3 @@ def setup_zsh_autocompletion():
         lines_as_string = "".join(lines_to_append)
         content += f"\n{lines_as_string}\n"
         f.write(content)
-
-
-def is_task_id_valid(task_id: str):
-    """Validates the task id.
-
-    Args:
-        task_id: The task id to validate.
-    
-    Returns:
-        True if the task_id is valid, False otherwise.
-    """
-    return all(c in ALPHABET for c in task_id) and len(task_id) == 25


### PR DESCRIPTION
## Summary

This PR aims to revamp the behavior of the `inductiva logs` cli command. Previously the command needed to have a `task_id` to work, instead we could use some default behavior such as `inductiva logs`, without any other arguments, default to the last submitted task. 

This is the new specification for the logs comand:

`inductiva logs SUBMITTED[-n] | STARTED[-n] | task_id`

If none is provided, then it defaults to the submitted behavior. 

Closes [#195](https://github.com/inductiva/tasks/issues/195)

## Examples

Without tasks running it tries to get the last task submmited:
➜  inductiva logs            
The current status of task caze0p7xn9ncp2tm5qpot7c6t is 'success'
and the simulation logs are not available for streaming.

Getting the second last task submitted:
➜  inductiva logs submitted-1
The current status of task bpnefgzsahdrynf2adowmchpf is 'success'
and the simulation logs are not available for streaming.

Without started task running it returns that there are no tasks with `started`
➜  inductiva logs started                        
No 'started' tasks found.

Getting logs for a specific task_id
➜  inductiva logs cv0p5hpbppb4herns44ods0s1                         
The current status of task cv0p5hpbppb4herns44ods0s1 is 'killed'
and the simulation logs are not available for streaming.

With a task running:
➜  inductiva logs started
 ● Opening connection to task ioa8vjbpa8i6339zda14ft2eu...

With an invalid task_id format:
➜  inductiva logs loremip 
Invalid task_id: loremip

With a valid task_id format but does not exist:
➜  inductiva logs aaaaaaaaaaaaaaaaaaaaaaaaa
Task ID not present in the list of tasks owned by the user.