### PR TITLE
Generate coverage only if push to main

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,11 +70,11 @@ jobs:
         coverage run --source=./inductiva -m pytest --noconftest
         coverage report -m
     - name: Generate badge
-      if: ${{ always() }}
+      if: github.ref == 'refs/heads/main'
       run: |
         coverage-badge -f -o ./badges-folder/badges/cov.svg
     - name: Push badge
-      if: ${{ always() }}
+      if: github.ref == 'refs/heads/main'
       working-directory: badges-folder
       run: |
         git config user.name "${GITHUB_ACTOR}"


### PR DESCRIPTION
This PR makes the badge generation only happen when we push to main. 