### PR TITLE
Task cost now always show. N/A if not present

### DIFF
--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -245,9 +245,10 @@ class TaskInfo:
         if self.estimated_computation_cost:
             estimated_cost = format_utils.currency_formatter(
                 self.estimated_computation_cost,)
-            table_str += ("\nEstimated computation cost (US$): "
-                          f"{estimated_cost}\n")
-
+        else:
+            estimated_cost = "N/A"
+        table_str += ("\nEstimated computation cost (US$): "
+                      f"{estimated_cost}\n")
         return table_str
 
 


### PR DESCRIPTION
This PR changes a bit the task info. Now it always shows the task estimated cost but writes N/A when not present.
Issue https://github.com/inductiva/tasks/issues/454