### PR TITLE
Fix simulator name

### DIFF
--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -20,7 +20,7 @@ class AmrWind(simulators.Simulator):
                 is used.
         """
         super().__init__(version=version, use_dev=use_dev)
-        self.simulator = "amrWind"
+        self.simulator = "amrwind"
 
     @property
     def name(self):


### PR DESCRIPTION
This PR fixes amrwind simulator name for the BE. They expect all lower case.