### PR TITLE
173 - inductiva logs can wait for task to be running

### DIFF
--- a/inductiva/constants.py
+++ b/inductiva/constants.py
@@ -20,4 +20,6 @@ LOADER_IGNORE_PREFIX = "_"
 # when printing the stack trace, how many lines to show
 EXCEPTIONS_MAX_TRACEBACK_DEPTH = 2
 
+INDUCTIVA_LOGS_WAIT_SLEEP_TIME = 1.0
+
 HOME_DIR = pathlib.Path.home() / ".inductiva"


### PR DESCRIPTION
https://github.com/inductiva/tasks/issues/173

This PR adds the ability to wait for a task to start running before consuming the logs.