### PR TITLE
Improved exception handling

### DIFF
--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -171,10 +171,9 @@ def _check_user_credits():
     if utils.format_utils.getenv_bool("GITHUB_ACTIONS", False):
         return
 
-    # Determine if we are importing from cli or script file
-    caller = sys.argv[0]
-    if not caller.endswith(("inductiva", "inductiva.exe")):
-        # Only print credits info if called from script file
+    if not logs.is_cli():
+        # Determine if we are importing from cli or script file
+        # and only print credits info if called from a script file
         get_info(None, sys.stdout)
 
 

--- a/inductiva/constants.py
+++ b/inductiva/constants.py
@@ -17,4 +17,7 @@ LOADER_COMMAND_PREFIX = "cmd_"
 
 LOADER_IGNORE_PREFIX = "_"
 
+# when printing the stack trace, how many lines to show
+EXCEPTIONS_MAX_TRACEBACK_DEPTH = 2
+
 HOME_DIR = pathlib.Path.home() / ".inductiva"

--- a/inductiva/logs/__init__.py
+++ b/inductiva/logs/__init__.py
@@ -1,2 +1,2 @@
 #pylint: disable=missing-module-docstring
-from .log import setup
+from .log import setup, is_cli

--- a/inductiva/logs/log.py
+++ b/inductiva/logs/log.py
@@ -1,4 +1,5 @@
 """Custom logging functions"""
+import traceback
 import json
 import os
 
@@ -37,16 +38,59 @@ class NoExceptionFormatter(logging.Formatter):
 
 
 def handle_uncaught_exception(exc_type, exc_value, exc_traceback):
-    if _handle_api_exception(exc_type, exc_value, exc_traceback):
+    if _handle_api_exception(exc_type, exc_value, exc_traceback,
+                             notebook=False):
         return
     sys.__excepthook__(exc_type, exc_value, exc_traceback)
 
 
-def _handle_api_exception(exc_type, exc_value, exc_traceback):
+def _get_traceback_first_and_last_lines(exc_traceback, n_lines: int,
+                                        notebook: bool):
+    """
+    This method gets the first and last N lines of the traceback.
+    Args:
+        exc_traceback: traceback object.
+        n_lines: number of lines to get.
+    """
+    tb_list = traceback.extract_tb(exc_traceback)
+
+    skip = 1 if notebook else 0
+
+    tb_first_list = tb_list[skip:n_lines + skip]
+    tb_last_list = tb_list[-n_lines:]
+
+    first_formatted_tb = [
+        f"  - {frame.filename} line {frame.lineno}, in {frame.name}"
+        for frame in tb_first_list
+    ]
+    last_formatted_tb = [
+        f"  - {frame.filename} line {frame.lineno}, in {frame.name}"
+        for frame in tb_last_list
+    ]
+
+    result_string = ("\n".join(first_formatted_tb) + "\n" + \
+                     "    ...\n" +
+                     "\n".join(last_formatted_tb) + "\n")
+
+    return result_string
+
+
+def _handle_api_exception(exc_type, exc_value, exc_traceback, notebook: bool):
     if issubclass(exc_type, exceptions.ApiException) and \
         400 <= exc_value.status  < 500:
         detail = json.loads(exc_value.body)["detail"]
-        root_logger.error("Error: %s",
+
+        # Gets the last N lines of the traceback
+        formatted_tb = _get_traceback_first_and_last_lines(
+            exc_traceback,
+            constants.EXCEPTIONS_MAX_TRACEBACK_DEPTH,
+            notebook=notebook)
+
+        detail = (f"{detail} in:\n{formatted_tb}\n"
+                  "For more information on this error, "
+                  f"check the logs at {get_logs_file_path()}")
+
+        root_logger.error("ERROR: %s",
                           detail,
                           exc_info=(exc_type, exc_value, exc_traceback))
         return True
@@ -63,7 +107,7 @@ def ipy_handle_uncaught_exception(self,
                                   exc_value,
                                   exc_traceback,
                                   tb_offset=None):
-    if _handle_api_exception(exc_type, exc_value, exc_traceback):
+    if _handle_api_exception(exc_type, exc_value, exc_traceback, notebook=True):
         return
     self.showtraceback((exc_type, exc_value, exc_traceback),
                        tb_offset=tb_offset)

--- a/inductiva/logs/log.py
+++ b/inductiva/logs/log.py
@@ -39,13 +39,13 @@ class NoExceptionFormatter(logging.Formatter):
 
 def handle_uncaught_exception(exc_type, exc_value, exc_traceback):
     if _handle_api_exception(exc_type, exc_value, exc_traceback,
-                             notebook=False):
+                             is_notebook=False):
         return
     sys.__excepthook__(exc_type, exc_value, exc_traceback)
 
 
 def _get_traceback_first_and_last_lines(exc_traceback, n_lines: int,
-                                        notebook: bool):
+                                        is_notebook: bool):
     """
     This method gets the first and last N lines of the traceback.
     Args:
@@ -54,7 +54,7 @@ def _get_traceback_first_and_last_lines(exc_traceback, n_lines: int,
     """
     tb_list = traceback.extract_tb(exc_traceback)
 
-    skip = 1 if notebook else 0
+    skip = 1 if is_notebook else 0
 
     tb_first_list = tb_list[skip:n_lines + skip]
     tb_last_list = tb_list[-n_lines:]
@@ -75,7 +75,7 @@ def _get_traceback_first_and_last_lines(exc_traceback, n_lines: int,
     return result_string
 
 
-def _handle_api_exception(exc_type, exc_value, exc_traceback, notebook: bool):
+def _handle_api_exception(exc_type, exc_value, exc_traceback, is_notebook: bool):
     if issubclass(exc_type, exceptions.ApiException) and \
         400 <= exc_value.status  < 500:
         detail = json.loads(exc_value.body)["detail"]
@@ -84,7 +84,7 @@ def _handle_api_exception(exc_type, exc_value, exc_traceback, notebook: bool):
         formatted_tb = _get_traceback_first_and_last_lines(
             exc_traceback,
             constants.EXCEPTIONS_MAX_TRACEBACK_DEPTH,
-            notebook=notebook)
+            is_notebook=is_notebook)
 
         detail = (f"{detail} in:\n{formatted_tb}\n"
                   "For more information on this error, "
@@ -107,7 +107,7 @@ def ipy_handle_uncaught_exception(self,
                                   exc_value,
                                   exc_traceback,
                                   tb_offset=None):
-    if _handle_api_exception(exc_type, exc_value, exc_traceback, notebook=True):
+    if _handle_api_exception(exc_type, exc_value, exc_traceback, is_notebook=True):
         return
     self.showtraceback((exc_type, exc_value, exc_traceback),
                        tb_offset=tb_offset)

--- a/inductiva/logs/log.py
+++ b/inductiva/logs/log.py
@@ -17,6 +17,12 @@ from inductiva.utils import format_utils
 root_logger = logging.getLogger()
 
 
+def is_cli():
+    """Determines if the caller is the CLI"""
+    caller = sys.argv[0]
+    return caller.endswith(("inductiva", "inductiva.exe"))
+
+
 def get_logs_file_path():
     system = platform.system()
     logs_name = "inductiva.log"
@@ -89,9 +95,10 @@ def _handle_api_exception(exc_type, exc_value, exc_traceback,
             constants.EXCEPTIONS_MAX_TRACEBACK_DEPTH,
             is_notebook=is_notebook)
 
-        detail = (f"{detail} in:\n{formatted_tb}\n"
-                  "For more information on this error, "
-                  f"check the logs at {get_logs_file_path()}")
+        if not is_cli():
+            detail = (f"{detail}\n  in:\n{formatted_tb}\n"
+                      "For more information on this error, "
+                      f"check the logs at {get_logs_file_path()}")
 
         root_logger.error("ERROR: %s",
                           detail,

--- a/inductiva/logs/log.py
+++ b/inductiva/logs/log.py
@@ -38,7 +38,9 @@ class NoExceptionFormatter(logging.Formatter):
 
 
 def handle_uncaught_exception(exc_type, exc_value, exc_traceback):
-    if _handle_api_exception(exc_type, exc_value, exc_traceback,
+    if _handle_api_exception(exc_type,
+                             exc_value,
+                             exc_traceback,
                              is_notebook=False):
         return
     sys.__excepthook__(exc_type, exc_value, exc_traceback)
@@ -75,7 +77,8 @@ def _get_traceback_first_and_last_lines(exc_traceback, n_lines: int,
     return result_string
 
 
-def _handle_api_exception(exc_type, exc_value, exc_traceback, is_notebook: bool):
+def _handle_api_exception(exc_type, exc_value, exc_traceback,
+                          is_notebook: bool):
     if issubclass(exc_type, exceptions.ApiException) and \
         400 <= exc_value.status  < 500:
         detail = json.loads(exc_value.body)["detail"]
@@ -107,7 +110,10 @@ def ipy_handle_uncaught_exception(self,
                                   exc_value,
                                   exc_traceback,
                                   tb_offset=None):
-    if _handle_api_exception(exc_type, exc_value, exc_traceback, is_notebook=True):
+    if _handle_api_exception(exc_type,
+                             exc_value,
+                             exc_traceback,
+                             is_notebook=True):
         return
     self.showtraceback((exc_type, exc_value, exc_traceback),
                        tb_offset=tb_offset)


### PR DESCRIPTION
This PR improves on the exception handling of the client.
We now print the error message when we get an APIException, followed by the first and last 2 lines of the stack.
After that we point that the user can get more information on the logs file.