### PR TITLE
71-expose-project-management-though-cli

### DIFF
--- a/inductiva/_cli/cmd_projects/__init__.py
+++ b/inductiva/_cli/cmd_projects/__init__.py
@@ -1,4 +1,4 @@
-"""Register CLI commands for projetcs."""
+"""Register CLI commands for projects."""
 import argparse
 import os
 
@@ -14,8 +14,10 @@ def register(root_parser):
         formatter_class=argparse.RawTextHelpFormatter)
 
     parser.description = ("Projects management utilities.\n\n"
-                          "The `inductiva projects` command allows you to "
-                          "consult existing projetcs.\n")
+                          "The `inductiva projects list` command allows you to "
+                          "consult existing projects.\n"
+                          "The `inductiva projects download` command allows you"
+                          " to download the files of the tasks of a project.\n")
 
     utils.show_help_msg(parser)
 

--- a/inductiva/_cli/cmd_projects/download.py
+++ b/inductiva/_cli/cmd_projects/download.py
@@ -14,7 +14,8 @@ def download_wrapper(task: Task,
     This method is a wrapper around the download_outputs method of the Task
     class. We do this to be able to set the outputdir for each worker.
     """
-    inductiva.set_output_dir(output_dir)
+    if output_dir:
+        inductiva.set_output_dir(output_dir)
     task.download_outputs(filenames)
 
 

--- a/inductiva/_cli/cmd_projects/download.py
+++ b/inductiva/_cli/cmd_projects/download.py
@@ -1,0 +1,79 @@
+"""Download the project tasks files via CLI."""
+import concurrent.futures as cf
+import argparse
+
+import inductiva
+
+
+def download_projects(args):
+    """Download the project tasks files.
+
+    This function downloads the files of the tasks of a project. The project
+    name is specified with the --project-name flag. The files to download can
+    be specified with the --files flag. If no files are specified, all files are
+    downloaded. The standard output and error files can be downloaded with the
+    --std flag. The files are saved in the default directory (inductiva-output)
+    if no output directory is specified with the --output-dir flag.
+
+    The downloads are done in parallel using a ThreadPoolExecutor with a maximum
+    of 100 workers.
+    """
+
+    project_name = args.project_name
+    output_dir = args.output_dir
+    files = args.files
+    std = args.std
+
+    if std:
+        files = ["stdout.txt", "stderr.txt"]
+
+    project = inductiva.projects.Project(project_name)
+    project_tasks = project.get_tasks()
+
+    if output_dir is not None:
+        inductiva.set_output_dir(output_dir)
+
+    futures = []
+
+    with cf.ThreadPoolExecutor(max_workers=100) as executor:
+        for task in project_tasks:
+            future = executor.submit(task.download_outputs, filenames=files)
+            futures.append(future)
+
+    cf.wait(futures)
+    print("Downloads completed.")
+
+
+def register(parser):
+    """Register the projetcs list command."""
+
+    subparser = parser.add_parser("download",
+                                  help="List the user's projetcs.",
+                                  formatter_class=argparse.RawTextHelpFormatter)
+
+    subparser.add_argument("project_name",
+                           type=str,
+                           help="Name of the project to download.")
+
+    subparser.description = (
+        "The `inductiva projects download` command provides "
+        "a way to download the tasks files of your projects.\n"
+        "You can specify the files to download with the --files flag \n"
+        "or download the standard output and error files with the --std flag.\n"
+        "If no files are specified, all files are downloaded.\n")
+
+    subparser.add_argument("--output-dir",
+                           type=str,
+                           help="Directory to save the downloaded files.")
+
+    group = subparser.add_mutually_exclusive_group()
+    group.add_argument("--files",
+                       nargs="+",
+                       type=str,
+                       help="Downloads the specified files from every task in "
+                       "the project.")
+    group.add_argument("--std",
+                       action="store_true",
+                       help="Downloads the standard output and error files.")
+
+    subparser.set_defaults(func=download_projects)

--- a/inductiva/_cli/cmd_projects/download.py
+++ b/inductiva/_cli/cmd_projects/download.py
@@ -8,15 +8,15 @@ import inductiva
 def download_projects(args):
     """Download the project tasks files.
 
-    This function downloads the files of the tasks of a project. The project
-    name is specified with the --project-name flag. The files to download can
-    be specified with the --files flag. If no files are specified, all files are
-    downloaded. The standard output and error files can be downloaded with the
-    --std flag. The files are saved in the default directory (inductiva-output)
-    if no output directory is specified with the --output-dir flag.
-
+    This function downloads the files of the tasks of a project.
+    Args:
+        args.project_name (str): Name of the project to download.
+        args.output_dir (str): Directory to save the downloaded files 
+            default(inductiva-output).
+        args.files (list): List of files to download.
+        args.std (bool): Flag to download the standard output and error files.
     The downloads are done in parallel using a ThreadPoolExecutor with a maximum
-    of 100 workers.
+    of 10 workers.
     """
 
     project_name = args.project_name
@@ -35,7 +35,7 @@ def download_projects(args):
 
     futures = []
 
-    with cf.ThreadPoolExecutor(max_workers=100) as executor:
+    with cf.ThreadPoolExecutor(max_workers=10) as executor:
         for task in project_tasks:
             future = executor.submit(task.download_outputs, filenames=files)
             futures.append(future)
@@ -45,11 +45,12 @@ def download_projects(args):
 
 
 def register(parser):
-    """Register the projetcs list command."""
+    """Register the projects download command."""
 
-    subparser = parser.add_parser("download",
-                                  help="List the user's projetcs.",
-                                  formatter_class=argparse.RawTextHelpFormatter)
+    subparser = parser.add_parser(
+        "download",
+        help="Downloads the tasks files of a project.",
+        formatter_class=argparse.RawTextHelpFormatter)
 
     subparser.add_argument("project_name",
                            type=str,

--- a/inductiva/_cli/cmd_projects/list.py
+++ b/inductiva/_cli/cmd_projects/list.py
@@ -10,10 +10,7 @@ from inductiva.utils import format_utils
 
 
 def get_projects(_, fout: TextIO = sys.stdout):
-    """ Lists the user's projects. 
-
-    Lists all the user's projects.
-    """
+    """Lists all the user's projects."""
 
     projects = inductiva.projects.project.get_projects()
     table = defaultdict(list)

--- a/inductiva/_cli/cmd_projects/list.py
+++ b/inductiva/_cli/cmd_projects/list.py
@@ -39,6 +39,7 @@ def register(parser):
     """Register the projetcs list command."""
 
     subparser = parser.add_parser("list",
+                                  aliases=["ls"],
                                   help="List the user's projetcs.",
                                   formatter_class=argparse.RawTextHelpFormatter)
 

--- a/inductiva/_cli/cmd_projects/list.py
+++ b/inductiva/_cli/cmd_projects/list.py
@@ -1,4 +1,4 @@
-"""List the user projetcs information via CLI."""
+"""List the user projects information via CLI."""
 from collections import defaultdict
 from typing import TextIO
 import argparse
@@ -10,14 +10,14 @@ from inductiva.utils import format_utils
 
 
 def get_projects(_, fout: TextIO = sys.stdout):
-    """ Lists the user's projetcs. 
+    """ Lists the user's projects. 
 
-    Lists all the user's projetcs.
+    Lists all the user's projects.
     """
 
-    projetcs = inductiva.projects.project.get_projects()
+    projects = inductiva.projects.project.get_projects()
     table = defaultdict(list)
-    for p in projetcs:
+    for p in projects:
         table["name"].append(p.name)
         table["nr_tasks"].append(p.num_tasks)
 
@@ -36,11 +36,11 @@ def get_projects(_, fout: TextIO = sys.stdout):
 
 
 def register(parser):
-    """Register the projetcs list command."""
+    """Register the projects list command."""
 
     subparser = parser.add_parser("list",
                                   aliases=["ls"],
-                                  help="List the user's projetcs.",
+                                  help="List the user's projects.",
                                   formatter_class=argparse.RawTextHelpFormatter)
 
     subparser.description = ("The `inductiva projects list` command provides "


### PR DESCRIPTION
This PR adds the commands to list and download files from projects to the CLI.

## How to use
List all projects with `inductiva projects list`

Download all files from every task in a project `inductiva projects download project-name`
Download all files from every task in a project to downlods dir `inductiva projects download project-name --output-dir downloads`
Download file1.txt from every task in a project `inductiva projects download project-name --files file1.txt`
Download stdout.txt and stderr.txt from every task in a project `inductiva projects download project-name --std`