### PR TITLE
Added cost to task info

### DIFF
--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -96,6 +96,7 @@ class TaskInfo:
         self.computation_start_time = None
         self.computation_end_time = None
         self.end_time = None
+        self.cost = None
         self.time_metrics = self.TimeMetrics()
         self.data_metrics = self.DataMetrics()
         self._kwargs = kwargs
@@ -238,6 +239,7 @@ class TaskInfo:
         table_str += f"\n{wall_time_table}"
         table_str += f"\nTime breakdown:\n{time_metrics_table}"
         table_str += f"\nData:\n{data_metrics_table}\n"
+        table_str += f"\nCost ($US): {self.cost}\n"
 
         return table_str
 

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -239,7 +239,8 @@ class TaskInfo:
         table_str += f"\n{wall_time_table}"
         table_str += f"\nTime breakdown:\n{time_metrics_table}"
         table_str += f"\nData:\n{data_metrics_table}\n"
-        table_str += f"\nCost ($US): {self.cost}\n"
+        if self.cost:
+            table_str += f"\nCost ($US): {self.cost}\n"
 
         return table_str
 


### PR DESCRIPTION
https://github.com/inductiva/tasks/issues/396

This PR adds the task cost to the info.

Running the cli command `inductiva task info <task_id>` should now also print the task cost.
This also works for python scripts with the task.info or task.get_info().

The task cost will only be displayed if there is a cost to be shown.