### PR TITLE
Fix resources available family, and allow for multiple families

### DIFF
--- a/inductiva/_cli/cmd_resources/list.py
+++ b/inductiva/_cli/cmd_resources/list.py
@@ -179,7 +179,7 @@ def register(parser):
                            help="Filter the available types by provider.")
     subparser.add_argument("-f",
                            "--family",
-                           nargs = "+",
+                           nargs="+",
                            default=None,
                            type=str,
                            help="Filter the available types by CPU series.")

--- a/inductiva/_cli/cmd_resources/list.py
+++ b/inductiva/_cli/cmd_resources/list.py
@@ -179,6 +179,7 @@ def register(parser):
                            help="Filter the available types by provider.")
     subparser.add_argument("-f",
                            "--family",
+                           nargs = "+",
                            default=None,
                            type=str,
                            help="Filter the available types by CPU series.")

--- a/inductiva/resources/machine_types.py
+++ b/inductiva/resources/machine_types.py
@@ -68,7 +68,7 @@ def get_available_machine_types(
     query_params = {"provider_id": provider.value}
 
     if machine_family is not None:
-        query_params["machine_family"] = machine_family
+        query_params["machine_families"] = machine_family
 
     try:
         resp = api_client.list_available_machine_types(query_params).response


### PR DESCRIPTION
This PR fixes the command `inductiva resources available -f`