### PR TITLE
1494 Increase fetch tasks per page number

### DIFF
--- a/inductiva/tasks/methods.py
+++ b/inductiva/tasks/methods.py
@@ -178,10 +178,9 @@ def get_all(
 
     all_tasks = []
     page_counter = 1
-
     while tasks_fetched := _fetch_tasks_from_api(status,
                                                  page=page_counter,
-                                                 per_page=50,
+                                                 per_page=500,
                                                  project=project):
         all_tasks.extend(tasks_fetched)
         page_counter += 1


### PR DESCRIPTION
This PR addresses issue [#1494](https://github.com/inductiva/inductiva/issues/1494).

To reduce the number of API calls, we have increased the `per_page` value. Further improvements would require modifications to the backend query logic.

This reduced `time inductiva tasks list -p pbarbosaaa788d1b` from 35s to 7.8s.