### PR TITLE
Add `resubmit_on_preemption`option to the `Simulator.run` method

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -342,6 +342,7 @@ def submit_task(api_instance,
                 params,
                 type_annotations,
                 provider_id: ProviderType,
+                resubmit_on_preemption: bool = False,
                 container_image: Optional[str] = None,
                 simulator=None):
     """Submit a task and send input files to the API."""
@@ -359,11 +360,12 @@ def submit_task(api_instance,
     task_request = TaskRequest(
         method=method_name,
         params=request_params,
-        resource_pool=resource_pool_id,
-        storage_path_prefix=storage_path_prefix,
-        container_image=container_image,
-        provider_id=provider_id.value,
         project=current_project,
+        provider_id=provider_id.value,
+        resource_pool=resource_pool_id,
+        container_image=container_image,
+        storage_path_prefix=storage_path_prefix,
+        resubmit_on_preemption=resubmit_on_preemption,
     )
 
     task_submitted_info = submit_request(
@@ -400,6 +402,7 @@ def invoke_async_api(method_name: str,
                      storage_path_prefix: Optional[str] = "",
                      provider_id: ProviderType = ProviderType.GCP,
                      container_image: Optional[str] = None,
+                     resubmit_on_preemption: bool = False,
                      simulator=None) -> str:
     """Perform a task asyc and remotely via Inductiva's Web API.
 
@@ -423,7 +426,10 @@ def invoke_async_api(method_name: str,
         provider_id: The provider id to use for the simulation (GCP or ICE).
         container_image: The container image to use for the simulation
             Example: container_image="docker://inductiva/kutu:xbeach_v1.23_dev"
-
+        resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
     Return:
         Returns the task id.
     """
@@ -447,6 +453,7 @@ def invoke_async_api(method_name: str,
                               provider_id=provider_id,
                               container_image=container_image,
                               type_annotations=type_annotations,
+                              resubmit_on_preemption=resubmit_on_preemption,
                               simulator=simulator)
 
     return task_id

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -35,6 +35,7 @@ class AmrWind(simulators.Simulator):
             extra_metadata: Optional[dict] = None,
             storage_dir: Optional[str] = "",
             on: Optional[types.ComputationalResources] = None,
+            resubmit_on_preemption: bool = False,
             **kwargs) -> tasks.Task:
         """Run the simulation.
         Args:
@@ -47,6 +48,10 @@ class AmrWind(simulators.Simulator):
             on: The computational resource to launch the simulation on. If None
                 the simulation is submitted to a machine in the default pool.
             other arguments: See the documentation of the base class.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
         """
         return super().run(input_dir,
                            on=on,
@@ -55,4 +60,5 @@ class AmrWind(simulators.Simulator):
                            use_hwthread=use_hwthread,
                            extra_metadata=extra_metadata,
                            input_filename=sim_config_filename,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -30,6 +30,7 @@ class CaNS(simulators.Simulator):
             n_vcpus: Optional[int] = None,
             extra_metadata: Optional[dict] = None,
             storage_dir: Optional[str] = "",
+            resubmit_on_preemption: bool = False,
             on: Optional[types.ComputationalResources] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
@@ -43,6 +44,10 @@ class CaNS(simulators.Simulator):
             number of slots available.
             on: The computational resource to launch the simulation on. If None
                 the simulation is submitted to a machine in the default pool.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
             other arguments: See the documentation of the base class.
         """
         return super().run(input_dir,
@@ -52,4 +57,5 @@ class CaNS(simulators.Simulator):
                            use_hwthread=use_hwthread,
                            extra_metadata=extra_metadata,
                            input_filename=sim_config_filename,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -28,6 +28,7 @@ class DualSPHysics(simulators.Simulator):
         on: Optional[types.ComputationalResources] = None,
         storage_dir: Optional[str] = "",
         extra_metadata: Optional[dict] = None,
+        resubmit_on_preemption: bool = False,
         **kwargs,
     ) -> tasks.Task:
         """Executes a DualSPHysics simulation.
@@ -38,6 +39,10 @@ class DualSPHysics(simulators.Simulator):
             on: The computational resource to launch the simulation on. If None
                 the simulation is submitted to a machine in the default pool.
             storage_dir: Directory for storing results.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
 
         Returns:
             tasks.Task: An object representing the simulation task.
@@ -47,4 +52,5 @@ class DualSPHysics(simulators.Simulator):
                            commands=commands,
                            storage_dir=storage_dir,
                            extra_metadata=extra_metadata,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/simulators/dummy_simulator.py
+++ b/inductiva/simulators/dummy_simulator.py
@@ -14,7 +14,7 @@ class DummySimulator(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -25,21 +25,29 @@ class DummySimulator(simulators.Simulator):
         super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "tester.echo.run_simulation"
 
+    def _get_image_uri(self):
+        return None
+
     def run(self,
             input_dir: str,
             input_filename: str,
             sleep_time: Optional[float] = 1,
             on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
+            resubmit_on_preemption: bool = False,
             extra_metadata: Optional[dict] = None,
             **kwargs) -> tasks.Task:
         """Run a dummy simulation that echo's to a file.
-        
-        Args: 
+
+        Args:
             input_dir: Path to directory with simulation input files.
             input_filename: Name of the test input file.
             sleep_time: Time to sleep before running the commands.
             extra_metadata: Extra metadata to be sent to the backend.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
         """
 
         return super().run(input_dir,
@@ -48,4 +56,5 @@ class DummySimulator(simulators.Simulator):
                            sleep_time=sleep_time,
                            storage_dir=storage_dir,
                            extra_metadata=extra_metadata,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -3,7 +3,6 @@
 from typing import Optional
 
 from inductiva import types, tasks, simulators
-from inductiva.utils import meta
 
 
 class FDS(simulators.Simulator):
@@ -11,7 +10,7 @@ class FDS(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the FDS simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -22,7 +21,6 @@ class FDS(simulators.Simulator):
         super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "fdm.fds.run_simulation"
 
-    @meta.deprecated_arg(n_cores="n_vcpus")
     def run(self,
             input_dir: str,
             sim_config_filename: str,
@@ -32,6 +30,7 @@ class FDS(simulators.Simulator):
             on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
+            resubmit_on_preemption: bool = False,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -46,6 +45,10 @@ class FDS(simulators.Simulator):
             on: The computational resource to launch the simulation on. If None
                 the simulation is submitted to a machine in the default pool.
             other arguments: See the documentation of the base class.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
         """
         return super().run(input_dir,
                            on=on,
@@ -55,4 +58,5 @@ class FDS(simulators.Simulator):
                            n_vcpus=n_vcpus,
                            use_hwthread=use_hwthread,
                            extra_metadata=extra_metadata,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/simulators/fenicsx.py
+++ b/inductiva/simulators/fenicsx.py
@@ -10,7 +10,7 @@ class FEniCSx(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the FEniCSx simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -20,6 +20,9 @@ class FEniCSx(simulators.Simulator):
         """
         super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "fem.fenicsx.run_simulation"
+
+    def _get_image_uri(self):
+        return None
 
     def run(self,
             input_dir: str,

--- a/inductiva/simulators/gromacs.py
+++ b/inductiva/simulators/gromacs.py
@@ -27,6 +27,7 @@ class GROMACS(simulators.Simulator):
         commands: types.Commands,
         on: Optional[types.ComputationalResources] = None,
         storage_dir: Optional[str] = "",
+        resubmit_on_preemption: bool = False,
         extra_metadata: Optional[dict] = None,
         **kwargs,
     ) -> tasks.Task:
@@ -39,6 +40,10 @@ class GROMACS(simulators.Simulator):
                 the simulation is submitted to a machine in the default pool.
             storage_dir: Parent directory for storing simulation
                                results.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
         """
 
         return super().run(input_dir,
@@ -46,4 +51,5 @@ class GROMACS(simulators.Simulator):
                            commands=commands,
                            storage_dir=storage_dir,
                            extra_metadata=extra_metadata,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/simulators/nwchem.py
+++ b/inductiva/simulators/nwchem.py
@@ -30,6 +30,7 @@ class NWChem(simulators.Simulator):
             on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
+            resubmit_on_preemption: bool = False,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -44,6 +45,10 @@ class NWChem(simulators.Simulator):
             on: The computational resource to launch the simulation on. If None
                 the simulation is submitted to a machine in the default pool.
             other arguments: See the documentation of the base class.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
         """
         return super().run(input_dir,
                            on=on,
@@ -52,4 +57,5 @@ class NWChem(simulators.Simulator):
                            n_vcpus=n_vcpus,
                            use_hwthread=use_hwthread,
                            extra_metadata=extra_metadata,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/simulators/openfast.py
+++ b/inductiva/simulators/openfast.py
@@ -28,6 +28,7 @@ class OpenFAST(simulators.Simulator):
             on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
+            resubmit_on_preemption: bool = False,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -37,10 +38,15 @@ class OpenFAST(simulators.Simulator):
             on: The computational resource to launch the simulation on. If None
                 the simulation is submitted to a machine in the default pool.
             other arguments: See the documentation of the base class.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
         """
         return super().run(input_dir,
                            on=on,
                            commands=commands,
                            storage_dir=storage_dir,
                            extra_metadata=extra_metadata,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -55,6 +55,7 @@ class OpenFOAM(simulators.Simulator):
             on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
+            resubmit_on_preemption: bool = False,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -68,6 +69,10 @@ class OpenFOAM(simulators.Simulator):
             number of slots available.
             on: The computational resource to launch the simulation on. If None
                 the simulation is submitted to a machine in the default pool.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
             other arguments: See the documentation of the base class.
         """
         return super().run(input_dir,
@@ -77,4 +82,5 @@ class OpenFOAM(simulators.Simulator):
                            n_vcpus=n_vcpus,
                            use_hwthread=use_hwthread,
                            extra_metadata=extra_metadata,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -29,6 +29,7 @@ class REEF3D(simulators.Simulator):
             on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
+            resubmit_on_preemption: bool = False,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -42,6 +43,10 @@ class REEF3D(simulators.Simulator):
             sim_config_filename: Name of the simulation configuration file.
             on: The computational resource to launch the simulation on. If None
                 the simulation is submitted to a machine in the default pool.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
             other arguments: See the documentation of the base class.
         """
         return super().run(input_dir,
@@ -50,4 +55,5 @@ class REEF3D(simulators.Simulator):
                            n_vcpus=n_vcpus,
                            use_hwthread=use_hwthread,
                            extra_metadata=extra_metadata,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/simulators/schism.py
+++ b/inductiva/simulators/schism.py
@@ -29,6 +29,7 @@ class SCHISM(simulators.Simulator):
             use_hwthread: bool = True,
             extra_metadata: Optional[dict] = None,
             n_vcpus: int = None,
+            resubmit_on_preemption: bool = False,
             **kwargs) -> tasks.Task:
         """Run the simulation.
         Args:
@@ -44,6 +45,10 @@ class SCHISM(simulators.Simulator):
             number of hardware threads on the node, and use that as the
             number of slots available.
             n_vcpus: Number of virtual cpus
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
         """
         return super().run(input_dir,
                            on=on,
@@ -52,4 +57,5 @@ class SCHISM(simulators.Simulator):
                            n_vcpus=n_vcpus,
                            use_hwthread=use_hwthread,
                            extra_metadata=extra_metadata,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/simulators/simsopt.py
+++ b/inductiva/simulators/simsopt.py
@@ -9,7 +9,7 @@ class SIMSOPT(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the SIMOPT simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -19,6 +19,9 @@ class SIMSOPT(simulators.Simulator):
         """
         super().__init__(version=version, use_dev=use_dev)
         self.api_method_name = "stellarators.simsopt.run_simulation"
+
+    def _get_image_uri(self):
+        return None
 
     def run(
         self,
@@ -33,6 +36,7 @@ class SIMSOPT(simulators.Simulator):
         objectives_weights_filename: str,
         on: Optional[types.ComputationalResources] = None,
         storage_dir: Optional[str] = "",
+        resubmit_on_preemption: bool = False,
         extra_metadata: Optional[dict] = None,
         **kwargs,
     ) -> tasks.Task:
@@ -64,6 +68,10 @@ class SIMSOPT(simulators.Simulator):
               each objective function used in the construction of the total
               objective.
             storage_dir: Directory for storing results.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
             other arguments: See the documentation of the base class.
         """
         return super().run(
@@ -72,6 +80,7 @@ class SIMSOPT(simulators.Simulator):
             coil_coefficients_filename=coil_coefficients_filename,
             plasma_surface_filename=plasma_surface_filename,
             coil_currents_filename=coil_currents_filename,
+            resubmit_on_preemption=resubmit_on_preemption,
             sigma_scaling_factor=sigma_scaling_factor,
             num_field_periods=num_field_periods,
             num_iterations=num_iterations,

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -126,6 +126,7 @@ class Simulator(ABC):
         *_args,
         on: Optional[types.ComputationalResources] = None,
         storage_dir: Optional[str] = "",
+        resubmit_on_preemption: bool = False,
         extra_metadata: Optional[dict] = None,
         **kwargs,
     ) -> tasks.Task:
@@ -139,6 +140,10 @@ class Simulator(ABC):
                 the simulation is launched in a machine of the default pool.
             storage_dir: Parent directory for storing simulation
                                results.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
             **kwargs: Additional keyword arguments to be passed to the
                 simulation API method.
         """
@@ -157,11 +162,12 @@ class Simulator(ABC):
         return tasks.run_simulation(
             self.api_method_name,
             input_dir_path,
+            simulator=self,
             storage_dir=storage_dir,
             computational_resources=on,
             extra_metadata=extra_metadata,
             container_image=container_image,
-            simulator=self,
+            resubmit_on_preemption=resubmit_on_preemption,
             **kwargs,
         )
 

--- a/inductiva/simulators/splishsplash.py
+++ b/inductiva/simulators/splishsplash.py
@@ -26,6 +26,7 @@ class SplishSplash(simulators.Simulator):
         sim_config_filename: str,
         on: Optional[types.ComputationalResources] = None,
         storage_dir: Optional[str] = "",
+        resubmit_on_preemption: bool = False,
         extra_metadata: Optional[dict] = None,
         **kwargs,
     ) -> tasks.Task:
@@ -37,6 +38,10 @@ class SplishSplash(simulators.Simulator):
             on: The computational resource to launch the simulation on. If None
                 the simulation is submitted to a machine in the default pool.
             storage_dir: Directory for storing simulation results.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
         Returns:
             Task object representing the simulation task.
         """
@@ -46,5 +51,6 @@ class SplishSplash(simulators.Simulator):
             extra_metadata=extra_metadata,
             storage_dir=storage_dir,
             on=on,
+            resubmit_on_preemption=resubmit_on_preemption,
             **kwargs,
         )

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -29,6 +29,7 @@ class SWAN(simulators.Simulator):
         use_hwthread: bool = True,
         on: Optional[types.ComputationalResources] = None,
         storage_dir: Optional[str] = "",
+        resubmit_on_preemption: bool = False,
         extra_metadata: Optional[dict] = None,
         **kwargs,
     ) -> tasks.Task:
@@ -45,6 +46,10 @@ class SWAN(simulators.Simulator):
             on: The computational resource to launch the simulation on. If None
                 the simulation is submitted to a machine in the default pool.
             storage_dir: Directory for storing simulation results.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
         """
         return super().run(input_dir,
                            on=on,
@@ -53,4 +58,5 @@ class SWAN(simulators.Simulator):
                            n_vcpus=n_vcpus,
                            use_hwthread=use_hwthread,
                            extra_metadata=extra_metadata,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -29,6 +29,7 @@ class SWASH(simulators.Simulator):
             on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
+            resubmit_on_preemption: bool = False,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -42,6 +43,10 @@ class SWASH(simulators.Simulator):
             number of slots available.
             on: The computational resource to launch the simulation on. If None
                 the simulation is submitted to a machine in the default pool.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
             storage_dir: Directory for storing simulation results.
         """
         return super().run(input_dir,
@@ -51,4 +56,5 @@ class SWASH(simulators.Simulator):
                            n_vcpus=n_vcpus,
                            use_hwthread=use_hwthread,
                            extra_metadata=extra_metadata,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -29,6 +29,7 @@ class XBeach(simulators.Simulator):
             on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
+            resubmit_on_preemption: bool = False,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -43,6 +44,10 @@ class XBeach(simulators.Simulator):
             on: The computational resource to launch the simulation on. If None
                 the simulation is submitted to a machine in the default pool.
             storage_dir: Directory for storing simulation results.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
             other arguments: See the documentation of the base class.
         """
         return super().run(input_dir,
@@ -52,4 +57,5 @@ class XBeach(simulators.Simulator):
                            n_vcpus=n_vcpus,
                            use_hwthread=use_hwthread,
                            extra_metadata=extra_metadata,
+                           resubmit_on_preemption=resubmit_on_preemption,
                            **kwargs)

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -21,6 +21,7 @@ _metadata_lock = threading.RLock()
 def run_simulation(
     api_method_name: str,
     input_dir: pathlib.Path,
+    resubmit_on_preemption: bool = False,
     computational_resources: Optional[types.ComputationalResources] = None,
     provider_id: Optional[Union[ProviderType, str]] = ProviderType.GCP,
     storage_dir: Optional[str] = "",
@@ -50,6 +51,7 @@ def run_simulation(
     task_id = api_invoker(api_method_name,
                           params,
                           type_annotations,
+                          resubmit_on_preemption=resubmit_on_preemption,
                           resource_pool=computational_resources,
                           container_image=container_image,
                           storage_path_prefix=storage_dir,

--- a/inductiva/tests/simulators/test_simulator_with_resources.py
+++ b/inductiva/tests/simulators/test_simulator_with_resources.py
@@ -213,7 +213,7 @@ def test_resubmit_on_preemption__is_correctly_handled(resubmit_on_preemption):
         method_signature = inspect.signature(simcls.run)
         assert resubmit_key in method_signature.parameters
 
-        api_invoker = "inductiva.tasks.run_simulation.methods.invoke_async_api"
+        api_invoker = "inductiva.api.methods.invoke_async_api"
         with mock.patch(api_invoker) as invoker_mock,\
             mock.patch.dict(os.environ,
                             {"DISABLE_TASK_METADATA_LOGGING": "true"}), \

--- a/inductiva/tests/simulators/test_simulator_with_resources.py
+++ b/inductiva/tests/simulators/test_simulator_with_resources.py
@@ -226,16 +226,17 @@ def test_resubmit_on_preemption__is_correctly_handled(resubmit_on_preemption):
             list_mock.return_value = {"production": DefaultDictMock()}
 
             sim_obj = simcls()
-            invoker_kwargs = invoker_mock.call_args.kwargs
             if resubmit_on_preemption is None:
                 # test that the default value of
                 # `resubmit_on_preemption` is False
                 sim_obj.run("inductiva/tests/simulators/test_input_dir", [])
+                invoker_kwargs = invoker_mock.call_args.kwargs
                 assert not invoker_kwargs[resubmit_key]
             else:
                 # test that the value of `resubmit_on_preemption` is passed
                 # correctly to the final api call
                 sim_obj.run("inductiva/tests/simulators/test_input_dir", [],
                             resubmit_on_preemption=resubmit_on_preemption)
+                invoker_kwargs = invoker_mock.call_args.kwargs
                 assert invoker_kwargs[resubmit_key] == resubmit_on_preemption
             invoker_mock.assert_called_once()


### PR DESCRIPTION
Task [#267](https://github.com/inductiva/tasks/issues/267)

This PR addresses the need to add the parameter `resubmit_on_preemption` to the Simulator.run method that specifies if the task is to be resubmitted when a spot is preempted and the task is not completed.