### PR TITLE
inductiva storage remove now works based on tasks

### DIFF
--- a/docs/how_to/manage-remote-storage.md
+++ b/docs/how_to/manage-remote-storage.md
@@ -89,8 +89,7 @@ Outputs the following::
 ### Removing directories
 
 Whenever space needs to be freed up, or in general, when you want to remove a directory
-from your remote storage, you can use a simple interface to remove it. In particular,
-in case you want to remove everything that is also possible.
+from your remote storage, you can use the task interface to do it. 
 
 The table above provides valuable information that can guide your decision to remove certain directories. 
 
@@ -98,7 +97,7 @@ The table above provides valuable information that can guide your decision to re
 
 ```python
 import inductiva
-inductiva.storage.rmdir(path="reef3d_simulation")
+inductiva.tasks.Task(task_id).remove_remote_files()
 ```
 
 **CLI**

--- a/inductiva/_cli/cmd_storage/remove.py
+++ b/inductiva/_cli/cmd_storage/remove.py
@@ -1,45 +1,26 @@
 """Remove the user's remote storage contents via CLI."""
 import argparse
-import sys
 
-from inductiva import storage
-from inductiva.client import exceptions
+import inductiva
 from inductiva.utils.input_functions import user_confirmation_prompt
 from ...localization import translator as __
 
 
 def remove(args):
     """Remove user's remote storage contents."""
-    paths = args.path
+    paths = args.id
     confirm = args.confirm
-    all_paths = args.all
 
-    if not all_paths and not paths:
-        print("No path(s) specified.\n"
-              "> Use `inductiva storage remove -h` for help.")
-        return 1
-
-    if paths and all_paths:
-        print(
-            "inductiva storage remove: error: "
-            "argument path not allowed with argument --all",
-            file=sys.stderr)
-        return 1
     paths = set(paths)
     if not confirm:
         confirm = user_confirmation_prompt(
             paths, __("storage-prompt-remove-all"),
             __("storage-prompt-remove-big", len(paths)),
-            __("storage-prompt-remove-small"), all_paths)
+            __("storage-prompt-remove-small"), False)
 
     if confirm:
-        if all_paths:
-            storage.rmdir("*", confirm=True)
-        for path in paths:
-            try:
-                storage.rmdir(path, confirm=True)
-            except exceptions.ApiValueError as rmdir_exception:
-                print(rmdir_exception)
+        for task_id in paths:
+            inductiva.tasks.Task(task_id).remove_remote_files()
 
     return 0
 
@@ -52,15 +33,13 @@ def register(parser):
     subparser.description = (
         "The `inductiva storage remove` command deletes specified data"
         " from the platform.\n"
-        "It targets a specific path for removal. Use with caution as "
-        "this action is irreversible.\n\n"
-        "Use `inductiva storage remove \"*\"` to remove all folders in"
-        " your storage.")
-    subparser.add_argument("path",
+        "It targets a specific task files for removal. Use with caution as "
+        "this action is irreversible.\n\n")
+    subparser.add_argument("id",
                            type=str,
-                           nargs="*",
-                           help="Path(s) to be removed from remote storage. "
-                           "To remove all contents, use \"*\".")
+                           nargs="+",
+                           help="Id(s) of the task(s) to remove from remote "
+                           "storage.")
 
     subparser.add_argument(
         "-y",
@@ -71,9 +50,5 @@ def register(parser):
         help="Sets any confirmation values to \"yes\" "
         "automatically. Users will not be asked for "
         "confirmation to remove path(s) from remote storage.")
-    subparser.add_argument("--all",
-                           action="store_true",
-                           default=False,
-                           help="Remove all contents from remote storage.")
 
     subparser.set_defaults(func=remove)

--- a/inductiva/_cli/cmd_storage/remove.py
+++ b/inductiva/_cli/cmd_storage/remove.py
@@ -8,18 +8,18 @@ from ...localization import translator as __
 
 def remove(args):
     """Remove user's remote storage contents."""
-    paths = args.id
+    task_ids = args.id
     confirm = args.confirm
 
-    paths = set(paths)
+    task_ids = set(task_ids)
     if not confirm:
         confirm = user_confirmation_prompt(
-            paths, __("storage-prompt-remove-all"),
-            __("storage-prompt-remove-big", len(paths)),
+            task_ids, __("storage-prompt-remove-all"),
+            __("storage-prompt-remove-big", len(task_ids)),
             __("storage-prompt-remove-small"), False)
 
     if confirm:
-        for task_id in paths:
+        for task_id in task_ids:
             inductiva.tasks.Task(task_id).remove_remote_files()
 
     return 0

--- a/inductiva/storage/__init__.py
+++ b/inductiva/storage/__init__.py
@@ -1,2 +1,2 @@
 """Storage related functions."""
-from .storage import get_space_used, listdir, rmdir
+from .storage import get_space_used, listdir

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -1,8 +1,5 @@
 """Methods to interact with the user storage resources."""
-import logging
-
 import inductiva
-from inductiva.client import exceptions
 from inductiva.client.apis.tags import storage_api
 from inductiva.utils import format_utils
 from typing import Literal
@@ -96,58 +93,3 @@ def _print_contents_table(contents):
         formatters=formatters,
         header_formatters=header_formatters,
     )
-
-
-def rmdir(path: str, /, confirm: bool = False):
-    """Delete paths inside the user's remote storage in the Inductiva platform.
-
-    This function removes the given `path` from the user's remote storage
-    in the Inductiva platform. The given path can either be the storage name of
-    a task to remove all content pertaining to that task, or `*` to remove all
-    content. The function requires an explicit `confirm=True` keyword argument
-    to confirm that the path is, indeed, to be removed.
-
-    E.g.:
-        #Works - remote path "task_id" exists and user is explicitly
-        # sets confirm=True:
-        >>> inductiva.storage.rmdir("task_id", confirm=True)
-        
-        #Works - The user explicitly sets confirm=True, confirming that
-        # all contents in his remote storage space are to be removed:
-        >>> inductiva.storage.rmdir("*", confirm=True)
-        # Fails -  remote path "task_id" exists but the user fails to
-        # confirm his intent. The call will fail win a runtime exception:
-        >>> inductiva.storage.rmdir("task_id")
-
-    Args:
-        path (str): Path relative to the root of the bucket to delete.
-            If path="*" then all the contents in the user's remote storage space
-            will be removed.
-        confirm (bool): Confirmation flag to explicitly ensure the intent
-            to remove the given path. The call will fail with a RuntimeException
-            if the user does not set `confirm=True`.
-    """
-    if not confirm:
-        if path == "*":
-            path = "all contents"
-        raise RuntimeError("Please set `confirm=True` to confirm you want to "
-                           f"delete {path} from the user's remote storage.")
-
-    if path == "*":
-        logging.info("Removing everything from user's remote storage.")
-    else:
-        logging.info("Removing %s in the user's remote storage.", path)
-
-    try:
-        api = storage_api.StorageApi(inductiva.api.get_client())
-        api.delete_path({"path": path})
-        logging.info("Successfully removed remote path '%s'.", path)
-    except exceptions.ApiException as api_exception:
-        if api_exception.status == 404:
-            raise exceptions.ApiValueError(
-                f"Unable to remove path '{path}'. Path does not exist in "
-                "user's remote storage.")
-        elif api_exception.status == 500:
-            raise exceptions.ApiRuntimeError(
-                f"Failed to remove remote path '{path}'.")
-        raise api_exception


### PR DESCRIPTION
This PR updates the inductiva storage remove to make it work based on task id's instead of paths.

Task should now be the interface to interact with the storage.

Issue https://github.com/inductiva/tasks/issues/222