### PR TITLE
Added mpiconfig to the command class

### DIFF
--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -16,6 +16,7 @@ from inductiva.client.api_client import ApiClient
 from . import simulators
 from . import resources
 from . import projects
+from . import commands
 from . import storage
 from . import utils
 from . import tasks

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -54,11 +54,7 @@ def submit_request(api_instance: TasksApi,
         Contains two fields, "id" and "status".
     """
 
-    try:
-        api_response = api_instance.submit_task(body=request)
-    except ApiException as e:
-        logging.exception("Exception when calling TasksApi->submit_task: %s", e)
-        raise e
+    api_response = api_instance.submit_task(body=request)
 
     logging.debug("Request status: %s", api_response.body["status"])
 

--- a/inductiva/commands/__init__.py
+++ b/inductiva/commands/__init__.py
@@ -1,2 +1,3 @@
 # pylint: disable=missing-module-docstring
 from .commands import Command
+from .mpiconfig import MPIConfig

--- a/inductiva/commands/commands.py
+++ b/inductiva/commands/commands.py
@@ -1,11 +1,12 @@
 """Wrapper class for simulator commands."""
 from inductiva import types
+from .mpiconfig import MPIConfig
 
 
 class Command:
     """Abstraction class for commands."""
 
-    def __init__(self, cmd: str, *prompts: str):
+    def __init__(self, cmd: str, *prompts: str, mpi_config: MPIConfig = None):
         """
         Args:
           cmd: A string with the command, e.g, 'gmx pdb2gmx -f protein.pdb'
@@ -22,6 +23,7 @@ class Command:
 
         self.cmd = cmd
         self.prompts = list(prompts)
+        self.mpi_config = mpi_config
 
     def to_dict(self):
         """
@@ -35,7 +37,12 @@ class Command:
         >>> cmd.to_dict()
         >>> {"cmd": "gmx pdb2gmx -f protein.pdb", prompts: ["y", "y"]}
         """
-        return self.__dict__.copy()
+        ret_dict = self.__dict__.copy()
+
+        if ret_dict["mpi_config"] is not None:
+            ret_dict["mpi_config"] = ret_dict["mpi_config"].to_dict()
+
+        return ret_dict
 
     @staticmethod
     def commands_to_dicts(commands: types.Commands):

--- a/inductiva/commands/commands.py
+++ b/inductiva/commands/commands.py
@@ -21,6 +21,9 @@ class Command:
         if not all(isinstance(prompt, str) for prompt in prompts):
             raise ValueError("Prompts must be all strings.")
 
+        if mpi_config and not isinstance(mpi_config, MPIConfig):
+            raise TypeError("'mpi_config' must be an instance of MPIConfig.")
+
         self.cmd = cmd
         self.prompts = list(prompts)
         self.mpi_config = mpi_config

--- a/inductiva/commands/mpiconfig.py
+++ b/inductiva/commands/mpiconfig.py
@@ -16,23 +16,13 @@ class MPIConfig:
         self.version = version
         self.options = kwargs
 
-    def _replace_underscores_in_keys(self, d):
-        """Replace underscores with hyphens in dictionary
-        Since we are using kwargs we cant use flags like use-hwthread-cpus
-        so we need to use use_hwthread_cpus as the parameter and then replace
-        the underscores with hyphens before sending the request to the API.
-        """
-        new_dict = {}
-        for key, value in d.items():
-            new_key = key.replace('_', '-')
-            if isinstance(value, dict):
-                new_dict[new_key] = self._replace_underscores_in_keys(value)
-            else:
-                new_dict[new_key] = value
-        return new_dict
-
     def to_dict(self):
         """Convert this MPIConfig to a dictionary representation.
         This method will replace the "_" with "-".
         """
-        return self._replace_underscores_in_keys(self.__dict__)
+        return {
+            "version": self.version,
+            "options": {
+                k.replace("_", "-"): v for k, v in self.options.items()
+            }
+        }

--- a/inductiva/commands/mpiconfig.py
+++ b/inductiva/commands/mpiconfig.py
@@ -5,6 +5,14 @@ class MPIConfig:
     """MPIConfig class"""
 
     def __init__(self, version: str, **kwargs):
+        """
+        Args:
+          version: The version of the MPI library to use.
+            At the moment, only 1.10.7 and 4.1.6 are supported.
+          **kwargs: Additional parameters or flags that Openmpi uses.
+            parameters that have "-" should be typed with "_" instead.
+            Example: np=2, use_hwthread_cpus=True
+        """
         self.version = version
         self.options = kwargs
 
@@ -24,5 +32,7 @@ class MPIConfig:
         return new_dict
 
     def to_dict(self):
-        """Convert this MPIConfig to a dictionary representation."""
+        """Convert this MPIConfig to a dictionary representation.
+        This method will replace the "_" with "-".
+        """
         return self._replace_underscores_in_keys(self.__dict__)

--- a/inductiva/commands/mpiconfig.py
+++ b/inductiva/commands/mpiconfig.py
@@ -1,0 +1,28 @@
+"""MPIConfig class"""
+
+
+class MPIConfig:
+    """MPIConfig class"""
+
+    def __init__(self, version: str, **kwargs):
+        self.version = version
+        self.options = kwargs
+
+    def _replace_underscores_in_keys(self, d):
+        """Replace underscores with hyphens in dictionary
+        Since we are using kwargs we cant use flags like use-hwthread-cpus
+        so we need to use use_hwthread_cpus as the parameter and then replace
+        the underscores with hyphens before sending the request to the API.
+        """
+        new_dict = {}
+        for key, value in d.items():
+            new_key = key.replace('_', '-')
+            if isinstance(value, dict):
+                new_dict[new_key] = self._replace_underscores_in_keys(value)
+            else:
+                new_dict[new_key] = value
+        return new_dict
+
+    def to_dict(self):
+        """Convert this MPIConfig to a dictionary representation."""
+        return self._replace_underscores_in_keys(self.__dict__)

--- a/inductiva/simulators/__init__.py
+++ b/inductiva/simulators/__init__.py
@@ -3,6 +3,7 @@ from .simulator import Simulator
 from .dummy_simulator import DummySimulator
 from .splishsplash import SplishSplash
 from .dualsphysics import DualSPHysics
+from .custom_image import CustomImage
 from .openfoam import OpenFOAM
 from .openfast import OpenFAST
 from .amr_wind import AmrWind

--- a/inductiva/simulators/custom_image.py
+++ b/inductiva/simulators/custom_image.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 from inductiva import types, tasks, simulators
 
+
 @simulators.simulator.mpi_enabled
 class CustomImage(simulators.Simulator):
     """Class to run commands on an custom image."""

--- a/inductiva/simulators/custom_image.py
+++ b/inductiva/simulators/custom_image.py
@@ -1,0 +1,53 @@
+"""Class to run commands on an custom image."""
+from typing import List, Optional
+
+from inductiva import types, tasks, simulators
+
+
+class CustomImage(simulators.Simulator):
+    """Class to run commands on an custom image."""
+
+    def __init__(self, container_image: str):
+        """Initialize the ArbitraryImage class.
+        Point to the API method to run a simulation.
+        Args:
+            container_image: The container image to use for the simulation.
+                Example: container_image="docker://inductiva/kutu:xbeach_v1.23"
+        """
+        self.container_image = container_image
+        super().__init__()
+
+        self.api_method_name = "arbitrary.arbitrary_commands.run_simulation"
+
+    def _get_image_uri(self):
+        return self.container_image
+
+    def run(self,
+            input_dir: str,
+            commands: List[str],
+            storage_dir: Optional[str] = "",
+            extra_metadata: Optional[dict] = None,
+            on: Optional[types.ComputationalResources] = None,
+            resubmit_on_preemption: bool = False,
+            **kwargs) -> tasks.Task:
+        """Run the simulation.
+        Args:
+            input_dir: Path to the directory containing the input files.
+            commands: List of commands to run.
+            on: The computational resource to launch the simulation on. If None
+                the simulation is submitted to a machine in the default pool.
+            storage_dir: Parent directory for storing simulation
+                               results.
+            resubmit_on_preemption (bool): Resubmit task for execution when
+                previous execution attempts were preempted. Only applicable when
+                using a preemptible resource, i.e., resource instantiates with
+                `spot=True`.
+        """
+        return super().run(input_dir,
+                           on=on,
+                           commands=commands,
+                           storage_dir=storage_dir,
+                           extra_metadata=extra_metadata,
+                           container_image=self._image_uri,
+                           resubmit_on_preemption=resubmit_on_preemption,
+                           **kwargs)

--- a/inductiva/simulators/custom_image.py
+++ b/inductiva/simulators/custom_image.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from inductiva import types, tasks, simulators
 
-
+@simulators.simulator.mpi_enabled
 class CustomImage(simulators.Simulator):
     """Class to run commands on an custom image."""
 

--- a/inductiva/tests/commands/test_commands.py
+++ b/inductiva/tests/commands/test_commands.py
@@ -51,3 +51,20 @@ def test_to_dict__with_mpi_config():
             }
         }
     }
+
+
+def test_to_dict__mpi_config_is_not_instance_of_mpiconfig():
+    with pytest.raises(TypeError, match="instance of MPIConfig"):
+        commands.Command("command with prompts",
+                         "y",
+                         "y",
+                         mpi_config="not an instance of MPIConfig")
+
+
+def test_to_dict__mpi_config_is_none():
+    cmd = commands.Command("command with prompts", "y", "y", mpi_config=None)
+    assert cmd.to_dict() == {
+        "cmd": "command with prompts",
+        "prompts": ["y", "y"],
+        "mpi_config": None
+    }

--- a/inductiva/tests/commands/test_commands.py
+++ b/inductiva/tests/commands/test_commands.py
@@ -3,19 +3,25 @@ import pytest
 from pytest import mark
 
 from inductiva import commands
+from inductiva.commands.mpiconfig import MPIConfig
 
 
 def test_to_dict__with_prompts():
     cmd = commands.Command("command with prompts", "y", "y")
     assert cmd.to_dict() == {
         "cmd": "command with prompts",
-        "prompts": ["y", "y"]
+        "prompts": ["y", "y"],
+        "mpi_config": None
     }
 
 
 def test_to_dict__without_prompts():
     cmd = commands.Command("command without prompts")
-    assert cmd.to_dict() == {"cmd": "command without prompts", "prompts": []}
+    assert cmd.to_dict() == {
+        "cmd": "command without prompts",
+        "prompts": [],
+        "mpi_config": None
+    }
 
 
 @mark.parametrize("cmd,prompts,expected_message", [
@@ -30,3 +36,18 @@ def test_to_dict_method_with_invalid_input(cmd, prompts, expected_message):
 def test_to_dict_does_not_return_object():
     x = commands.Command("command", "y", "n")
     assert id(x.to_dict()) != id(x.__dict__)
+
+
+def test_to_dict__with_mpi_config():
+    config = MPIConfig("1.2.3", np=4)
+    cmd = commands.Command("command with prompts", "y", "y", mpi_config=config)
+    assert cmd.to_dict() == {
+        "cmd": "command with prompts",
+        "prompts": ["y", "y"],
+        "mpi_config": {
+            "version": "1.2.3",
+            "options": {
+                "np": 4
+            }
+        }
+    }

--- a/inductiva/tests/simulators/test_simulator_with_resources.py
+++ b/inductiva/tests/simulators/test_simulator_with_resources.py
@@ -224,8 +224,10 @@ def test_resubmit_on_preemption__is_correctly_handled(resubmit_on_preemption):
             list_mock.return_value = {"production": DefaultDictMock()}
 
             submit_mock.return_value = {"id": "123", "status": None}
-
-            sim_obj = simcls()
+            if sim_name == "CustomImage":
+                sim_obj = simcls(container_image="test")
+            else:
+                sim_obj = simcls()
             if resubmit_on_preemption is None:
                 # test that the default value of
                 # `resubmit_on_preemption` is False

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -69,6 +69,7 @@ intro_to_api/computational-infrastructure
 intro_to_api/templating
 intro_to_api/configuring-simulators
 intro_to_api/projects
+intro_to_api/custom_docker_images
 
 ```
 

--- a/tutorials/intro_to_api/custom_docker_images.md
+++ b/tutorials/intro_to_api/custom_docker_images.md
@@ -1,0 +1,96 @@
+# Running Simulations with Custom Docker Images
+
+In this tutorial, we will guide you through running simulations with custom
+Docker images. This can be particularly useful if you need to use a specific
+version of software that isn't available on our Docker Hub. Using this feature,
+you can run your own Docker image on the platform.
+
+This tutorial will focus on two main points:
+- The simulator you want to use
+- The inputs required by that simulator
+
+## CustomImage Simulator
+
+The `CustomImage` simulator allows you to specify a `container_image` pointing
+to your custom Docker image. Besides the `container_image`, this simulator
+accepts a list of commands to run inside the container. These are the only
+special parameters for this simulator. The rest are the same as other simulators.
+
+Here’s an example of how to use the `CustomImage` simulator:
+
+```python
+import inductiva
+
+input_dir = inductiva.utils.download_from_url(
+    "https://storage.googleapis.com/inductiva-api-demo-files/fds-input-example.zip", unzip=True)
+
+custom_simulator = inductiva.simulators.CustomImage(container_image="docker://inductiva/kutu:fds_v6.8")
+
+task = custom_simulator.run(input_dir=input_dir, commands=["fds mccaffrey.fds"])
+
+task.wait()
+task.download_outputs()
+```
+
+This basic example demonstrates how to run a custom Docker image. To leverage
+this feature fully, we introduce the `Command` and `MPIConfig` classes, which
+enable you to run commands on MPI clusters supporting multiple MPI versions.
+
+## Command and MPIConfig
+
+In the previous example, `commands` is a list of strings to be run inside the
+container. For more advanced usage, such as running a command with a specific
+MPI version, use the `Command` and `MPIConfig` classes. A list of `commands` can
+include `Command` instances, each potentially having an `MPIConfig`. Here’s an
+example:
+
+```python
+import inductiva
+
+input_dir = inductiva.utils.download_from_url(
+    "https://storage.googleapis.com/inductiva-api-demo-files/fds-input-example.zip", unzip=True)
+
+mpi_config = inductiva.commands.MPIConfig("4.1.6", np=4, use_hwthread_cpus=True)
+command = inductiva.commands.Command("fds mccaffrey.fds", mpi_config=mpi_config)
+
+task = custom_simulator.run(input_dir=input_dir, commands=[command])
+
+task.wait()
+task.download_outputs()
+```
+
+This example runs four instances of your image with the command `fds mccaffrey.fds`
+using MPI version 4.1.6, equivalent to:
+
+```sh
+mpirun -np 4 -use_hwthread_cpus apptainer run ... fds mccaffrey.fds
+```
+
+Alternatively, you can run MPI directly inside your container with:
+
+```python
+import inductiva
+
+input_dir = inductiva.utils.download_from_url(
+    "https://storage.googleapis.com/inductiva-api-demo-files/fds-input-example.zip", unzip=True)
+
+command = inductiva.commands.Command("mpirun -np 4 -use_hwthread_cpus fds mccaffrey.fds")
+
+task = custom_simulator.run(input_dir=input_dir, commands=[command])
+
+task.wait()
+task.download_outputs()
+```
+
+This runs:
+
+```sh
+apptainer run ... mpirun -np 4 -use_hwthread_cpus fds mccaffrey.fds
+```
+
+Ensure the MPI version in your container matches the one specified in `MPIConfig`.
+For instance, if your container has OpenMPI 1.10.6, choose a compatible OpenMPI
+version (like 1.10.7) in `MPIConfig`.
+
+Currently, we support OpenMPI versions 1.10.7 and 4.1.6. If you need a different
+version, please contact us.


### PR DESCRIPTION
Issue https://github.com/inductiva/tasks/issues/273

This PR adds mpiconfigs to the commands send to the backend.

```python
import inductiva
import inductiva.commands
from inductiva.commands.mpiconfig import MPIConfig

mpi_config = MPIConfig("1.10.7",np=2,use_hwthread_cpus=True)

command = inductiva.commands.Command("ls",mpi_config=mpi_config)
command2 = inductiva.commands.Command("cd")

print(command.to_dict())
print(command2.to_dict())
```
Will give 
```
{'cmd': 'ls', 'prompts': [], 'mpi_config': {'version': '1.10.7', 'options': {'np': 2, 'use-hwthread-cpus': True}}}
{'cmd': 'cd', 'prompts': [], 'mpi_config': None}
```