### PR TITLE
181 - Added error_detail to the get_info() method

### DIFF
--- a/inductiva/_cli/cmd_tasks/info.py
+++ b/inductiva/_cli/cmd_tasks/info.py
@@ -1,0 +1,31 @@
+"""Prints a task information via CLI."""
+from typing import TextIO
+import argparse
+import sys
+
+from inductiva import tasks, _cli
+
+
+def task_info(args, fout: TextIO = sys.stdout):
+    """Prints a task information."""
+    task_id = args.id
+    task = tasks.Task(task_id)
+    info = task.get_info()
+    print(info, file=fout)
+    return 0
+
+
+def register(parser):
+    """Register the info tasks command."""
+    subparser = parser.add_parser("info",
+                                  help="Prints information related to a task.",
+                                  formatter_class=argparse.RawTextHelpFormatter)
+
+    subparser.description = ("The `inductiva tasks info` command provides "
+                             "an extensive list of information about a task.")
+
+    _cli.utils.add_watch_argument(subparser)
+    subparser.add_argument("id",
+                           type=str,
+                           help="ID of the task to get information about.")
+    subparser.set_defaults(func=task_info)

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -225,6 +225,8 @@ class TaskInfo:
             "\t" + line for line in data_metrics_table.splitlines())
 
         table_str = f"\nTask status: {self.status}"
+        if self.executer and self.executer.error_detail:
+            table_str += f"\n\tStatus detail: {self.executer.error_detail}"
         table_str += f"\n{wall_time_table}"
         table_str += f"\nTime breakdown:\n{time_metrics_table}"
         table_str += f"\nData:\n{data_metrics_table}\n"


### PR DESCRIPTION
This PR adds the error_detail to the get_info method. The error detail will only be added if it exists.

We also added the cli command `inductiva tasks info task_id` that will print the get_info() to the cli