### PR TITLE
Improved resources terminate and task kill messages

### DIFF
--- a/inductiva/_cli/cmd_resources/terminate.py
+++ b/inductiva/_cli/cmd_resources/terminate.py
@@ -9,7 +9,7 @@ from ...localization import translator as __
 
 
 def terminate_machine_group(args):
-    """Terminate one or all computational resoruces."""
+    """Terminate one or all computational resources."""
     names = args.name
     all_names = args.all
     confirm = args.confirm
@@ -24,6 +24,7 @@ def terminate_machine_group(args):
     active_machines = resources.machine_groups.get()
 
     if not active_machines:
+        print("No active resources to terminate.")
         return 0
 
     if not all_names and not names:
@@ -33,10 +34,9 @@ def terminate_machine_group(args):
 
     # dict to map from name to machine
     name_to_machine = {machine.name: machine for machine in active_machines}
-    active_machine_names = name_to_machine.keys()
-    # the user can give the same name multiple times!!
-    target_machine_names = set(names)
-    invalid_names = target_machine_names.difference(active_machine_names)
+    # the user can give the same name multiple times
+    target_machine_names = set(names or name_to_machine.keys())
+    invalid_names = target_machine_names.difference(name_to_machine)
 
     if invalid_names:
         for name in invalid_names:
@@ -46,16 +46,13 @@ def terminate_machine_group(args):
 
     confirm = confirm or input_functions.user_confirmation_prompt(
         target_machine_names, __("resources-prompt-terminate-all"),
-        __("resources-prompt-terminate-big", len(names)),
-        __("resources-prompt-terminate-small"), all_names)
+        __("resources-prompt-terminate-big", len(target_machine_names)),
+        __("resources-prompt-terminate-small"), False)
 
     if not confirm:
         return 0
 
-    machines_to_kill = active_machine_names if (all_names) else (
-        target_machine_names)
-
-    for name in machines_to_kill:
+    for name in target_machine_names:
         name_to_machine[name].terminate()
 
     return 0

--- a/inductiva/_cli/cmd_tasks/kill.py
+++ b/inductiva/_cli/cmd_tasks/kill.py
@@ -34,13 +34,17 @@ def kill_task(args):
                 "task_id": task.id
             } for task in get_all(status=status)])
 
+    if not tasks:
+        print("There are not tasks to kill.")
+        return 1
+
     ids = [task["task_id"] for task in tasks]
 
     confirm = args.yes or \
         user_confirmation_prompt(ids,
                                 __("task-prompt-kill-all"),
                                 __("task-prompt-kill-big", len(ids)),
-                                __("task-prompt-kill-small"), kill_all
+                                __("task-prompt-kill-small"), False
                                 )
 
     if not confirm:

--- a/inductiva/_cli/cmd_tasks/kill.py
+++ b/inductiva/_cli/cmd_tasks/kill.py
@@ -35,7 +35,7 @@ def kill_task(args):
             } for task in get_all(status=status)])
 
     if not tasks:
-        print("There are not tasks to kill.")
+        print("There are no tasks to kill.")
         return 1
 
     ids = [task["task_id"] for task in tasks]


### PR DESCRIPTION
### Terminate message
- The message for the --all command has been updated to display the machines that will be removed (or the number of machines if there are more than 5).

Current output:
```
$ inductiva resources terminate --all
You are about to terminate ALL resources.
Are you sure you want to proceed (y/[N])? y
...
```

Output with the new changes:
```
$ inductiva resources terminate --all                        
You are about to terminate the following resources:
  - api-cgxaxawfstran71xszgserpb2
  - api-cd0imcswv8f46mf8eqvuh9whk
  - api-8u4z3ypf09dpd7krm2893t271
  - api-cef4169p84mdoe0bm819rj1x2
  - api-4wo9mr6bef16ofeaqux51oqa5
Are you sure you want to proceed (y/[N])? y
```

The same thing also for tasks