### PR TITLE
Allow -n and -p while using inductiva tasks list

### DIFF
--- a/docs/simulators/Reef3D.md
+++ b/docs/simulators/Reef3D.md
@@ -228,7 +228,7 @@ Task ggkjuzhivoon56vkozgqxapfk submitted to the queue of the Machine Group api-k
 Simulation metadata logged to: inductiva_output/task_metadata.json
 Task ggkjuzhivoon56vkozgqxapfk configurations metadata saved to the tasks metadata file task_metadata.json in the current working directory.
 Consider tracking the status of the task via CLI:
-	inductiva tasks list --task-id ggkjuzhivoon56vkozgqxapfk
+	inductiva tasks list --id ggkjuzhivoon56vkozgqxapfk
 Or, tracking the logs of the task via CLI:
 	inductiva logs ggkjuzhivoon56vkozgqxapfk
 Task ggkjuzhivoon56vkozgqxapfk successfully queued and waiting to be picked-up for execution...

--- a/docs/simulators/XBeach.md
+++ b/docs/simulators/XBeach.md
@@ -183,7 +183,7 @@ Number of tasks ahead in the queue: 0
 Simulation metadata logged to: inductiva_output/task_metadata.json
 Task 9ob6gknv794pvazg5bzd4oczo configurations metadata saved to the tasks metadata file task_metadata.json in the current working directory.
 Consider tracking the status of the task via CLI:
-	inductiva tasks list --task-id 9ob6gknv794pvazg5bzd4oczo
+	inductiva tasks list --id 9ob6gknv794pvazg5bzd4oczo
 Or, tracking the logs of the task via CLI:
 	inductiva logs 9ob6gknv794pvazg5bzd4oczo
 Task 9ob6gknv794pvazg5bzd4oczo successfully queued and waiting to be picked-up for execution...

--- a/inductiva/_cli/cmd_logs/__init__.py
+++ b/inductiva/_cli/cmd_logs/__init__.py
@@ -19,7 +19,7 @@ def register(root_parser):
         "finished, or transitioned to a status other than 'running', the\n"
         "logs will not be available for streaming.\n"
         "To check the status of a task, use:\n"
-        "  inductiva tasks list --task-id <task_id>")
+        "  inductiva tasks list --id <task_id>")
 
     utils.show_help_msg(parser)
 

--- a/inductiva/_cli/cmd_logs/logs.py
+++ b/inductiva/_cli/cmd_logs/logs.py
@@ -59,7 +59,7 @@ def _check_if_task_is_running(task: tasks.Task) -> Tuple[bool, str]:
             f"The current status of task {task.id} is '{info.status}'\n"
             "and the simulation logs are not available for streaming.\n"
             "For more information about the task status, use:\n\n"
-            f"  inductiva tasks list --task-id {task.id}\n")
+            f"  inductiva tasks list --id {task.id}\n")
 
     return True, task.id
 

--- a/inductiva/_cli/cmd_tasks/list.py
+++ b/inductiva/_cli/cmd_tasks/list.py
@@ -27,7 +27,6 @@ def list_tasks(args, fout: TextIO = sys.stdout):
             file=sys.stderr)
         return 1
 
-
     if project_name is not None:
         print(f"Showing tasks for project: {project_name}.")
         # With project the default last_n is -1 (all tasks)

--- a/inductiva/_cli/cmd_tasks/list.py
+++ b/inductiva/_cli/cmd_tasks/list.py
@@ -31,7 +31,7 @@ def _list_tasks(project_name, last_n, task_id, all_tasks: bool, fout: TextIO,
     last_n = -1 if all_tasks else last_n
 
     if task_id:
-        task_list = [tasks.Task(task_id)]
+        task_list = [tasks.Task(i) for i in task_id]
     elif project_name:
         print(f"Showing tasks for project: {project_name}.", file=fout)
         task_list = projects.Project(project_name).get_tasks(last_n=last_n)
@@ -102,6 +102,7 @@ def register(parser):
     group.add_argument("-i",
                        "--id",
                        type=str,
+                       nargs="+",
                        default=None,
                        dest="task_id",
                        help="List a task with a specific ID.")

--- a/inductiva/projects/project.py
+++ b/inductiva/projects/project.py
@@ -267,9 +267,9 @@ class Project:
             status: Status of the tasks to get. If `None`, tasks with any
                 status will be returned.
         """
-        if last_n <= 0:
-            return inductiva.tasks.get_all(status=status, project=self)
-        return inductiva.tasks.get(last_n=last_n, status=status, project=self)
+        return inductiva.tasks.get_tasks(last_n=last_n,
+                                         project=self,
+                                         status=status)
 
     def __enter__(self):
         self.open()

--- a/inductiva/tasks/__init__.py
+++ b/inductiva/tasks/__init__.py
@@ -1,6 +1,6 @@
 #pylint: disable=missing-module-docstring
 from inductiva.tasks.task import Task
 from inductiva.tasks.run_simulation import run_simulation
-from inductiva.tasks.methods import get, to_dict, get_all
+from inductiva.tasks.methods import get, to_dict, get_all, get_tasks
 from inductiva.tasks.output_info import TaskOutputInfo
 from . import streams

--- a/inductiva/tasks/methods.py
+++ b/inductiva/tasks/methods.py
@@ -5,11 +5,12 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Union
 
 import inductiva
 from inductiva import api
-from inductiva.client import ApiClient, ApiException
-from inductiva.client.apis.tags.tasks_api import TasksApi
+from inductiva import projects
 from inductiva.client import models
 from inductiva.tasks.task import Task
 from inductiva.utils import format_utils
+from inductiva.client import ApiClient, ApiException
+from inductiva.client.apis.tags.tasks_api import TasksApi
 
 
 def to_dict(list_of_tasks: Iterable[Task]) -> Mapping[str, List[Any]]:
@@ -157,6 +158,27 @@ def get(
     ]
 
     return tasks
+
+
+def get_tasks(last_n: int = 10,
+              project: projects.Project = None,
+              status: Optional[Union[str, models.TaskStatusCode]] = None):
+    """Get the last N submitted tasks.
+
+        Get the last N submitted tasks, eventually filtered by status.
+        By default, only the last 10 submitted tasks are returned,
+        irrespectively of their status.
+
+        Args:
+            last_n (int): The number of tasks with repect to the submission
+                time to fectch. If `last_n<=0` we fetch all tasks submitted
+                to the project.
+            status: Status of the tasks to get. If `None`, tasks with any
+                status will be returned.
+        """
+    if last_n <= 0:
+        return inductiva.tasks.get_all(status=status, project=project)
+    return inductiva.tasks.get(last_n=last_n, status=status, project=project)
 
 
 def get_all(

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -102,7 +102,7 @@ def run_simulation(
 
     logging.info(
         "Consider tracking the status of the task via CLI:"
-        "\n\tinductiva tasks list --task-id %s", task_id)
+        "\n\tinductiva tasks list --id %s", task_id)
     logging.info(
         "Or, tracking the logs of the task via CLI:"
         "\n\tinductiva logs %s", task_id)

--- a/inductiva/utils/format_utils.py
+++ b/inductiva/utils/format_utils.py
@@ -27,7 +27,7 @@ tabulate._table_formats["inductiva"] = TableFormat(
 
 class Emphasis(Enum):
     RED = "\033[31m"
-    GREEN = "\033[92m"
+    GREEN = "\033[32m"
     BOLD = "\033[1m"
     RESET = "\033[0m"
 

--- a/tutorials/generating-synthetic-data/synthetic-data-generation-2.md
+++ b/tutorials/generating-synthetic-data/synthetic-data-generation-2.md
@@ -131,7 +131,7 @@ Simulation metadata logged to: inductiva_output/task_metadata.json
 Task i13o8djcoq70bsdut1x73zi69 configurations metadata saved to the tasks
 metadata file task_metadata.json in the current working directory.
 Consider tracking the status of the task via CLI: 
-        inductiva tasks list --task-id i13o8djcoq70bsdut1x73zi69
+        inductiva tasks list --id i13o8djcoq70bsdut1x73zi69
 Or, tracking the logs of the task via CLI:
         inductiva logs i13o8djcoq70bsdut1x73zi69
 Task i13o8djcoq70bsdut1x73zi69 successfully queued and waiting to be picked-up


### PR DESCRIPTION
This PR allows the user to combine `-n and -p` while using `inductiva tasks list`.
Also did a small refactor to the get tasks. Added get_tasks to the tasks methods. This method either calls tasks.get or get_all based on the last_n.
The projects method `get_tasks` now is just a wrapper to the tasks.get_tasks.
