### PR TITLE
Maybe the manual actions were not working due to the escape char

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -36,14 +36,22 @@ jobs:
         with:
           docs-folder: "source/docs/"
           # required by #1291
-          pre-build-command: "apt-get update -y && apt-get install -y git && pip install myst-parser -y && echo 'extensions = [\'myst_parser\',]' > conf.py"
+          pre-build-command: |
+            apt-get update -y && \
+            apt-get install -y git && \
+            pip install -y myst-parser && \
+            echo "extensions = ['myst_parser']" > conf.py
           build-command: "sphinx-build . ../../build/en/latest -W -D version=latest"
 
       - uses: nicholasphair/sphinx-action@7.0.0
         with:
           docs-folder: "source-dev/docs/"
           # required by #1291
-          pre-build-command: "apt-get update -y && apt-get install -y git && pip install myst-parser -y && echo 'extensions = [\'myst_parser\',]' > conf.py"
+          pre-build-command: |
+            apt-get update -y && \
+            apt-get install -y git && \
+            pip install -y myst-parser && \
+            echo "extensions = ['myst_parser']" > conf.py
           build-command: "sphinx-build . ../../build/en/development -W -D version=development"
 
       - name: disable jekyll

--- a/.github/workflows/deploy-docs-to-staging.yml
+++ b/.github/workflows/deploy-docs-to-staging.yml
@@ -18,7 +18,11 @@ jobs:
         with:
           docs-folder: "source/docs/"
           # required by #1291
-          pre-build-command: "apt-get update -y && apt-get install -y git && pip install myst-parser -y && echo 'extensions = [\'myst_parser\',]' > conf.py"
+          pre-build-command: |
+            apt-get update -y && \
+            apt-get install -y git && \
+            pip install -y myst-parser && \
+            echo "extensions = ['myst_parser']" > conf.py
           build-command: "sphinx-build . ../../build/en/latest -W -D version=latest"
 
       - name: Deploy to staging webserver via rsync

--- a/.github/workflows/deploy-tutorials-to-prod.yaml
+++ b/.github/workflows/deploy-tutorials-to-prod.yaml
@@ -20,7 +20,11 @@ jobs:
         with:
           docs-folder: "source/tutorials/"
           # required by #1291
-          pre-build-command: "apt-get update -y && apt-get install -y git && pip install myst-parser -y && echo 'extensions = [\'myst_parser\',]' > conf.py"
+          pre-build-command: |
+            apt-get update -y && \
+            apt-get install -y git && \
+            pip install -y myst-parser && \
+            echo "extensions = ['myst_parser']" > conf.py
           build-command: "sphinx-build . ../../build/en/latest -W -D version=latest"
 
       - name: Deploy to staging webserver via rsync

--- a/.github/workflows/deploy-tutorials-to-staging.yml
+++ b/.github/workflows/deploy-tutorials-to-staging.yml
@@ -18,7 +18,11 @@ jobs:
         with:
           docs-folder: "source/tutorials/"
           # required by #1291
-          pre-build-command: "apt-get update -y && apt-get install -y git && pip install myst-parser -y && echo 'extensions = [\'myst_parser\',]' > conf.py"
+          pre-build-command: |
+            apt-get update -y && \
+            apt-get install -y git && \
+            pip install -y myst-parser && \
+            echo "extensions = ['myst_parser']" > conf.py
           build-command: "sphinx-build . ../../build/en/latest -W -D version=latest"
 
       - name: Deploy to staging webserver via rsync


### PR DESCRIPTION
This PR changes some actions a bit. Some manual github actions were not working (maybe due to this "... echo 'extensions = [\'myst_parser\',]' > conf.py")