### PR TITLE
Added idle_time to inductiva resources list

### DIFF
--- a/docs/how_to/manage_computational_resources.md
+++ b/docs/how_to/manage_computational_resources.md
@@ -37,10 +37,10 @@ One obtains for example the following information:
 ```
 Active Resources:
 
-       NAME                                MACHINE TYPE         ELASTIC         TYPE           # MACHINES         DATA SIZE IN GB         SPOT         STARTED AT (UTC)
-       api-23zssj6oq77xxsot3o0nhax3d       c2d-highmem-16       False           mpi            3                  70                      False        01 Feb, 12:30:06
-       api-45fetsr58okcs0x6j9m0vsi2z       c2-standard-4        True            standard       1/5                70                      False        01 Feb, 12:25:54
-       api-4kken08fnoxuu5zjjak6ak2xe       c2-standard-8        False           standard       2                  60                      True         01 Feb, 12:26:37
+ NAME                            MACHINE TYPE     ELASTIC     TYPE       # MACHINES     DATA SIZE IN GB     SPOT     STARTED AT (UTC)     IDLE TIME         MAX COST ($/HOUR)
+ api-3ejvh64mxuxnfcv3yxdhoyjuj   c2-standard-4    False       standard   5/5            50                  False    10 Jul, 16:23:00     0:04:15/0:30:00   1.4909
+ api-5014txg0rwx3jbbpf6y0ndzmv   c2d-highmem-16   False       mpi        3/3            10                  False    10 Jul, 16:22:04     0:05:12/0:30:00   3.27774
+ api-es9sjockjymvkwfmjioibfw8p   c2-standard-8    False       standard   2/2            60                  False    10 Jul, 16:23:25     0:03:50/0:30:00   1.08312
 ```
 
 ## Terminate the active computational resources

--- a/docs/how_to/manage_computational_resources.md
+++ b/docs/how_to/manage_computational_resources.md
@@ -25,7 +25,7 @@ information of each one either via Python or via the CLI.
 
 **Python**
 ```python
-inductiva.resources.machine_groups.list()
+inductiva.resources.machine_groups.get()
 ```
 
 **CLI**

--- a/inductiva/_cli/cmd_resources/list.py
+++ b/inductiva/_cli/cmd_resources/list.py
@@ -121,7 +121,8 @@ def _machine_group_list_to_str(machine_group_list) -> str:
         rows.append([
             machine_group.name, machine_group.machine_type, is_elastic,
             resource_type, num_active_machines, machine_group.data_disk_gb,
-            spot, machine_group.create_time, machine_group.idle_time,
+            spot, machine_group.create_time,
+            f"{machine_group.idle_time}/{machine_group.max_idle_time}",
             machine_group.quota_usage.get("cost_per_hour")
         ])
 

--- a/inductiva/_cli/cmd_resources/list.py
+++ b/inductiva/_cli/cmd_resources/list.py
@@ -123,7 +123,7 @@ def _machine_group_list_to_str(machine_group_list) -> str:
             resource_type, num_active_machines, machine_group.data_disk_gb,
             spot, machine_group.create_time,
             f"{machine_group.idle_time}/{machine_group.max_idle_time}",
-            machine_group.quota_usage.get("cost_per_hour")
+            machine_group.quota_usage.get("max_price_hour")
         ])
 
     formatters = {

--- a/inductiva/_cli/cmd_resources/list.py
+++ b/inductiva/_cli/cmd_resources/list.py
@@ -6,6 +6,7 @@ import bisect
 import sys
 
 from inductiva.resources.machine_types import ProviderType
+from inductiva.resources import machines_base
 from inductiva.utils import format_utils
 from inductiva import resources, _cli
 
@@ -97,9 +98,69 @@ def list_machine_types_available(args):
     pretty_print_machines_info(machines_dict)
 
 
-def list_machine_groups(unused_args, fout: TextIO = sys.stdout):
-    """List Resources."""
-    resources.machine_groups.list(fout=fout)
+def _machine_group_list_to_str(machine_group_list) -> str:
+    """Returns a string representation of a list of machine groups."""
+    columns = [
+        "Name", "Machine Type", "Elastic", "Type", "# machines",
+        "Data Size in GB", "Spot", "Started at (UTC)", "Idle Time",
+        "Max Cost ($/hour)"
+    ]
+    rows = []
+
+    for machine_group in machine_group_list:
+        is_elastic = False
+        resource_type = machines_base.ResourceType.STANDARD.value
+        spot = machine_group.spot if hasattr(machine_group, "spot") else False
+
+        if isinstance(machine_group, resources.ElasticMachineGroup):
+            is_elastic = True
+        else:
+            if isinstance(machine_group, resources.MPICluster):
+                resource_type = machines_base.ResourceType.MPI.value
+        num_active_machines = machine_group.active_machines_to_str()
+        rows.append([
+            machine_group.name, machine_group.machine_type, is_elastic,
+            resource_type, num_active_machines, machine_group.data_disk_gb,
+            spot, machine_group.create_time, machine_group.idle_time,
+            machine_group.quota_usage.get("cost_per_hour")
+        ])
+
+    formatters = {
+        "Started at (UTC)": [format_utils.datetime_formatter],
+    }
+
+    emph_formatter = format_utils.get_ansi_formatter()
+    header_formatters = [
+        lambda x: emph_formatter(x.upper(), format_utils.Emphasis.BOLD)
+    ]
+
+    return format_utils.get_tabular_str(rows,
+                                        columns,
+                                        formatters=formatters,
+                                        header_formatters=header_formatters)
+
+
+def list_machine_groups(_, fout: TextIO = sys.stdout):
+    # pylint: disable=line-too-long
+    """Lists all active resources info.
+
+    This method queries Google Cloud for active resources
+    that belong to the user. It outputs all the information relative to
+    each resource as folllows:
+
+    Active Resources:
+                                        Name         VM Type    Elastic   # machines    Disk Size in GB       Spot   Started at (UTC)
+    api-6359c03d-c4f9-479f-8b11-ba1f8f55a58c   e2-standard-4      False            3                 40      False   10 Oct, 13:40:50
+    api-db2046cf-a6fc-4124-926c-1a24329da5ea   e2-standard-4       True          2/4                 40      False   10 Oct, 12:43:03
+    """
+    # pylint: enable=line-too-long
+
+    machine_group_list = resources.machine_groups.get()
+    if len(machine_group_list) != 0:
+        print("Active Resources:", file=fout)
+        print(_machine_group_list_to_str(machine_group_list), file=fout, end="")
+    else:
+        print("No active computational resources found.", file=fout, end="")
 
 
 def register(parser):

--- a/inductiva/resources/__init__.py
+++ b/inductiva/resources/__init__.py
@@ -5,3 +5,4 @@ from . import machine_groups
 from .machine_groups import estimate_machine_cost
 from .machine_cluster import MPICluster
 from .machine_types import list_available_machines
+from .machine_groups import get

--- a/inductiva/resources/machine_groups.py
+++ b/inductiva/resources/machine_groups.py
@@ -1,14 +1,11 @@
 """Functions to manage or retrieve user resources."""
-from typing import Optional, TextIO
+from typing import Optional
 from absl import logging
-import sys
 
 import inductiva
 import inductiva.client
 from inductiva.client.apis.tags import compute_api
-from inductiva.utils import format_utils
 from inductiva import resources
-from . import machines_base
 
 
 def estimate_machine_cost(machine_type: str, spot: bool = False):
@@ -36,47 +33,6 @@ def estimate_machine_cost(machine_type: str, spot: bool = False):
     return float(estimated_cost)
 
 
-def _machine_group_list_to_str(machine_group_list) -> str:
-    """Returns a string representation of a list of machine groups."""
-    columns = [
-        "Name", "Machine Type", "Elastic", "Type", "# machines",
-        "Data Size in GB", "Spot", "Started at (UTC)", "Max Cost ($/hour)"
-    ]
-    rows = []
-
-    for machine_group in machine_group_list:
-        is_elastic = False
-        resource_type = machines_base.ResourceType.STANDARD.value
-        spot = machine_group.spot if hasattr(machine_group, "spot") else False
-
-        if isinstance(machine_group, resources.ElasticMachineGroup):
-            is_elastic = True
-        else:
-            if isinstance(machine_group, resources.MPICluster):
-                resource_type = machines_base.ResourceType.MPI.value
-        num_active_machines = machine_group.active_machines_to_str()
-        rows.append([
-            machine_group.name, machine_group.machine_type, is_elastic,
-            resource_type, num_active_machines, machine_group.data_disk_gb,
-            spot, machine_group.create_time,
-            machine_group.quota_usage.get("cost_per_hour")
-        ])
-
-    formatters = {
-        "Started at (UTC)": [format_utils.datetime_formatter],
-    }
-
-    emph_formatter = format_utils.get_ansi_formatter()
-    header_formatters = [
-        lambda x: emph_formatter(x.upper(), format_utils.Emphasis.BOLD)
-    ]
-
-    return format_utils.get_tabular_str(rows,
-                                        columns,
-                                        formatters=formatters,
-                                        header_formatters=header_formatters)
-
-
 def _fetch_machine_groups_from_api():
     """Get all active machine groups of a user from the API."""
     try:
@@ -87,30 +43,6 @@ def _fetch_machine_groups_from_api():
 
     except inductiva.client.ApiException as api_exception:
         raise api_exception
-
-
-# pylint: disable=redefined-builtin
-def list(fout: TextIO = sys.stdout):
-    # pylint: disable=line-too-long
-    """Lists all active resources info.
-
-    This method queries Google Cloud for active resources
-    that belong to the user. It outputs all the information relative to
-    each resource as folllows:
-
-    Active Resources:
-                                        Name         VM Type    Elastic   # machines    Disk Size in GB       Spot   Started at (UTC)
-    api-6359c03d-c4f9-479f-8b11-ba1f8f55a58c   e2-standard-4      False            3                 40      False   10 Oct, 13:40:50
-    api-db2046cf-a6fc-4124-926c-1a24329da5ea   e2-standard-4       True          2/4                 40      False   10 Oct, 12:43:03
-    """
-    # pylint: enable=line-too-long
-
-    machine_group_list = get()
-    if len(machine_group_list) != 0:
-        print("Active Resources:", file=fout)
-        print(_machine_group_list_to_str(machine_group_list), file=fout, end="")
-    else:
-        print("No active computational resources found.", file=fout, end="")
 
 
 def get_by_name(machine_name: str):

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -104,6 +104,13 @@ class BaseMachineGroup:
     def auto_terminate_ts(self):
         return self._auto_terminate_ts
 
+    @property
+    def idle_time(self) -> str:
+        """
+        String representation of the idle time in seconds.
+        """
+        return f"{self._idle_seconds}/{self._max_idle_time}"
+
     @staticmethod
     def _timedelta_to_seconds(
             value: Optional[datetime.timedelta] = None) -> Optional[float]:
@@ -176,6 +183,8 @@ class BaseMachineGroup:
         # from the API response if they were not provided by the user
         self._max_idle_time = self._seconds_to_timedelta(
             body.get("max_idle_time"))
+        self._idle_seconds = self._seconds_to_timedelta(
+            body.get("idle_seconds"))
         self._auto_terminate_ts = self._iso_to_datetime(
             body.get("auto_terminate_ts"))
         self._log_machine_group_info()
@@ -206,6 +215,8 @@ class BaseMachineGroup:
         machine_group.quota_usage = resp.get("quota_usage") or {}
         machine_group._max_idle_time = cls._seconds_to_timedelta(
             resp.get("max_idle_time"))
+        machine_group._idle_seconds = cls._seconds_to_timedelta(
+            resp.get("idle_seconds"))
         machine_group._auto_terminate_ts = cls._iso_to_datetime(
             resp.get("auto_terminate_ts"))
 

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -97,7 +97,7 @@ class BaseMachineGroup:
         return self._name
 
     @property
-    def max_idle_time(self):
+    def max_idle_time(self) -> datetime.timedelta:
         return self._max_idle_time
 
     @property
@@ -105,7 +105,7 @@ class BaseMachineGroup:
         return self._auto_terminate_ts
 
     @property
-    def idle_time(self) -> str:
+    def idle_time(self) -> datetime.timedelta:
         """
         Resource idle time in seconds.
         """

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -107,9 +107,9 @@ class BaseMachineGroup:
     @property
     def idle_time(self) -> str:
         """
-        String representation of the idle time in seconds.
+        Resource idle time in seconds.
         """
-        return f"{self._idle_seconds}/{self._max_idle_time}"
+        return self._idle_seconds
 
     @staticmethod
     def _timedelta_to_seconds(


### PR DESCRIPTION
Issue [#107](https://github.com/inductiva/tasks/issues/107)

This PR adds Idle time to the resources listing via the cli.

```
NAME                            MACHINE TYPE     ELASTIC     TYPE       # MACHINES     DATA SIZE IN GB     SPOT     STARTED AT (UTC)     IDLE TIME     MAX COST ($/HOUR)
 api-n8yek6gn3sde5jure0f6o253f   c2d-standard-4   False       standard   1/1            10                  False    04 Jul, 17:10:48     0:07:20/0:30:00       0.19996
```

Also did a small code refactor. Moved some code from machine_group to the cli.

We removed the machine_groups.list() method. To make it consistent with tasks.get() we now should only use resources.get() or resources.machine_group.get()