### PR TITLE
Enable simulator version

### DIFF
--- a/docs/simulators/OpenFOAM.md
+++ b/docs/simulators/OpenFOAM.md
@@ -6,11 +6,11 @@ extensive
 range of features to solve anything from complex fluid flows involving chemical 
 reactions, turbulence and heat transfer, to solid dynamics and electromagnetics.
 
-There are two main open-source versions of OpenFOAM, one developed by
+There are two main open-source distributions of OpenFOAM, one developed by
 [OpenFOAM foundation](https://openfoam.org/) and another by the
-[ESI Group](https://www.openfoam.com/). Inductiva API supports both versions,
-and you can choose which one you want to use by setting the `version` parameter
-when initializing the simulator. The default version is the one developed by
+[ESI Group](https://www.openfoam.com/). Inductiva API supports both distributions,
+and you can choose which one you want to use by setting the `distribution` parameter
+when initializing the simulator. The default distribution is the one developed by
 the OpenFOAM foundation.
 
 A single simulation via Inductiva API comprises several steps done via OpenFOAM 
@@ -67,7 +67,7 @@ commands = [
 ]
 
 # Initialize the Simulator
-openfoam = inductiva.simulators.OpenFOAM(version="foundation")
+openfoam = inductiva.simulators.OpenFOAM(distribution="foundation")
 
 # Run simulation with config files in the input directory
 task = openfoam.run(input_dir=input_dir, commands=commands, n_vcpus=4)
@@ -79,13 +79,14 @@ task.download_outputs()
 ## What to read next
 
 If you are interested in OpenFOAM, you may also be interested in checking
-the following related simulators that are also avaiable via Inductiva API:
+the following related simulators that are also available via Inductiva API:
 
 * [CaNS](CaNS.md)
 * [DualSPHysics](DualSPHysics.md)
 * [SPlisHSPlasH](SPlisHSPlasH.md)
 
 You may also be interested in reading our blog post
-[The 3D Mesh Resolution Threshold - 5k Points is All You Need!](https://inductiva.ai/blog/article/5k-points-is-all-you-need), where we investigate the impact of reducing the
-level of detail of a 3D object in the accuracy of aerodynamic metrics obtain
-using a (virtual) wind tunnel implemented using OpenFOAM.
+[The 3D Mesh Resolution Threshold - 5k Points is All You Need!](https://inductiva.ai/blog/article/5k-points-is-all-you-need),
+where we investigate the impact of reducing the level of detail of a 3D object in
+the accuracy of aerodynamic metrics obtained using a (virtual) wind tunnel
+implemented using OpenFOAM.

--- a/inductiva/_cli/cmd_simulators/__init__.py
+++ b/inductiva/_cli/cmd_simulators/__init__.py
@@ -1,0 +1,27 @@
+"""Register CLI commands for simulators."""
+import argparse
+import os
+
+from inductiva._cli import loader, utils
+from inductiva import constants
+
+
+def register(root_parser):
+    """Register the "simulators" sub-command."""
+
+    parser = root_parser.add_parser(
+        "simulators",
+        help="Information about available simulators.",
+        formatter_class=argparse.RawTextHelpFormatter)
+
+    parser.description = (
+        "Information about available simulators.\n\n"
+        "The `inductiva simulators` command provides utility sub-commands\n"
+        "for managing the available simulators within the Inductiva API.\n")
+
+    utils.show_help_msg(parser)
+    subparsers = parser.add_subparsers(title="available subcomands")
+    loader.load_commands(subparsers,
+                         os.path.dirname(__file__),
+                         package=__name__,
+                         ignores_prefix=constants.LOADER_IGNORE_PREFIX)

--- a/inductiva/_cli/cmd_simulators/list.py
+++ b/inductiva/_cli/cmd_simulators/list.py
@@ -1,0 +1,53 @@
+"""List the available simulators via CLI."""
+import argparse
+
+from inductiva.simulators import methods
+from inductiva.utils import format_utils
+
+
+def list_versions(args):
+    """List available simulators and associated versions for each branch."""
+
+    available = methods.list_available_images()
+
+    if not args.dev:
+        available.pop("development")
+    fmtr = format_utils.get_ansi_formatter()
+
+    def header_fmtr(s):
+        return fmtr(s.upper(), format_utils.Emphasis.BOLD)
+
+    for branch, simulators in available.items():
+        sims = sorted(simulators.keys())
+
+        data = {
+            "simulator": sims,
+            "versions": [", ".join(simulators[s]) for s in sims],
+        }
+
+        table = format_utils.get_tabular_str(data,
+                                             header_formatters=[header_fmtr])
+        header = f"Available simulators and versions for {branch} runs:"
+
+        print(header_fmtr(header))
+        print(table)
+
+
+def register(parser):
+    """Register the "simulators list" sub-command."""
+
+    subparser = parser.add_parser("list",
+                                  aliases=["ls"],
+                                  help="List available simulators.",
+                                  formatter_class=argparse.RawTextHelpFormatter)
+
+    subparser.description = (
+        "The `list` sub-command lists all available simulators and\n"
+        "associated versions for use with the Inductiva API,\n"
+        "including those available for development purposes.\n")
+    subparser.add_argument(
+        "--dev",
+        action="store_true",
+        help="include development versions of the simulators.")
+
+    subparser.set_defaults(func=list_versions)

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -300,12 +300,16 @@ def blocking_task_context(api_instance: TasksApi, task_id):
         signal.signal(signal.SIGINT, original_sig)
 
 
-def log_task_info(task_id, method_name, params, resource_pool):
+def log_task_info(task_id, params, resource_pool, simulator):
     """Logging the main components of a task submission."""
 
     logging.info("Task Information:")
     logging.info("> ID:                    %s", task_id)
-    logging.info("> Method:                %s", method_name.split(".")[1])
+    if simulator is not None:
+        logging.info("> Simulator:             %s", simulator.name)
+        logging.info("> Version:               %s", simulator.version)
+        logging.info("> Image:                 %s", simulator.image_uri)
+
     logging.info("> Local input directory: %s", params["sim_dir"])
     logging.info("> Submitting to the following computational resources:")
     if resource_pool is not None:
@@ -323,7 +327,8 @@ def submit_task(api_instance,
                 params,
                 type_annotations,
                 provider_id: ProviderType,
-                container_image: Optional[str] = None):
+                container_image: Optional[str] = None,
+                simulator=None):
     """Submit a task and send input files to the API."""
 
     resource_pool_id = None
@@ -352,7 +357,7 @@ def submit_task(api_instance,
     )
 
     task_id = task["id"]
-    log_task_info(task_id, method_name, params, resource_pool)
+    log_task_info(task_id, params, resource_pool, simulator)
 
     if task["status"] == "pending-input":
 
@@ -373,7 +378,8 @@ def invoke_async_api(method_name: str,
                          types.ComputationalResources] = None,
                      storage_path_prefix: Optional[str] = "",
                      provider_id: ProviderType = ProviderType.GCP,
-                     container_image: Optional[str] = None) -> str:
+                     container_image: Optional[str] = None,
+                     simulator=None) -> str:
     """Perform a task asyc and remotely via Inductiva's Web API.
 
     Submits a simulation async to the API and returns the task id.
@@ -419,6 +425,7 @@ def invoke_async_api(method_name: str,
                               params=params,
                               provider_id=provider_id,
                               container_image=container_image,
-                              type_annotations=type_annotations)
+                              type_annotations=type_annotations,
+                              simulator=simulator)
 
     return task_id

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -22,6 +22,11 @@ class AmrWind(simulators.Simulator):
         super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "amrWind.amrWind.run_simulation"
 
+    @property
+    def name(self):
+        """Get the name of the this simulator."""
+        return "AMR-Wind"
+
     def run(self,
             input_dir: types.Path,
             sim_config_filename: str,

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -9,9 +9,17 @@ class AmrWind(simulators.Simulator):
     """Class to invoke a generic AmrWind simulation on the API.
     """
 
-    def __init__(self):
-
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the AmrWind simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "amrWind.amrWind.run_simulation"
 
     def run(self,

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -10,9 +10,17 @@ class CaNS(simulators.Simulator):
 
     """
 
-    def __init__(self):
-
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the CaNS simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "cans.cans.run_simulation"
 
     def run(self,

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -8,8 +8,17 @@ from inductiva import types, tasks, simulators
 class DualSPHysics(simulators.Simulator):
     """Class to invoke a generic DualSPHysics simulation on the API."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the DualSPHysics simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "sph.dualsphysics.run_simulation"
 
     def run(

--- a/inductiva/simulators/dummy_simulator.py
+++ b/inductiva/simulators/dummy_simulator.py
@@ -12,8 +12,17 @@ from inductiva import types, tasks, simulators
 class DummySimulator(simulators.Simulator):
     """Dummy simulator for demo and testing purposes."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "tester.echo.run_simulation"
 
     def run(self,

--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -9,8 +9,17 @@ from inductiva.utils import meta
 class FDS(simulators.Simulator):
     """Class to invoke a generic FDS simulation on the API."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the FDS simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "fdm.fds.run_simulation"
 
     @meta.deprecated_arg(n_cores="n_vcpus")

--- a/inductiva/simulators/fenicsx.py
+++ b/inductiva/simulators/fenicsx.py
@@ -8,8 +8,17 @@ from inductiva import simulators, types, tasks
 class FEniCSx(simulators.Simulator):
     """Class to invoke a generic FEniCSx simulation on the API."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the FEniCSx simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "fem.fenicsx.run_simulation"
 
     def run(self,

--- a/inductiva/simulators/gromacs.py
+++ b/inductiva/simulators/gromacs.py
@@ -8,8 +8,17 @@ from inductiva import types, tasks, simulators
 class GROMACS(simulators.Simulator):
     """Class to invoke any GROMACS command on the API."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the GROMACS simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "md.gromacs.run_simulation"
 
     def run(

--- a/inductiva/simulators/methods.py
+++ b/inductiva/simulators/methods.py
@@ -1,0 +1,62 @@
+"""Methods to interact with the available simulators."""
+import requests
+from collections import defaultdict
+import re
+
+# Regex to extract metadata from the image name
+# Example:
+#   dualsphysics_v5.2.1_dev -> name=dualsphysics, version=5.2.1, isdev=_dev
+#   dualsphysics_v5.2.1 -> name=dualsphysics, version=5.2.1, isdev=None
+IMAGE_TOKENIZER = re.compile(r"(?P<name>[a-zA-Z-_0-9]+)"
+                             r"_v(?P<version>.+?(?=(_dev|$)))"
+                             r"(?P<isdev>_dev)?")
+
+DOCKERHUB_URL = "https://hub.docker.com/v2/repositories/inductiva/kutu/tags/"
+
+SKIP_IMAGES = ["base-image", "echo"]
+
+
+def list_available_images():
+    """List available images on DockerHub for the Inductiva API.
+
+    Returns:
+        A dictionary with the available images for the API, grouped by branch
+        (dev/prod) and simulator name.
+
+    Example:
+    >>> list_available_images()
+    {
+        {'dev':
+            {'amr-wind': ['1.4.0'],
+              ...
+             'dualsphysics': ['5.2.1']
+            },
+        'prod':
+            {'amr-wind': ['1.3.0', '1.4.0'],
+              ...
+             'dualsphysics': ['5.2.1']
+            }
+        }
+    """
+
+    images = defaultdict(lambda: defaultdict(list))
+    url = f"{DOCKERHUB_URL}?page_size=100"
+
+    while url is not None:
+        resp = requests.get(url, timeout=10)
+        data = resp.json()
+
+        for tag in data["results"]:
+            if (match := IMAGE_TOKENIZER.match(tag["name"])) is None:
+                continue
+
+            if match.group("name") in SKIP_IMAGES:
+                continue
+
+            name, version = match.group("name"), match.group("version")
+            branch = "development" if match.group("isdev") else "production"
+            images[branch][name].append(version)
+
+        url = data["next"]
+
+    return images

--- a/inductiva/simulators/openfast.py
+++ b/inductiva/simulators/openfast.py
@@ -9,9 +9,17 @@ class OpenFAST(simulators.Simulator):
 
     """
 
-    def __init__(self):
-
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the OpenFAST simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "openfast.openfast.run_simulation"
 
     def run(self,

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from inductiva import types, tasks, simulators
 
-AVAILABLE_OPENFOAM_BRANCHES = ["foundation", "esi"]
+AVAILABLE_OPENFOAM_DISTRIBUTIONS = ["foundation", "esi"]
 
 
 @simulators.simulator.mpi_enabled
@@ -17,32 +17,34 @@ class OpenFOAM(simulators.Simulator):
 
     def __init__(self,
                  /,
-                 branch: str = "foundation",
+                 distribution: str = "foundation",
                  version: Optional[str] = None,
                  use_dev: bool = False):
         """Initialize the OpenFOAM simulator.
 
         Args:
-            branch (str): The branch of OpenFOAM to use. Available branches are
-                "foundation" and "esi". Default is "foundation".
+            distribution (str): The distribution of OpenFOAM to use. Available
+                distributions are "foundation" and "esi". Default is
+                "foundation".
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
             use_dev (bool): Request use of the development version of
                 the simulator. By default (False), the production version
                 is used.
         """
-        if branch not in AVAILABLE_OPENFOAM_BRANCHES:
+        if distribution not in AVAILABLE_OPENFOAM_DISTRIBUTIONS:
             raise ValueError(
-                f"Branch {branch} of OpenFOAM is not supported. "
-                f"Available branches are: {AVAILABLE_OPENFOAM_BRANCHES}")
+                f"Distribution '{distribution}' of OpenFOAM is not supported. "
+                f"Available distributions are: "
+                f"{AVAILABLE_OPENFOAM_DISTRIBUTIONS}")
 
-        self._branch = branch
+        self._distribution = distribution
         super().__init__(version=version, use_dev=use_dev)
-        self.api_method_name = f"fvm.openfoam_{branch}.run_simulation"
+        self.api_method_name = f"fvm.openfoam_{distribution}.run_simulation"
 
     def _get_simulator_name(self):
         """Get the name of the simulator."""
-        return "OpenFOAM-" + self._branch
+        return "OpenFOAM-" + self._distribution
 
     def run(self,
             input_dir: types.Path,

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from inductiva import types, tasks, simulators
 
-AVAILABLE_OPENFOAM_VERSIONS = ["foundation", "esi"]
+AVAILABLE_OPENFOAM_BRANCHES = ["foundation", "esi"]
 
 
 @simulators.simulator.mpi_enabled
@@ -15,13 +15,34 @@ class OpenFOAM(simulators.Simulator):
     some input files may only work for a specific version.
     """
 
-    def __init__(self, version: str = "foundation"):
-        if version not in AVAILABLE_OPENFOAM_VERSIONS:
-            raise ValueError("Version not currently supported."
-                             f"Available: {AVAILABLE_OPENFOAM_VERSIONS}")
+    def __init__(self,
+                 /,
+                 branch: str = "foundation",
+                 version: Optional[str] = None,
+                 use_dev: bool = False):
+        """Initialize the OpenFOAM simulator.
 
-        super().__init__()
-        self.api_method_name = f"fvm.openfoam_{version}.run_simulation"
+        Args:
+            branch (str): The branch of OpenFOAM to use. Available branches are
+                "foundation" and "esi". Default is "foundation".
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        if branch not in AVAILABLE_OPENFOAM_BRANCHES:
+            raise ValueError(
+                f"Branch {branch} of OpenFOAM is not supported. "
+                f"Available branches are: {AVAILABLE_OPENFOAM_BRANCHES}")
+
+        self._branch = branch
+        super().__init__(version=version, use_dev=use_dev)
+        self.api_method_name = f"fvm.openfoam_{branch}.run_simulation"
+
+    def _get_simulator_name(self):
+        """Get the name of the simulator."""
+        return "OpenFOAM-" + self._branch
 
     def run(self,
             input_dir: types.Path,

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -42,7 +42,8 @@ class OpenFOAM(simulators.Simulator):
         super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = f"fvm.openfoam_{distribution}.run_simulation"
 
-    def _get_simulator_name(self):
+    @property
+    def name(self):
         """Get the name of the simulator."""
         return "OpenFOAM-" + self._distribution
 

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -7,10 +7,19 @@ from inductiva import simulators, types, tasks
 
 @simulators.simulator.mpi_enabled
 class REEF3D(simulators.Simulator):
-    """Class to invoke a generic FDS simulation on the API."""
+    """Class to invoke a generic REEF3D simulation on the API."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the REEF3D simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "reef3d.reef3d.run_simulation"
 
     def run(self,

--- a/inductiva/simulators/schism.py
+++ b/inductiva/simulators/schism.py
@@ -8,8 +8,17 @@ from inductiva import types, tasks, simulators
 class SCHISM(simulators.Simulator):
     """Class to invoke a generic SCHISM simulation on the API."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the SCHISM simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "schism.schism.run_simulation"
 
     def run(self,

--- a/inductiva/simulators/simsopt.py
+++ b/inductiva/simulators/simsopt.py
@@ -7,8 +7,17 @@ from inductiva import simulators, tasks, types
 class SIMSOPT(simulators.Simulator):
     """Invokes a simsopt simulation on the API."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the SIMOPT simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "stellarators.simsopt.run_simulation"
 
     def run(

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -37,9 +37,11 @@ class Simulator(ABC):
                 the simulator. By default (False), the production version
                 is used.
         """
+        if version is not None and not isinstance(version, str):
+            raise ValueError("Version must be a string or None.")
         self.api_method_name = ""
         self._version = version
-        self._use_dev = use_dev
+        self._use_dev = bool(use_dev)
         self._image_uri = self._get_image_uri()
 
     @property

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -52,15 +52,21 @@ class Simulator(ABC):
         """Get whether the development version of the simulator is used."""
         return self._use_dev
 
-    def _get_simulator_name(self):
+    @property
+    def name(self):
         """Get the name of the simulator."""
         return self.__class__.__name__
+
+    @property
+    def image_uri(self):
+        """Get the image URI for this simulator."""
+        return self._image_uri
 
     def _get_image_uri(self):
         """Get the appropriate image name for this simulator."""
 
         img_type = "development" if self._use_dev else "production"
-        sim_name = self._get_simulator_name()
+        sim_name = self.name
         name = sim_name.lower()
 
         available = list_available_images()
@@ -152,6 +158,7 @@ class Simulator(ABC):
             computational_resources=on,
             extra_metadata=extra_metadata,
             container_image=container_image,
+            simulator=self,
             **kwargs,
         )
 

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -1,10 +1,12 @@
 """Base class for low-level simulators."""
 from typing import Optional
 from abc import ABC
+import logging
 
 import pathlib
 
 from inductiva import types, tasks, resources
+from .methods import list_available_images
 from inductiva import commands
 
 
@@ -23,9 +25,62 @@ class Simulator(ABC):
     _supported_resources = {
         resources.MachineGroup, resources.ElasticMachineGroup
     }
+    _logger = logging.getLogger(__name__)
 
-    def __init__(self):
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the simulator.
+
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
         self.api_method_name = ""
+        self._version = version
+        self._use_dev = use_dev
+        self._image_uri = self._get_image_uri()
+
+    @property
+    def version(self):
+        """Get the version of the simulator."""
+        return self._version
+
+    @property
+    def use_dev(self):
+        """Get whether the development version of the simulator is used."""
+        return self._use_dev
+
+    def _get_simulator_name(self):
+        """Get the name of the simulator."""
+        return self.__class__.__name__
+
+    def _get_image_uri(self):
+        """Get the appropriate image name for this simulator."""
+
+        img_type = "development" if self._use_dev else "production"
+        sim_name = self._get_simulator_name()
+        name = sim_name.lower()
+
+        available = list_available_images()
+        listing = available.get(img_type, {}).get(name, [])
+
+        if self._version is None:
+            # kutu does not have a specific tag for the latest version
+            # this hack is a workaround to get that version, but it is prone
+            # to errors.
+            self._version = max(listing)
+
+        if self._version not in listing:
+            raise ValueError(
+                f"Version {self.version} is not available for simulator {name}."
+                f" Available versions are: {listing}.")
+        self._logger.info("Using %s image of %s version %s", img_type, sim_name,
+                          self.version)
+
+        suffix = "_dev" if self._use_dev else ""
+        return f"docker://inductiva/kutu:{name}_v{self._version}" + suffix
 
     @classmethod
     def get_supported_resources(cls):
@@ -83,15 +138,20 @@ class Simulator(ABC):
         self.validate_computational_resources(on)
 
         if "commands" in kwargs:
-            kwargs["commands"] = commands.Command.commands_to_dicts(
-                kwargs["commands"])
+            cmds = commands.Command.commands_to_dicts(kwargs["commands"])
+            kwargs["commands"] = cmds
+
+        # Get the user-specified image name. If not specified,
+        # use the default image name for the current simulator
+        container_image = kwargs.get("container_image", self._image_uri)
 
         return tasks.run_simulation(
             self.api_method_name,
             input_dir,
-            computational_resources=on,
             storage_dir=storage_dir,
+            computational_resources=on,
             extra_metadata=extra_metadata,
+            container_image=container_image,
             **kwargs,
         )
 

--- a/inductiva/simulators/splishsplash.py
+++ b/inductiva/simulators/splishsplash.py
@@ -7,8 +7,17 @@ from inductiva import types, tasks, simulators
 class SplishSplash(simulators.Simulator):
     """Class to invoke a generic SPlisHSPlasH simulation on the API."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the SPlisHSplasH simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "sph.splishsplash.run_simulation"
 
     def run(

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -8,8 +8,17 @@ from inductiva import types, tasks, simulators
 class SWAN(simulators.Simulator):
     """Class to invoke a generic SWAN simulation on the API."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the SWAN simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "swan.swan.run_simulation"
 
     def run(

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -8,8 +8,17 @@ from inductiva import types, tasks, simulators
 class SWASH(simulators.Simulator):
     """Class to invoke a generic SWASH simulation on the API."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the SWASH simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "sw.swash.run_simulation"
 
     def run(self,

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -8,8 +8,17 @@ from inductiva import types, tasks, simulators
 class XBeach(simulators.Simulator):
     """Class to invoke a generic XBeach simulation on the API."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
+        """Initialize the XBeach simulator.
+        
+        Args:
+            version (str): The version of the simulator to use. If None, the
+                latest available version in the platform is used.
+            use_dev (bool): Request use of the development version of
+                the simulator. By default (False), the production version
+                is used.
+        """
+        super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "sw.xbeach.run_simulation"
 
     def run(self,

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -26,6 +26,7 @@ def run_simulation(
     storage_dir: Optional[types.Path] = "",
     api_invoker=None,
     extra_metadata=None,
+    simulator=None,
     **kwargs: Any,
 ) -> tasks.Task:
     """Run a simulation via Inductiva Web API."""
@@ -52,7 +53,8 @@ def run_simulation(
                           resource_pool=computational_resources,
                           container_image=container_image,
                           storage_path_prefix=storage_dir,
-                          provider_id=provider_id)
+                          provider_id=provider_id,
+                          simulator=simulator)
 
     if computational_resources is not None:
         logging.info("Task %s submitted to the queue of the %s.", task_id,

--- a/inductiva/tests/simulators/test_simulator_with_resources.py
+++ b/inductiva/tests/simulators/test_simulator_with_resources.py
@@ -9,8 +9,8 @@ import inductiva
 inductiva.set_api_key("dummy")
 
 
-@pytest.fixture(name="list_available")
-def list_available():
+@pytest.fixture(name="list_available_fixture")
+def _list_available_fixture():
     # Fixture that returns a dictionary with the available images for
     # the TesterSimulator local class.
     ret = {
@@ -49,7 +49,7 @@ def new_machine_init(self, machine_type):
 
 @mock.patch("inductiva.resources.MPICluster")
 def test_validate_computational_resources__unsupported_resource__raise_error(
-        mpi_cluster_mock, list_available):
+        mpi_cluster_mock, list_available_fixture):  # pylint: disable=unused-argument
     """Check non-mpi simulator raises error with MPICluster.
 
     Goal: Verify that simulators without the mpi_enabled decorator raise an
@@ -91,7 +91,7 @@ def test_valid_resources__non_mpi_simulators(simulator):
 
 
 def test_validate_computational_resources__none_resource__no_wrapper(
-        list_available):
+        list_available_fixture):  # pylint: disable=unused-argument
     """Verify that simulators the mpi_enabled decorator run
     normally with a standard machine group."""
 
@@ -103,7 +103,7 @@ def test_validate_computational_resources__none_resource__no_wrapper(
 
 
 def test_validate_computational_resources__none_resource_mpi_wrapped(
-        list_available):
+        list_available_fixture):  # pylint: disable=unused-argument
     """Verify that simulators with the mpi_enabled decorator run
     normally with a standard machine group."""
 
@@ -115,7 +115,7 @@ def test_validate_computational_resources__none_resource_mpi_wrapped(
 
 
 def test_validate_computational_resources__valid_machine_group__no_error(
-        list_available):
+        list_available_fixture):  # pylint: disable=unused-argument
     """Check simulator run correctly with a standard machine group.
     
     Goal: Verify that simulators with and without the mpi_enabled decorator run
@@ -141,7 +141,7 @@ def test_validate_computational_resources__valid_machine_group__no_error(
 
 
 def test_validate_computational_resources__valid_mpi_cluster__no_error(
-        list_available):
+        list_available_fixture):  # pylint: disable=unused-argument
     """Check mpi-enabled simulator runs correctly with a standard MPICluster.
     
     Goal: Verify that an mpi simulator correctly validated the MPI Cluster"""


### PR DESCRIPTION
## Enable specification of simulator version [#201](https://github.com/inductiva/tasks/issues/201)

### Description
This PR enables users to specify the version of the simulator to use when instantiating the simulator proxy object.
It also allows users to specify whether the development version of the image is to be used. The `Simulator` constructor now accepts 2 parameters: `version` and `use_dev` to specify the version and request the development version, respectively.

IMPORTANT: OpenFOAM had the previous `version` argument renamed to `distribution`.

#### Examples

```python

>>> inductiva.simulators.GROMACS(version='2022.2')
>>> inductiva.simulators.GROMACS(version=None, use_dev=True)
>>> inductiva.simulators.GROMACS(use_dev=True)
>>> inductiva.simulators.GROMACS(use_dev=False)
>>> inductiva.simulators.GROMACS()

>>> inductiva.simulators.SplishSplash(version='2.13.0')
>>> inductiva.simulators.OpenFOAM(distribution='esi')
```

When submitting a task, the user is also informed about the name, version, and docker image URL used to run the simulation:

```
[...]
Task Information:
> ID:                    s39on1fiv8eyfyw68ws8fmihz
> Simulator:             OpenFOAM-foundation
> Version:               8
> Image:                 docker://inductiva/kutu:openfoam-foundation_v8
> Local input directory: /Users/ssantos/repos/inductiva/working/tests/openfoam-input-example
> Submitting to the following computational resources:
[...]
```

### CLI

A new CLI command was created to allows users to list all available simulators:

```bash
$ inductiva simulators list --dev         
AVAILABLE SIMULATORS AND VERSIONS FOR PRODUCTION RUNS:

 SIMULATOR             VERSIONS
 amr-wind              1.4.0
 cans                  2.3.4
[...]
 xbeach                1.24, 1.23

AVAILABLE SIMULATORS AND VERSIONS FOR DEVELOPMENT RUNS:

 SIMULATOR             VERSIONS
 amr-wind              1.4.0
 cans                  2.3.4
[...]
```