### PR TITLE
Task wait was not handling the status correctly

### DIFF
--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -665,8 +665,9 @@ class Task:
                     self._tasks_ahead is not None):
                 requires_newline = True
                 self._update_queue_info(is_tty=is_tty, duration=duration)
-
-            if self.is_terminal():
+            #use is_terminal instead of the method to avoid an api call
+            #that can make the task status inconsistent
+            if self.info.is_terminal:
                 self._handle_terminal_status(
                     download_std_on_completion=download_std_on_completion,
                     status=status)


### PR DESCRIPTION
@luispcunha Pointed this out.
The way we had the wait before we could exit the method with a strange status.
- We get the task info and print something
- from the time we print and get to `if self.is_terminal()` the task might end
- The user would see "Task running ..." and wait would exit without any other text.

We now don't call the api to check if is_terminal and use the current value we get from the first get_info