### PR TITLE
Correct bug in retrieving simulator image in simulator.py

### DIFF
--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -151,7 +151,7 @@ class Simulator(ABC):
 
         # Get the user-specified image name. If not specified,
         # use the default image name for the current simulator
-        container_image = kwargs.get("container_image", self._image_uri)
+        container_image = kwargs.pop("container_image", self._image_uri)
 
         return tasks.run_simulation(
             self.api_method_name,


### PR DESCRIPTION
A bug in getting the name of the simulator image was causing a type error exception when the explicit name of the image is passed on through the `simulator.run` method:

```
>>> swash = inductiva.simulators.SWASH()
>>> task = swash.run(input_dir=input_dir,
                 sim_config_filename="input.sws",
                 container_image='docker://inductiva/kutu:swash_v9.01A')
...
TypeError: inductiva.tasks.run_simulation.run_simulation() got multiple values for keyword argument 'container_image'
```

With this fix, multiple keyword arguments with the `container_image` name are no longer possible.