### PR TITLE
Add comp started and ended to the RUNNING_STATUSES

### DIFF
--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -315,7 +315,9 @@ class Task:
     }
 
     RUNNING_STATUSES = {
-        models.TaskStatusCode.PENDINGINPUT, models.TaskStatusCode.STARTED
+        models.TaskStatusCode.PENDINGINPUT, models.TaskStatusCode.STARTED,
+        models.TaskStatusCode.COMPUTATIONSTARTED,
+        models.TaskStatusCode.COMPUTATIONENDED
     }
 
     KILLABLE_STATUSES = {models.TaskStatusCode.SUBMITTED


### PR DESCRIPTION
This PR fixes an error with the kill --all command. We use a list of running status to get all tasks. ComputationStarted/ended was missing from there.