### PR TITLE
Add download task inputs

### DIFF
--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -26,10 +26,6 @@ from .templating import TemplateManager
 logs.setup(getattr(logging, os.environ.get("INDUCTIVA_LOG_LEVEL", "INFO")))
 
 api_url = os.environ.get("INDUCTIVA_API_URL", "https://api.inductiva.ai")
-_input_dir = contextvars.ContextVar("INDUCTIVA_INPUT_DIR",
-                                    default=os.environ.get(
-                                        "INDUCTIVA_INPUT_DIR",
-                                        "inductiva_input"))
 _output_dir = contextvars.ContextVar("INDUCTIVA_OUTPUT_DIR",
                                      default=os.environ.get(
                                          "INDUCTIVA_OUTPUT_DIR",
@@ -54,16 +50,6 @@ def set_output_dir(new_output_dir):
 def get_output_dir():
     """Returns the value of inductiva._output_dir"""
     return _output_dir.get()
-
-
-def set_input_dir(new_input_dir):
-    """Sets the value of `inductiva._input_dir` to `new_input_dir`"""
-    _input_dir.set(new_input_dir)
-
-
-def get_input_dir():
-    """Returns the value of inductiva._input_dir"""
-    return _input_dir.get()
 
 
 def _check_for_available_package_update():

--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -26,6 +26,10 @@ from .templating import TemplateManager
 logs.setup(getattr(logging, os.environ.get("INDUCTIVA_LOG_LEVEL", "INFO")))
 
 api_url = os.environ.get("INDUCTIVA_API_URL", "https://api.inductiva.ai")
+_input_dir = contextvars.ContextVar("INDUCTIVA_INPUT_DIR",
+                                     default=os.environ.get(
+                                         "INDUCTIVA_INPUT_DIR",
+                                         "inductiva_input"))
 _output_dir = contextvars.ContextVar("INDUCTIVA_OUTPUT_DIR",
                                      default=os.environ.get(
                                          "INDUCTIVA_OUTPUT_DIR",
@@ -50,6 +54,16 @@ def set_output_dir(new_output_dir):
 def get_output_dir():
     """Returns the value of inductiva._output_dir"""
     return _output_dir.get()
+
+
+def set_input_dir(new_input_dir):
+    """Sets the value of `inductiva._input_dir` to `new_input_dir`"""
+    _input_dir.set(new_input_dir)
+
+
+def get_input_dir():
+    """Returns the value of inductiva._input_dir"""
+    return _input_dir.get()
 
 
 def _check_for_available_package_update():

--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -27,9 +27,9 @@ logs.setup(getattr(logging, os.environ.get("INDUCTIVA_LOG_LEVEL", "INFO")))
 
 api_url = os.environ.get("INDUCTIVA_API_URL", "https://api.inductiva.ai")
 _input_dir = contextvars.ContextVar("INDUCTIVA_INPUT_DIR",
-                                     default=os.environ.get(
-                                         "INDUCTIVA_INPUT_DIR",
-                                         "inductiva_input"))
+                                    default=os.environ.get(
+                                        "INDUCTIVA_INPUT_DIR",
+                                        "inductiva_input"))
 _output_dir = contextvars.ContextVar("INDUCTIVA_OUTPUT_DIR",
                                      default=os.environ.get(
                                          "INDUCTIVA_OUTPUT_DIR",

--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -54,8 +54,8 @@ def register(parser):
         "--dir option. Files are downloaded to a subdirectory named after the\n"
         "ID of the corresponding task. The output files are downloaded when\n"
         "the --output/-o option is passed. Similarly, the input files are\n"
-        "downloaded when the --input/-i option is passed. If neither option is\n"
-        "specified, the output files are downloaded by default.")
+        "downloaded when the --input/-i option is passed. If neither option \n"
+        "is specified, the output files are downloaded by default.")
 
     subparser.add_argument("task_id",
                            type=str,

--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -68,11 +68,13 @@ def register(parser):
     subparser.add_argument("--dir",
                            type=str,
                            help="Path of where to download the task"
-                                "input/output files.")
-    subparser.add_argument("--input", "-i",
+                           "input/output files.")
+    subparser.add_argument("--input",
+                           "-i",
                            action='store_true',
                            help="Option to download input files.")
-    subparser.add_argument("--output", "-o",
+    subparser.add_argument("--output",
+                           "-o",
                            action='store_true',
                            help="Option to download output files (default).")
 

--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -47,13 +47,15 @@ def register(parser):
                                   formatter_class=argparse.RawTextHelpFormatter)
 
     subparser.description = (
-        "Download the input/output files in the context of the tasks with\n"
-        "the given ID(s). All files are downloaded unless the --filenames\n"
-        "list is given, in which case only the indicated files for each task\n"
-        " are downloaded."
-        " The name of the input/output folder can be configured through the\n"
-        "--dir option. Files are downloaded to a subdirectory\n"
-        "named after the ID of the corresponding task.")
+        "Download the input/output files of tasks with the given ID(s).\n"
+        "All files are downloaded unless the --filenames list is given,\n"
+        "in which case only the indicated files for each task are downloaded.\n"
+        "The name of the input/output folder can be configured through the\n"
+        "--dir option. Files are downloaded to a subdirectory named after the\n"
+        "ID of the corresponding task. The output files are downloaded when\n"
+        "the --output option is passed. Similarly, the input files are\n"
+        "downloaded when the --input option is passed. If neither option is\n"
+        "specified, the output files are downloaded by default.")
 
     subparser.add_argument("task_id",
                            type=str,

--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -8,15 +8,15 @@ def download(args):
     """Download the outputs of a task by ID."""
     task_ids = args.task_id
     filenames = args.filenames
-    dir = args.dir
+    download_dir = args.dir
 
     if not args.output and not args.input:
         args.output = True
 
-    if dir is not None:
-        inductiva.set_output_dir(dir)
+    if download_dir is not None:
+        inductiva.set_output_dir(download_dir)
 
-    if dir == "":
+    if download_dir == "":
         print("`dir` must not be an empty string.")
         return 1
 
@@ -71,11 +71,11 @@ def register(parser):
                            "input/output files.")
     subparser.add_argument("--input",
                            "-i",
-                           action='store_true',
+                           action="store_true",
                            help="Option to download input files.")
     subparser.add_argument("--output",
                            "-o",
-                           action='store_true',
+                           action="store_true",
                            help="Option to download output files (default).")
 
     subparser.set_defaults(func=download)

--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -54,7 +54,7 @@ def register(parser):
         "--dir option. Files are downloaded to a subdirectory named after the\n"
         "ID of the corresponding task. The output files are downloaded when\n"
         "the --output/-o option is passed. Similarly, the input files are\n"
-        "downloaded when the --input option is passed. If neither option is\n"
+        "downloaded when the --input/-i option is passed. If neither option is\n"
         "specified, the output files are downloaded by default.")
 
     subparser.add_argument("task_id",

--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -4,6 +4,13 @@ import argparse
 import inductiva
 
 
+def _download(download_func, filenames, task_id):
+    try:
+        download_func(filenames=filenames)
+    except inductiva.client.exceptions.ApiException as exc:
+        print(f"Error for task {task_id}:", exc)
+
+
 def download(args):
     """Download the outputs of a task by ID."""
     task_ids = args.task_id
@@ -28,14 +35,11 @@ def download(args):
     task_ids = set(task_ids)
 
     for task_id in task_ids:
-        try:
-            task = inductiva.tasks.Task(task_id)
-            if args.output:
-                task.download_outputs(filenames=filenames)
-            if args.input:
-                task.download_inputs(filenames=filenames)
-        except inductiva.client.exceptions.ApiException as exc:
-            print(f"Error for task {task_id}:", exc)
+        task = inductiva.tasks.Task(task_id)
+        if args.output:
+            _download(task.download_outputs, filenames, task_id)
+        if args.input:
+            _download(task.download_inputs, filenames, task_id)
     return 0
 
 

--- a/inductiva/_cli/cmd_tasks/download.py
+++ b/inductiva/_cli/cmd_tasks/download.py
@@ -53,7 +53,7 @@ def register(parser):
         "The name of the input/output folder can be configured through the\n"
         "--dir option. Files are downloaded to a subdirectory named after the\n"
         "ID of the corresponding task. The output files are downloaded when\n"
-        "the --output option is passed. Similarly, the input files are\n"
+        "the --output/-o option is passed. Similarly, the input files are\n"
         "downloaded when the --input option is passed. If neither option is\n"
         "specified, the output files are downloaded by default.")
 

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -830,9 +830,6 @@ class Task:
             The URL to download the input files of the task, or None
         """
         response_body = self._request_download_input_url()
-        if not response_body:
-            return None
-
         download_url = response_body.get("url")
         if download_url is None:
             raise RuntimeError(

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -797,9 +797,12 @@ class Task:
         self
     ) -> Optional[get_tasks_task_id_download_input_url.
                   SchemaFor200ResponseBodyApplicationJson]:
-        api_response = self._api.get_input_download_url(
-            path_params=self._get_path_params(),)
-        return api_response.body
+        try:
+            api_response = self._api.get_input_download_url(
+                path_params=self._get_path_params(),)
+            return api_response.body
+        except exceptions.ApiException:
+            return None
 
     def get_output_url(self) -> Optional[str]:
         """Get a public URL to download the output files of the task.

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -881,7 +881,7 @@ class Task:
 
         if dest_dir is None:
             dest_dir = self.id
-        dest_dir += f'/{sub_dir}/'
+        dest_dir += f"/{sub_dir}/"
 
         dir_path = files.resolve_output_path(dest_dir)
 
@@ -977,7 +977,7 @@ class Task:
         return self._download(
             filenames=filenames,
             dest_dir=output_dir,
-            sub_dir='outputs',
+            sub_dir="outputs",
             uncompress=uncompress,
             rm_downloaded_zip_archive=rm_downloaded_zip_archive,
             rm_remote_files=rm_remote_files,
@@ -1014,7 +1014,7 @@ class Task:
         return self._download(
             filenames=filenames,
             dest_dir=input_dir,
-            sub_dir='inputs',
+            sub_dir="inputs",
             uncompress=uncompress,
             rm_downloaded_zip_archive=rm_downloaded_zip_archive,
             rm_remote_files=rm_remote_files,

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -802,18 +802,8 @@ class Task:
                 path_params=self._get_path_params(),)
         except exceptions.ApiException as e:
             if not self._called_from_wait:
-
-                if self._status == models.TaskStatusCode.EXECUTERFAILED:
-                    logging.info("The remote process running the task failed:")
-                    self.get_info()
-                    detail = self.info.executer.error_detail
-                    if detail:
-                        logging.info(" > Message: %s", detail)
-                    else:
-                        logging.info(" > No error message available.")
-                else:
-                    # Raise the exception to be handled by the exception handler
-                    raise e
+                # Raise the exception to be handled by the exception handler
+                raise e
             return None
         finally:
             # Reset internal state

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -851,12 +851,12 @@ class Task:
         self,
         filenames: Optional[List[str]],
         dest_dir: Optional[str],
+        sub_dir: str,
         uncompress: bool,
         rm_downloaded_zip_archive: bool,
         rm_remote_files: bool,
         zip_name: str,
         request_download_url: Callable,
-        resolve_path: Callable,
         download_partial_files: Callable,
         download_task_files: Callable,
     ) -> pathlib.Path:
@@ -881,8 +881,9 @@ class Task:
 
         if dest_dir is None:
             dest_dir = self.id
+        dest_dir += f'/{sub_dir}/'
 
-        dir_path = resolve_path(dest_dir)
+        dir_path = files.resolve_output_path(dest_dir)
 
         if (dir_path.exists() and not self._contains_only_std_files(dir_path)):
             warnings.warn("Path already exists, files may be overwritten.")
@@ -964,7 +965,7 @@ class Task:
                 files are downloaded.
             output_dir: Directory where to download the files. If None, the
                 files are downloaded to the default directory. The default is
-                {inductiva.get_output_dir()}/{output_dir}/{task_id}.
+                {inductiva.get_output_dir()}/[{output_dir}|{task_id}]/outputs/.
             uncompress: Whether to uncompress the archive after downloading it.
             rm_downloaded_zip_archive: Whether to remove the archive after
                 uncompressing it. If uncompress is False, this argument is
@@ -976,12 +977,12 @@ class Task:
         return self._download(
             filenames=filenames,
             dest_dir=output_dir,
+            sub_dir='outputs',
             uncompress=uncompress,
             rm_downloaded_zip_archive=rm_downloaded_zip_archive,
             rm_remote_files=rm_remote_files,
             zip_name="output.zip",
             request_download_url=self._request_download_output_url,
-            resolve_path=files.resolve_output_path,
             download_partial_files=data.download_partial_outputs,
             download_task_files=self._api.download_task_output,
         )
@@ -1001,7 +1002,7 @@ class Task:
                 files are downloaded.
             input_dir: Directory where to download the files. If None, the
                 files are downloaded to the default directory. The default is
-                {inductiva.get_input_dir()}/{input_dir}/{task_id}.
+                {inductiva.get_output_dir()}/[{input_dir}|{task_id}]/inputs/.
             uncompress: Whether to uncompress the archive after downloading it.
             rm_downloaded_zip_archive: Whether to remove the archive after
                 uncompressing it. If uncompress is False, this argument is
@@ -1013,12 +1014,12 @@ class Task:
         return self._download(
             filenames=filenames,
             dest_dir=input_dir,
+            sub_dir='inputs',
             uncompress=uncompress,
             rm_downloaded_zip_archive=rm_downloaded_zip_archive,
             rm_remote_files=rm_remote_files,
             zip_name="input.zip",
             request_download_url=self._request_download_input_url,
-            resolve_path=files.resolve_input_path,
             download_partial_files=data.download_partial_inputs,
             download_task_files=self._api.download_task_input,
         )

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -795,14 +795,11 @@ class Task:
 
     def _request_download_input_url(
         self
-    ) -> Optional[get_tasks_task_id_download_input_url.
-                  SchemaFor200ResponseBodyApplicationJson]:
-        try:
-            api_response = self._api.get_input_download_url(
-                path_params=self._get_path_params(),)
-            return api_response.body
-        except exceptions.ApiException:
-            return None
+    ) -> get_tasks_task_id_download_input_url.\
+         SchemaFor200ResponseBodyApplicationJson:
+        api_response = self._api.get_input_download_url(
+            path_params=self._get_path_params(),)
+        return api_response.body
 
     def get_output_url(self) -> Optional[str]:
         """Get a public URL to download the output files of the task.

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -888,7 +888,7 @@ class Task:
 
         if filenames is self.STANDARD_OUTPUT_FILES:
             download_message = "Downloading stdout and stderr files to %s..."
-        
+
         if filenames:
             if file_server_available:
                 logging.info(download_message, dir_path)
@@ -901,7 +901,7 @@ class Task:
 
             logging.info("Partial download completed to %s.", dir_path)
             return dir_path
-    
+
         zip_path = dir_path.joinpath(zip_name)
         logging.info(download_message, zip_path)
 
@@ -944,7 +944,7 @@ class Task:
                 "For more information.", self.id, dir_path)
 
         return dir_path
-    
+
     def download_outputs(
         self,
         filenames: Optional[List[str]] = None,
@@ -981,7 +981,7 @@ class Task:
             download_partial_files=data.download_partial_outputs,
             download_task_files=self._api.download_task_output,
         )
-    
+
     def download_inputs(
         self,
         filenames: Optional[List[str]] = None,

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -797,18 +797,8 @@ class Task:
         self
     ) -> Optional[get_tasks_task_id_download_input_url.
                   SchemaFor200ResponseBodyApplicationJson]:
-        try:
-            api_response = self._api.get_input_download_url(
-                path_params=self._get_path_params(),)
-        except exceptions.ApiException as e:
-            if not self._called_from_wait:
-                # Raise the exception to be handled by the exception handler
-                raise e
-            return None
-        finally:
-            # Reset internal state
-            self._called_from_wait = False
-
+        api_response = self._api.get_input_download_url(
+            path_params=self._get_path_params(),)
         return api_response.body
 
     def get_output_url(self) -> Optional[str]:

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -843,6 +843,27 @@ class Task:
 
         return download_url
 
+    def get_input_url(self) -> Optional[str]:
+        """Get a public URL to download the input files of the task.
+
+        Returns:
+            The URL to download the input files of the task, or None
+        """
+        response_body = self._request_download_input_url()
+        if not response_body:
+            return None
+
+        download_url = response_body.get("url")
+        if download_url is None:
+            raise RuntimeError(
+                "The API did not return a download URL for the task outputs.")
+
+        logging.info("■ Use the following URL to download the input "
+                     "files of you simulation:")
+        logging.info(" > %s", download_url)
+
+        return download_url
+
     def _download(
         self,
         filenames: Optional[List[str]],

--- a/inductiva/tests/simulators/test_simulator_with_resources.py
+++ b/inductiva/tests/simulators/test_simulator_with_resources.py
@@ -2,6 +2,7 @@
 from argparse import Namespace
 from unittest import mock
 import inspect
+from pathlib import Path
 import sys
 import os
 import uuid
@@ -244,10 +245,11 @@ def test_resubmit_on_preemption__is_correctly_handled(resubmit_on_preemption):
             print(args_spec)
             args = ([],) * (len(args_spec) - 2)  # -2 for self and input_dir
 
+            test_input_dir = Path(__file__).parent / 'test_input_dir'
             if resubmit_on_preemption is None:
                 # test that the default value of
                 # `resubmit_on_preemption` is False
-                sim_obj.run("inductiva/tests/simulators/test_input_dir",
+                sim_obj.run(test_input_dir,
                             *args,
                             on=mock_mg)
                 req_arg = submit_mock.call_args[1]["request"]
@@ -255,7 +257,7 @@ def test_resubmit_on_preemption__is_correctly_handled(resubmit_on_preemption):
             else:
                 # test that the value of `resubmit_on_preemption` is passed
                 # correctly to the final api call
-                sim_obj.run("inductiva/tests/simulators/test_input_dir",
+                sim_obj.run(test_input_dir,
                             *args,
                             on=mock_mg,
                             resubmit_on_preemption=resubmit_on_preemption)

--- a/inductiva/tests/simulators/test_simulator_with_resources.py
+++ b/inductiva/tests/simulators/test_simulator_with_resources.py
@@ -245,7 +245,7 @@ def test_resubmit_on_preemption__is_correctly_handled(resubmit_on_preemption):
             print(args_spec)
             args = ([],) * (len(args_spec) - 2)  # -2 for self and input_dir
 
-            test_input_dir = Path(__file__).parent / 'test_input_dir'
+            test_input_dir = Path(__file__).parent / "test_input_dir"
             if resubmit_on_preemption is None:
                 # test that the default value of
                 # `resubmit_on_preemption` is False

--- a/inductiva/tests/simulators/test_simulator_with_resources.py
+++ b/inductiva/tests/simulators/test_simulator_with_resources.py
@@ -249,9 +249,7 @@ def test_resubmit_on_preemption__is_correctly_handled(resubmit_on_preemption):
             if resubmit_on_preemption is None:
                 # test that the default value of
                 # `resubmit_on_preemption` is False
-                sim_obj.run(test_input_dir,
-                            *args,
-                            on=mock_mg)
+                sim_obj.run(test_input_dir, *args, on=mock_mg)
                 req_arg = submit_mock.call_args[1]["request"]
                 assert not req_arg[resubmit_key]
             else:

--- a/inductiva/tests/utils/test_files_utils.py
+++ b/inductiva/tests/utils/test_files_utils.py
@@ -230,10 +230,10 @@ def test_extract_zip_file_to_output_dir(tmp_path: pathlib.Path):
 
         for file in files_list:
             #pylint: disable=protected-access
-            data._extract_zip_file_to_output(output_dir=output_dir,
-                                             remove_zip_file=zip_f,
-                                             zip_path=file,
-                                             filename=file)
+            data._extract_zip_file_to_dir(dest_dir=output_dir,
+                                          remove_zip_file=zip_f,
+                                          zip_path=file,
+                                          filename=file)
             #pylint: enable=protected-access
 
     assert (output_dir / "file1.txt").exists()

--- a/inductiva/utils/data.py
+++ b/inductiva/utils/data.py
@@ -11,7 +11,7 @@ import pathlib
 import zipfile
 import tempfile
 import shutil
-from typing import List
+from typing import Callable, List
 from tqdm import tqdm
 import fsspec
 import urllib3
@@ -226,8 +226,8 @@ def zip_dir(dir_path, zip_name):
     return zip_path
 
 
-def _extract_zip_file_to_output(
-    output_dir: pathlib.Path,
+def _extract_zip_file_to_dir(
+    dest_dir: pathlib.Path,
     remove_zip_file: zipfile.ZipFile,
     filename: str,
     zip_path: str,
@@ -235,17 +235,51 @@ def _extract_zip_file_to_output(
     """Write a file from a ZIP archive to the output directory.
 
     Args:
-        output_dir: Directory where to store the extracted file.
+        dest_dir: Directory where to store the extracted file.
         remove_zip_file: ZipFile object from which to extract the file.
         filename: Name of the file to extract.
         zip_path: Path of the file inside the ZIP archive.
     """
     with remove_zip_file.open(zip_path) as source:
-        target_path = output_dir / pathlib.Path(filename)
+        target_path = dest_dir / pathlib.Path(filename)
         target_path.parent.mkdir(parents=True, exist_ok=True)
         with open(target_path, "wb") as target:
             target.write(source.read())
 
+def _download_partial_files(
+    download_url: str,
+    filenames: List[str],
+    dest_dir: pathlib.Path,
+    make_zip_path: Callable,
+) -> None:
+    """Download the partial files of a task.
+
+    Args:
+        download_url: URL from which to download the files.
+        filenames: List of filenames to download.
+        dest_dir: Path where to store the downloaded files.
+
+    Return:
+        Returns True if the download was successful, False otherwise.
+    """
+    try:
+        remote_filesystem = fsspec.filesystem("http")
+
+        with remote_filesystem.open(download_url, "rb") as remote_file:
+            with zipfile.ZipFile(remote_file) as remote_zip_file:
+                for filename in filenames:
+                    zip_path = make_zip_path(filename)
+                    try:
+                        _extract_zip_file_to_dir(dest_dir, remote_zip_file,
+                                                 filename, zip_path)
+                    except KeyError:
+                        logging.warning(
+                            "File %s not found in the output archive.",
+                            zip_path)
+
+    except Exception as e:  # pylint: disable=broad-except
+        logging.debug("Error downloading partial outputs: %s", e)
+        logging.error("Partial download failed.")
 
 def download_partial_outputs(
     download_url: str,
@@ -262,25 +296,33 @@ def download_partial_outputs(
     Return:
         Returns True if the download was successful, False otherwise.
     """
-    try:
-        remote_filesystem = fsspec.filesystem("http")
+    make_zip_path = lambda filename: "artifacts/" + filename
+    return _download_partial_files(download_url=download_url,
+                                   filenames=filenames,
+                                   dest_dir=output_dir,
+                                   make_zip_path=make_zip_path)
 
-        with remote_filesystem.open(download_url, "rb") as remote_file:
-            with zipfile.ZipFile(remote_file) as remote_zip_file:
-                for filename in filenames:
-                    zip_path = "artifacts/" + filename
-                    try:
-                        _extract_zip_file_to_output(output_dir, remote_zip_file,
-                                                    filename, zip_path)
-                    except KeyError:
-                        logging.warning(
-                            "File %s not found in the output archive.",
-                            zip_path)
+def download_partial_inputs(
+    download_url: str,
+    filenames: List[str],
+    input_dir: pathlib.Path,
+) -> None:
+    """Download the partial inputs of a task.
 
-    except Exception as e:  # pylint: disable=broad-except
-        logging.debug("Error downloading partial outputs: %s", e)
-        logging.error("Partial download failed.")
+    Args:
+        download_url: URL from which to download the inputs.
+        filenames: List of filenames to download.
+        output_dir: Path where to store the downloaded files.
 
+    Return:
+        Returns True if the download was successful, False otherwise.
+    """
+    make_zip_path = lambda filename: "sim_dir/" + filename \
+        if filename != 'input.json' else filename
+    return _download_partial_files(download_url=download_url,
+                                   filenames=filenames,
+                                   dest_dir=input_dir,
+                                   make_zip_path=make_zip_path)
 
 def download_file(
     response: urllib3.response.HTTPResponse,

--- a/inductiva/utils/data.py
+++ b/inductiva/utils/data.py
@@ -300,11 +300,11 @@ def download_partial_outputs(
     Return:
         Returns True if the download was successful, False otherwise.
     """
-    make_zip_path = lambda filename: "artifacts/" + filename
-    return _download_partial_files(download_url=download_url,
-                                   filenames=filenames,
-                                   dest_dir=output_dir,
-                                   make_zip_path=make_zip_path)
+    return _download_partial_files(
+        download_url=download_url,
+        filenames=filenames,
+        dest_dir=output_dir,
+        make_zip_path=lambda filename: "artifacts/" + filename)
 
 
 def download_partial_inputs(
@@ -322,12 +322,12 @@ def download_partial_inputs(
     Return:
         Returns True if the download was successful, False otherwise.
     """
-    make_zip_path = lambda filename: "sim_dir/" + filename \
-        if filename != 'input.json' else filename
-    return _download_partial_files(download_url=download_url,
-                                   filenames=filenames,
-                                   dest_dir=input_dir,
-                                   make_zip_path=make_zip_path)
+    return _download_partial_files(
+        download_url=download_url,
+        filenames=filenames,
+        dest_dir=input_dir,
+        make_zip_path=lambda filename: "sim_dir/" + filename \
+            if filename != "input.json" else filename)
 
 
 def download_file(

--- a/inductiva/utils/data.py
+++ b/inductiva/utils/data.py
@@ -258,6 +258,8 @@ def _download_partial_files(
         download_url: URL from which to download the files.
         filenames: List of filenames to download.
         dest_dir: Path where to store the downloaded files.
+        make_zip_path: Function to create a path of a file inside the ZIP 
+        given a filename.
 
     Return:
         Returns True if the download was successful, False otherwise.

--- a/inductiva/utils/data.py
+++ b/inductiva/utils/data.py
@@ -373,7 +373,7 @@ def uncompress_task_outputs(zip_path: pathlib.Path, output_dir: pathlib.Path):
     """Uncompress a ZIP archive containing the outputs of a task.
 
     If the archive contains the directory called artifacts, it means that the
-    download includes the full ouputs of the task with the full directory
+    download includes the full outputs of the task with the full directory
     structure of the outputs (output.json, artifacts/*). Only the contents
     inside artifacts are extracted to the output directory. If the archive
     does not contain the artifacts directory, it means that the download

--- a/inductiva/utils/data.py
+++ b/inductiva/utils/data.py
@@ -246,6 +246,7 @@ def _extract_zip_file_to_dir(
         with open(target_path, "wb") as target:
             target.write(source.read())
 
+
 def _download_partial_files(
     download_url: str,
     filenames: List[str],
@@ -283,6 +284,7 @@ def _download_partial_files(
         logging.debug("Error downloading partial outputs: %s", e)
         logging.error("Partial download failed.")
 
+
 def download_partial_outputs(
     download_url: str,
     filenames: List[str],
@@ -303,6 +305,7 @@ def download_partial_outputs(
                                    filenames=filenames,
                                    dest_dir=output_dir,
                                    make_zip_path=make_zip_path)
+
 
 def download_partial_inputs(
     download_url: str,
@@ -325,6 +328,7 @@ def download_partial_inputs(
                                    filenames=filenames,
                                    dest_dir=input_dir,
                                    make_zip_path=make_zip_path)
+
 
 def download_file(
     response: urllib3.response.HTTPResponse,

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -60,6 +60,22 @@ def get_path_size(path_str: str) -> float:
             size += fp.stat().st_size
     return size
 
+def _resolve_io_path(path: Optional[str], io_dir: str) -> pathlib.Path:
+    """Resolve a path relative to I/O directory
+
+    Args:
+        path: Path to a file or directory.
+        io_dir: Name of I/O directory
+    """
+    resolved_path = pathlib.Path.cwd()
+
+    if io_dir:
+        resolved_path = pathlib.Path(io_dir)
+
+    if path is not None:
+        resolved_path = pathlib.Path(resolved_path, path)
+
+    return resolved_path
 
 def resolve_output_path(path: Optional[str]) -> pathlib.Path:
     """Resolve a path relative to the output_dir
@@ -67,16 +83,15 @@ def resolve_output_path(path: Optional[str]) -> pathlib.Path:
     Args:
         path: Path to a file or directory.
     """
-    resolved_path = pathlib.Path.cwd()
+    return _resolve_io_path(path, inductiva.get_output_dir())
 
-    if inductiva.get_output_dir():
-        resolved_path = pathlib.Path(inductiva.get_output_dir())
+def resolve_input_path(path: Optional[str]) -> pathlib.Path:
+    """Resolve a path relative to the output_dir
 
-    if path is not None:
-        resolved_path = pathlib.Path(resolved_path, path)
-
-    return resolved_path
-
+    Args:
+        path: Path to a file or directory.
+    """
+    return _resolve_io_path(path, inductiva.get_input_dir())
 
 def get_sorted_files(data_dir: str,
                      file_format: str = "name",

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -61,40 +61,21 @@ def get_path_size(path_str: str) -> float:
     return size
 
 
-def _resolve_io_path(path: Optional[str], io_dir: str) -> pathlib.Path:
+def resolve_output_path(path: Optional[str]) -> pathlib.Path:
     """Resolve a path relative to I/O directory
 
     Args:
         path: Path to a file or directory.
-        io_dir: Name of I/O directory
     """
     resolved_path = pathlib.Path.cwd()
 
-    if io_dir:
-        resolved_path = pathlib.Path(io_dir)
+    if inductiva.get_output_dir():
+        resolved_path = pathlib.Path(inductiva.get_output_dir())
 
     if path is not None:
         resolved_path = pathlib.Path(resolved_path, path)
 
     return resolved_path
-
-
-def resolve_output_path(path: Optional[str]) -> pathlib.Path:
-    """Resolve a path relative to the output_dir
-
-    Args:
-        path: Path to a file or directory.
-    """
-    return _resolve_io_path(path, inductiva.get_output_dir())
-
-
-def resolve_input_path(path: Optional[str]) -> pathlib.Path:
-    """Resolve a path relative to the output_dir
-
-    Args:
-        path: Path to a file or directory.
-    """
-    return _resolve_io_path(path, inductiva.get_input_dir())
 
 
 def get_sorted_files(data_dir: str,

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -60,6 +60,7 @@ def get_path_size(path_str: str) -> float:
             size += fp.stat().st_size
     return size
 
+
 def _resolve_io_path(path: Optional[str], io_dir: str) -> pathlib.Path:
     """Resolve a path relative to I/O directory
 
@@ -77,6 +78,7 @@ def _resolve_io_path(path: Optional[str], io_dir: str) -> pathlib.Path:
 
     return resolved_path
 
+
 def resolve_output_path(path: Optional[str]) -> pathlib.Path:
     """Resolve a path relative to the output_dir
 
@@ -85,6 +87,7 @@ def resolve_output_path(path: Optional[str]) -> pathlib.Path:
     """
     return _resolve_io_path(path, inductiva.get_output_dir())
 
+
 def resolve_input_path(path: Optional[str]) -> pathlib.Path:
     """Resolve a path relative to the output_dir
 
@@ -92,6 +95,7 @@ def resolve_input_path(path: Optional[str]) -> pathlib.Path:
         path: Path to a file or directory.
     """
     return _resolve_io_path(path, inductiva.get_input_dir())
+
 
 def get_sorted_files(data_dir: str,
                      file_format: str = "name",


### PR DESCRIPTION
This PR adds functionality for users to download task inputs. It includes refactoring output download functions to adapt and reuse the same logic for input downloads. It also adds the functionality to CLI.

Example in Python:
```python3
import inductiva

task = inductiva.tasks.Task("123456789")

# download all inputs
task.download_inputs()

# select some input files to download
task.download_inputs(
    input_dir='json-file-and-control-txt',
    filenames=['input.json', 'control.txt'],
)
```

Examples in CLI:
```bash
# download all output files (default)
inductiva tasks download 123456789
# download all input files
inductiva tasks download 123456789 --input
# download all output files
inductiva tasks download 123456789 --output
# download all input and output files
inductiva tasks download 123456789 --input --output
# download selected input and output files
inductiva tasks download 123456789 --input --output --filenames input.json stdout.txt
```