### PR TITLE
Make `on` argument on `simulator.run` method mandatory

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -342,10 +342,7 @@ def submit_task(api_instance,
                 container_image: Optional[str] = None,
                 simulator=None):
     """Submit a task and send input files to the API."""
-
-    resource_pool_id = None
-    if resource_pool is not None:
-        resource_pool_id = resource_pool.id
+    resource_pool_id = resource_pool.id
 
     current_project = inductiva.projects.get_current_project()
     if current_project is not None:
@@ -393,8 +390,7 @@ def submit_task(api_instance,
 def invoke_async_api(method_name: str,
                      params,
                      type_annotations: Dict[Any, Type],
-                     resource_pool: Optional[
-                         types.ComputationalResources] = None,
+                     resource_pool: types.ComputationalResources,
                      storage_path_prefix: Optional[str] = "",
                      provider_id: ProviderType = ProviderType.GCP,
                      container_image: Optional[str] = None,
@@ -424,7 +420,7 @@ def invoke_async_api(method_name: str,
             Example: container_image="docker://inductiva/kutu:xbeach_v1.23_dev"
         resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
     Return:
         Returns the task id.

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -11,7 +11,7 @@ class AmrWind(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the AmrWind simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -30,31 +30,31 @@ class AmrWind(simulators.Simulator):
     def run(self,
             input_dir: str,
             sim_config_filename: str,
+            *,
+            on: types.ComputationalResources,
             use_hwthread: bool = True,
             n_vcpus: Optional[int] = None,
             extra_metadata: Optional[dict] = None,
             storage_dir: Optional[str] = "",
-            on: Optional[types.ComputationalResources] = None,
             resubmit_on_preemption: bool = False,
             **kwargs) -> tasks.Task:
         """Run the simulation.
         Args:
             input_dir: Path to the directory of the simulation input files.
+            on: The computational resource to launch the simulation on.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
             (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
             number of hardware threads on the node, and use that as the
             number of slots available.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
             other arguments: See the documentation of the base class.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
         """
-        return super().run(input_dir,
-                           on=on,
+        return super().run(on,
+                           input_dir,
                            n_vcpus=n_vcpus,
                            storage_dir=storage_dir,
                            use_hwthread=use_hwthread,

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -12,7 +12,7 @@ class CaNS(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the CaNS simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -26,27 +26,27 @@ class CaNS(simulators.Simulator):
     def run(self,
             input_dir: str,
             sim_config_filename: str,
+            *,
+            on: types.ComputationalResources,
             use_hwthread: bool = True,
             n_vcpus: Optional[int] = None,
             extra_metadata: Optional[dict] = None,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            on: Optional[types.ComputationalResources] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
         Args:
             input_dir: Path to the directory of the simulation input files.
+            on: The computational resource to launch the simulation on.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
             (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
             number of hardware threads on the node, and use that as the
             number of slots available.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
             other arguments: See the documentation of the base class.
         """

--- a/inductiva/simulators/custom_image.py
+++ b/inductiva/simulators/custom_image.py
@@ -26,22 +26,22 @@ class CustomImage(simulators.Simulator):
     def run(self,
             input_dir: str,
             commands: List[str],
+            *,
+            on: types.ComputationalResources,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
-            on: Optional[types.ComputationalResources] = None,
             resubmit_on_preemption: bool = False,
             **kwargs) -> tasks.Task:
         """Run the simulation.
         Args:
             input_dir: Path to the directory containing the input files.
             commands: List of commands to run.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
+            on: The computational resource to launch the simulation on.
             storage_dir: Parent directory for storing simulation
                                results.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
         """
         return super().run(input_dir,

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -10,7 +10,7 @@ class DualSPHysics(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the DualSPHysics simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -25,7 +25,8 @@ class DualSPHysics(simulators.Simulator):
         self,
         input_dir: str,
         commands: types.Commands,
-        on: Optional[types.ComputationalResources] = None,
+        *,
+        on: types.ComputationalResources,
         storage_dir: Optional[str] = "",
         extra_metadata: Optional[dict] = None,
         resubmit_on_preemption: bool = False,
@@ -36,12 +37,11 @@ class DualSPHysics(simulators.Simulator):
         Args:
             input_dir: Directory with simulation input files.
             sim_config_filename: Simulation config file.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
+            on: The computational resource to launch the simulation on.
             storage_dir: Directory for storing results.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
 
         Returns:

--- a/inductiva/simulators/dummy_simulator.py
+++ b/inductiva/simulators/dummy_simulator.py
@@ -31,8 +31,9 @@ class DummySimulator(simulators.Simulator):
     def run(self,
             input_dir: str,
             input_filename: str,
+            *,
+            on: types.ComputationalResources,
             sleep_time: Optional[float] = 1,
-            on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
             extra_metadata: Optional[dict] = None,
@@ -46,7 +47,7 @@ class DummySimulator(simulators.Simulator):
             extra_metadata: Extra metadata to be sent to the backend.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
         """
 

--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -24,10 +24,11 @@ class FDS(simulators.Simulator):
     def run(self,
             input_dir: str,
             sim_config_filename: str,
+            *,
+            on: types.ComputationalResources,
             n_vcpus: Optional[int] = None,
             use_hwthread: bool = True,
-            post_processing_filename: str = None,
-            on: Optional[types.ComputationalResources] = None,
+            post_processing_filename: Optional[str] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
             resubmit_on_preemption: bool = False,
@@ -36,18 +37,17 @@ class FDS(simulators.Simulator):
 
         Args:
             input_dir: Path to the directory of the simulation input files.
+            on: The computational resource to launch the simulation on.
             sim_config_filename: Name of the simulation configuration file.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
-            (default), all vCPUs will be used.
+                (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
-            number of hardware threads on the node, and use that as the
-            number of slots available.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
+                number of hardware threads on the node, and use that as the
+                number of slots available.
             other arguments: See the documentation of the base class.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
         """
         return super().run(input_dir,

--- a/inductiva/simulators/fenicsx.py
+++ b/inductiva/simulators/fenicsx.py
@@ -29,22 +29,22 @@ class FEniCSx(simulators.Simulator):
             geometry_filename: str,
             bcs_filename: str,
             material_filename: str,
+            *,
+            on: types.ComputationalResources,
             mesh_filename: Optional[str] = None,
             mesh_info_filename: Optional[str] = None,
-            on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
         Args:
+            on: The computational resource to launch the simulation on.
             geometry_filename: Geometry filename.
             bcs_filename: Boundary conditions filename.
             material_filename: Material filename.
             mesh_filename: Mesh filename.
             mesh_info_filename: Mesh information filename.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
             storage_dir: Parent directory for storing simulation results.
             **kwargs: Arbitrary keyword arguments, including:
                 - global_refinement_meshing_factor (float): Factor for global

--- a/inductiva/simulators/gromacs.py
+++ b/inductiva/simulators/gromacs.py
@@ -10,7 +10,7 @@ class GROMACS(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the GROMACS simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -25,7 +25,8 @@ class GROMACS(simulators.Simulator):
         self,
         input_dir: str,
         commands: types.Commands,
-        on: Optional[types.ComputationalResources] = None,
+        *,
+        on: types.ComputationalResources,
         storage_dir: Optional[str] = "",
         resubmit_on_preemption: bool = False,
         extra_metadata: Optional[dict] = None,
@@ -35,14 +36,13 @@ class GROMACS(simulators.Simulator):
 
         Args:
             input_dir: Path to the directory containing the input files.
+            on: The computational resource to launch the simulation on.
             commands: List of commands to run using the GROMACS simulator.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
             storage_dir: Parent directory for storing simulation
                                results.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
         """
 

--- a/inductiva/simulators/nwchem.py
+++ b/inductiva/simulators/nwchem.py
@@ -11,7 +11,7 @@ class NWChem(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the NWChem simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -25,9 +25,10 @@ class NWChem(simulators.Simulator):
     def run(self,
             input_dir: str,
             sim_config_filename: str,
+            *,
+            on: types.ComputationalResources,
             n_vcpus: Optional[int] = None,
             use_hwthread: bool = True,
-            on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
             resubmit_on_preemption: bool = False,
@@ -36,18 +37,17 @@ class NWChem(simulators.Simulator):
 
         Args:
             input_dir: Path to the directory of the simulation input files.
+            on: The computational resource to launch the simulation on.
             sim_config_filename: Name of the simulation configuration file.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
             (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
             number of hardware threads on the node, and use that as the
             number of slots available.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
             other arguments: See the documentation of the base class.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
         """
         return super().run(input_dir,

--- a/inductiva/simulators/openfast.py
+++ b/inductiva/simulators/openfast.py
@@ -11,7 +11,7 @@ class OpenFAST(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the OpenFAST simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -25,7 +25,8 @@ class OpenFAST(simulators.Simulator):
     def run(self,
             input_dir: str,
             commands: types.Commands,
-            on: Optional[types.ComputationalResources] = None,
+            *,
+            on: types.ComputationalResources,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
             resubmit_on_preemption: bool = False,
@@ -35,12 +36,11 @@ class OpenFAST(simulators.Simulator):
         Args:
             input_dir: Path to the directory of the simulation input files.
             commands: List of commands to run using the OpenFAST simulator.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
+            on: The computational resource to launch the simulation on.
             other arguments: See the documentation of the base class.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
         """
         return super().run(input_dir,

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -50,9 +50,10 @@ class OpenFOAM(simulators.Simulator):
     def run(self,
             input_dir: str,
             commands: types.Commands,
+            *,
+            on: types.ComputationalResources,
             n_vcpus: Optional[int] = None,
             use_hwthread: bool = True,
-            on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
             resubmit_on_preemption: bool = False,
@@ -61,17 +62,16 @@ class OpenFOAM(simulators.Simulator):
 
         Args:
             input_dir: Path to the directory of the simulation input files.
+            on: The computational resource to launch the simulation on.
             commands: List of commands to run using the OpenFOAM simulator.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
             (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
             number of hardware threads on the node, and use that as the
             number of slots available.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
             other arguments: See the documentation of the base class.
         """

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -11,7 +11,7 @@ class REEF3D(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the REEF3D simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -24,9 +24,10 @@ class REEF3D(simulators.Simulator):
 
     def run(self,
             input_dir: str,
+            *,
+            on: Optional[types.ComputationalResources],
             n_vcpus: Optional[int] = None,
             use_hwthread: bool = True,
-            on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
             resubmit_on_preemption: bool = False,
@@ -35,17 +36,16 @@ class REEF3D(simulators.Simulator):
 
         Args:
             input_dir: Path to the directory of the simulation input files.
+            on: The computational resource to launch the simulation on.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
             (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
             number of hardware threads on the node, and use that as the
             number of slots available.
             sim_config_filename: Name of the simulation configuration file.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
             other arguments: See the documentation of the base class.
         """

--- a/inductiva/simulators/schism.py
+++ b/inductiva/simulators/schism.py
@@ -10,7 +10,7 @@ class SCHISM(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the SCHISM simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -23,23 +23,21 @@ class SCHISM(simulators.Simulator):
 
     def run(self,
             input_dir: str,
+            *,
+            on: types.ComputationalResources,
             num_scribes: int = 1,
-            on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             use_hwthread: bool = True,
             extra_metadata: Optional[dict] = None,
-            n_vcpus: int = None,
+            n_vcpus: Optional[int] = None,
             resubmit_on_preemption: bool = False,
             **kwargs) -> tasks.Task:
         """Run the simulation.
         Args:
             input_dir: Path to the directory of the simulation input files.
+            on: The computational resource to launch the simulation on.
             num_scribes: The num_scribes as per the simulator documentation.
-            # pylint: disable=line-too-long
             https://schism-dev.github.io/schism/master/getting-started/running-model.html
-            # pylint: enable=line-too-long
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
             storage_dir: Directory for storing simulation results.
             use_hwthread: If specified Open MPI will attempt to discover the
             number of hardware threads on the node, and use that as the
@@ -47,7 +45,7 @@ class SCHISM(simulators.Simulator):
             n_vcpus: Number of virtual cpus
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
         """
         return super().run(input_dir,

--- a/inductiva/simulators/simsopt.py
+++ b/inductiva/simulators/simsopt.py
@@ -34,7 +34,8 @@ class SIMSOPT(simulators.Simulator):
         num_samples: int,
         sigma_scaling_factor: float,
         objectives_weights_filename: str,
-        on: Optional[types.ComputationalResources] = None,
+        *,
+        on: types.ComputationalResources,
         storage_dir: Optional[str] = "",
         resubmit_on_preemption: bool = False,
         extra_metadata: Optional[dict] = None,
@@ -70,7 +71,7 @@ class SIMSOPT(simulators.Simulator):
             storage_dir: Directory for storing results.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
             other arguments: See the documentation of the base class.
         """

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -124,7 +124,7 @@ class Simulator(ABC):
         self,
         input_dir: str,
         *_args,
-        on: Optional[types.ComputationalResources] = None,
+        on: types.ComputationalResources,
         storage_dir: Optional[str] = "",
         resubmit_on_preemption: bool = False,
         extra_metadata: Optional[dict] = None,
@@ -133,21 +133,29 @@ class Simulator(ABC):
         """Run the simulation.
 
         Args:
+            on: The computational resource to launch the simulation in. If None
+                the simulation is launched in a machine of the default pool.
             input_dir: Path to the directory containing the input files.
             _args: Unused in this method, but defined to allow for more
                 non-default arguments in method override in subclasses.
-            on: The computational resource to launch the simulation in. If None
-                the simulation is launched in a machine of the default pool.
             storage_dir: Parent directory for storing simulation
                                results.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
             **kwargs: Additional keyword arguments to be passed to the
                 simulation API method.
         """
         input_dir_path = self._setup_input_dir(input_dir)
+
+        if on is None:
+            raise ValueError(
+                "A default computational resource is no longer "
+                "provided. Please specify a computational resource. "
+                "Check https://docs.inductiva.ai/en/latest/how_to/"
+                "run-parallel_simulations.html "
+                "to learn how to create your own computational resource.")
 
         self.validate_computational_resources(on)
 
@@ -179,8 +187,7 @@ class Simulator(ABC):
             valid_resources: The valid computational resources for the simulator
         """
 
-        if resource is not None \
-            and not isinstance(resource, tuple(self._supported_resources)):
+        if not isinstance(resource, tuple(self._supported_resources)):
             raise ValueError(
                 "The computational resource is invalid for this simulator. "
                 f"Expected one of {self._supported_resources} but got "

--- a/inductiva/simulators/splishsplash.py
+++ b/inductiva/simulators/splishsplash.py
@@ -9,7 +9,7 @@ class SplishSplash(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the SPlisHSplasH simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -24,7 +24,8 @@ class SplishSplash(simulators.Simulator):
         self,
         input_dir: str,
         sim_config_filename: str,
-        on: Optional[types.ComputationalResources] = None,
+        *,
+        on: types.ComputationalResources,
         storage_dir: Optional[str] = "",
         resubmit_on_preemption: bool = False,
         extra_metadata: Optional[dict] = None,
@@ -40,7 +41,7 @@ class SplishSplash(simulators.Simulator):
             storage_dir: Directory for storing simulation results.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
         Returns:
             Task object representing the simulation task.

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -10,7 +10,7 @@ class SWAN(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the SWAN simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -25,9 +25,10 @@ class SWAN(simulators.Simulator):
         self,
         input_dir: str,
         sim_config_filename: str,
+        *,
+        on: types.ComputationalResources,
         n_vcpus: Optional[int] = None,
         use_hwthread: bool = True,
-        on: Optional[types.ComputationalResources] = None,
         storage_dir: Optional[str] = "",
         resubmit_on_preemption: bool = False,
         extra_metadata: Optional[dict] = None,
@@ -43,12 +44,11 @@ class SWAN(simulators.Simulator):
             use_hwthread: If specified Open MPI will attempt to discover the
             number of hardware threads on the node, and use that as the
             number of slots available.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
+            on: The computational resource to launch the simulation on.
             storage_dir: Directory for storing simulation results.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
         """
         return super().run(input_dir,

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -10,7 +10,7 @@ class SWASH(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the SWASH simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -24,9 +24,10 @@ class SWASH(simulators.Simulator):
     def run(self,
             input_dir: str,
             sim_config_filename: str,
+            *,
+            on: types.ComputationalResources,
             n_vcpus: Optional[int] = None,
             use_hwthread: bool = True,
-            on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
             resubmit_on_preemption: bool = False,
@@ -36,16 +37,15 @@ class SWASH(simulators.Simulator):
         Args:
             input_dir: Path to the directory of the simulation input files.
             sim_config_filename: Name of the simulation configuration file.
+            on: The computational resource to launch the simulation on.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
             (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
             number of hardware threads on the node, and use that as the
             number of slots available.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
             storage_dir: Directory for storing simulation results.
         """

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -10,7 +10,7 @@ class XBeach(simulators.Simulator):
 
     def __init__(self, /, version: Optional[str] = None, use_dev: bool = False):
         """Initialize the XBeach simulator.
-        
+
         Args:
             version (str): The version of the simulator to use. If None, the
                 latest available version in the platform is used.
@@ -23,10 +23,11 @@ class XBeach(simulators.Simulator):
 
     def run(self,
             input_dir: str,
+            *,
+            on: types.ComputationalResources,
             n_vcpus: Optional[int] = None,
             use_hwthread: bool = True,
             sim_config_filename: Optional[str] = "params.txt",
-            on: Optional[types.ComputationalResources] = None,
             storage_dir: Optional[str] = "",
             extra_metadata: Optional[dict] = None,
             resubmit_on_preemption: bool = False,
@@ -35,18 +36,17 @@ class XBeach(simulators.Simulator):
 
         Args:
             input_dir: Path to the directory of the simulation input files.
+            on: The computational resource to launch the simulation on.
             sim_config_filename: Name of the simulation configuration file.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
-            (default), all vCPUs will be used.
+                (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
-            number of hardware threads on the node, and use that as the
-            number of slots available.
-            on: The computational resource to launch the simulation on. If None
-                the simulation is submitted to a machine in the default pool.
+                number of hardware threads on the node, and use that as the
+                number of slots available.
             storage_dir: Directory for storing simulation results.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
-                using a preemptible resource, i.e., resource instantiates with
+                using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
             other arguments: See the documentation of the base class.
         """

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -21,8 +21,9 @@ _metadata_lock = threading.RLock()
 def run_simulation(
     api_method_name: str,
     input_dir: pathlib.Path,
+    *,
+    computational_resources: types.ComputationalResources,
     resubmit_on_preemption: bool = False,
-    computational_resources: Optional[types.ComputationalResources] = None,
     provider_id: Optional[Union[ProviderType, str]] = ProviderType.GCP,
     storage_dir: Optional[str] = "",
     api_invoker=None,
@@ -51,17 +52,14 @@ def run_simulation(
     task_id = api_invoker(api_method_name,
                           params,
                           type_annotations,
+                          computational_resources,
                           resubmit_on_preemption=resubmit_on_preemption,
-                          resource_pool=computational_resources,
                           container_image=container_image,
                           storage_path_prefix=storage_dir,
                           provider_id=provider_id,
                           simulator=simulator)
-    if computational_resources is not None:
-        logging.info("■ Task %s submitted to the queue of the %s.", task_id,
-                     computational_resources)
-    else:
-        logging.info("■ Task %s submitted to the default queue.", task_id)
+    logging.info("■ Task %s submitted to the queue of the %s.", task_id,
+                 computational_resources)
 
     task = tasks.Task(task_id)
     if not isinstance(task_id, str):


### PR DESCRIPTION
It is now mandatory to specify a computational resource when submitting a task, as a result of no longer providing a shared queue. The `on` argument doesn't have a default, but remains a keyword argument.

Tests and examples that rely on default machine group need to be updated.