### PR TITLE
Now shows storage cost and total size

### DIFF
--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -46,6 +46,11 @@ def listdir(path="/",
     """
 
     api = storage_api.StorageApi(inductiva.api.get_client())
+
+    estimated_storage_cost = api.get_storage_monthly_cost(
+    ).body["estimated_monthly_cost"]
+    storage_total_size = api.get_storage_size().body
+
     contents = api.list_storage_contents({
         "path": path,
         "max_results": max_results,
@@ -62,6 +67,14 @@ def listdir(path="/",
             "creation_time": creation_time
         })
     print(_print_contents_table(all_contents))
+
+    print("Total storage size used:")
+    print(f"\tVolume: {format_utils.bytes_formatter(storage_total_size)}")
+    print(
+        f"\tCost: {format_utils.currency_formatter(estimated_storage_cost)}/month"
+    )
+    print("")
+
     print(f"Listed {len(all_contents)} folder(s). Ordered by {order_by}.\n"
           "Use --max-results/-m to control the number of results displayed.")
     return all_contents


### PR DESCRIPTION
This PR adds the total storage size and cost to the storage list command.

```
inductiva storage list

 NAME                        SIZE        CREATION TIME
 0wrda3n4jfvnp9sfhjncuyj96   125.52 MB   23 Oct, 09:21:43
 2y2rxkbr2tx3tbyadhgqtytpr   125.52 MB   22 Oct, 17:12:36
 jqqz426631rrc6ibu024u29v3   125.52 MB   22 Oct, 17:01:10
 azxd8aogxiaqub2p2qkhur8a5   125.52 MB   22 Oct, 12:43:37
 i197cfzuvxvsereky7ysxk04g   325.99 KB   22 Oct, 12:36:04
 905mfarahciqx6tb7amdsebu9   325.99 KB   22 Oct, 12:36:03
 b4a0b7ajb6n0paj7pr0f7hf4u   325.99 KB   22 Oct, 12:36:01
 dnwf7r6gaag60t0nirhpky3j8   325.99 KB   22 Oct, 12:36:00
 tno9c0117ddo6xi1ka64cyq33   325.99 KB   22 Oct, 12:35:59
 t6k33enpv5kchqex9ie30t9z4   325.99 KB   22 Oct, 12:35:54

Total storage size used:
	Volume: 340.61 GB
	Cost: 6.34 US$/month

Listed 10 folder(s). Ordered by creation_time.
Use --max-results/-m to control the number of results displayed.
```