### PR TITLE
Add organization to inductiva user info

### DIFF
--- a/inductiva/_cli/cmd_user/info.py
+++ b/inductiva/_cli/cmd_user/info.py
@@ -100,11 +100,13 @@ def get_info(_, fout: TextIO = sys.stdout):
     """
     user_info = users.get_info()
 
+    organization = user_info["organization"] or ""
     tier = user_info["tier"]["name"]
     username = user_info["username"]
     email = user_info["email"]
     name = user_info["name"] or ""
 
+    print(f"\nOrganization: {organization}\n", file=fout)
     print(f"Name: {name}", file=fout)
     print(f"Email: {email}", file=fout)
     print(f"Username: {username}", file=fout)


### PR DESCRIPTION
Issue https://github.com/inductiva/tasks/issues/426

This PR adds the user's organization to the cli info method.

```
inductiva user info

Organization: inductiva

Name: PAULO 🥾🐛
Email: pbarbosa@inductiva.ai
Username: pbarbosaaa788d1b
```