### PR TITLE
Refactor methods for gathering and exporting runs info

### DIFF
--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -120,7 +120,7 @@ class Benchmark(Project):
         """
         with self:
             for simulator, input_dir, machine_group, kwargs in self.runs:
-                machine_group.start(wait_on_pending_quota=True)
+                machine_group.start(wait_on_pending_quota=False)
                 for _ in range(num_repeats):
                     simulator.run(input_dir=input_dir,
                                   on=machine_group,

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -221,9 +221,9 @@ class Benchmark(Project):
                 "task_id": task_info.task_id,
                 "simulator": task_info.simulator,
                 "machine_type": task_info.executer.vm_type,
-                "computation_time": \
+                "computation_time":  \
                     task_info.time_metrics.computation_seconds.value,
-                "estimated_computation_cost": \
+                "estimated_computation_cost":  \
                     task_info.estimated_computation_cost,
                 **task_input_params,
             })

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -182,23 +182,28 @@ class Benchmark(Project):
             list: A list containing the configuration and performance 
                 metrics for each run.
         """
-        metrics = []
-        tasks = self.get_tasks()
-        for task in tasks:
+
+        def get_task_input_params(task):
             input_filename = "input.json"
             input_dir_path = task.download_inputs(filenames=[input_filename])
             input_file_path = input_dir_path.joinpath(input_filename)
             with open(input_file_path, mode="r", encoding="utf-8") as file:
-                input_json = json.load(file)
+                params = json.load(file)
+                excluded = ["sim_dir", "container_image"]
+                return {k: v for k, v in params.items() if k not in excluded}
 
+        metrics = []
+        tasks = self.get_tasks()
+        for task in tasks:
+            input_params = get_task_input_params(task)
             info = task.get_info()
             metrics.append({
                 "task id": info.task_id,
                 "simulator": info.simulator,
                 "machine type": info.executer.vm_type,
-                **input_json,
                 "computation time": info.time_metrics.computation_seconds.value,
                 "estimated computation cost": info.estimated_computation_cost,
+                **input_params,
             })
         return metrics
 

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -185,18 +185,18 @@ class Benchmark(Project):
             dict: A dictionary organized by virtual machine type, containing
                 performance metrics for each task associated with the benchmark.
         """
-        data = {}
+        metrics = {}
         tasks = self.get_tasks()
         for task in tasks:
             info = task.get_info()
             vm_type = info.executer.vm_type
-            data.setdefault(vm_type, [])
-            data[vm_type].append({
+            metrics.setdefault(vm_type, [])
+            metrics[vm_type].append({
                 "task_id": info.task_id,
                 "estimated_computation_cost": info.estimated_computation_cost,
                 "computation_time": info.time_metrics.computation_seconds.value,
             })
-        return data
+        return metrics
 
     def gather_detailed_data(self) -> dict:
         """

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -149,8 +149,8 @@ class Benchmark(Project):
         Exports the benchmark performance metrics in the specified format.
 
         Args:
-            fmt (ExportFormat): The format to export the results in. Defaults
-                to ExportFormat.JSON.
+            fmt (Union[ExportFormat, str]): The format to export the results
+                in. Defaults to ExportFormat.JSON.
             filename (Optional[str]): The name of the output file to save the
                 exported results. Defaults to the benchmark's name if not
                 provided.

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -185,11 +185,18 @@ class Benchmark(Project):
         metrics = []
         tasks = self.get_tasks()
         for task in tasks:
+            input_filename = "input.json"
+            input_dir_path = task.download_inputs(filenames=[input_filename])
+            input_file_path = input_dir_path.joinpath(input_filename)
+            with open(input_file_path, mode="r", encoding="utf-8") as file:
+                input_json = json.load(file)
+
             info = task.get_info()
             metrics.append({
                 "task id": info.task_id,
                 "simulator": info.simulator,
                 "machine type": info.executer.vm_type,
+                **input_json,
                 "computation time": info.time_metrics.computation_seconds.value,
                 "estimated computation cost": info.estimated_computation_cost,
             })

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -165,36 +165,33 @@ class Benchmark(Project):
                 file.write(json_content)
         elif fmt == ExportFormat.CSV:
             with open(filename, mode="w", encoding="utf-8") as file:
-                csv_content = [{
-                    "machine_type": machine_type,
-                    **task,
-                } for machine_type, tasks in metrics.items() for task in tasks]
-                fieldnames = csv_content[0].keys()
+                fieldnames = metrics[0].keys() if not metrics else []
                 writer = csv.DictWriter(file, fieldnames=fieldnames)
                 writer.writeheader()
-                writer.writerows(csv_content)
+                writer.writerows(metrics)
         else:
             raise ValueError(f"Unsupported export format: {fmt}")
 
-    def gather_metrics(self) -> dict:
+    def gather_metrics(self) -> list:
         """
-        Gathers performance metrics for all tasks associated with the
-        benchmark, which include computation cost and execution time.    
-    
+        Gathers the configuration and performance metrics for each run
+        associated with the benchmark in a list, including computation cost
+        and execution time.
+
         Returns:
-            dict: A dictionary organized by virtual machine type, containing
-                performance metrics for each task associated with the benchmark.
+            list: A list containing the configuration and performance 
+                metrics for each run.
         """
-        metrics = {}
+        metrics = []
         tasks = self.get_tasks()
         for task in tasks:
             info = task.get_info()
-            vm_type = info.executer.vm_type
-            metrics.setdefault(vm_type, [])
-            metrics[vm_type].append({
-                "task_id": info.task_id,
-                "estimated_computation_cost": info.estimated_computation_cost,
-                "computation_time": info.time_metrics.computation_seconds.value,
+            metrics.append({
+                "task id": info.task_id,
+                "simulator": info.simulator,
+                "machine type": info.executer.vm_type,
+                "computation time": info.time_metrics.computation_seconds.value,
+                "estimated computation cost": info.estimated_computation_cost,
             })
         return metrics
 

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -217,14 +217,14 @@ class Benchmark(Project):
         for task in tasks:
             task_input_params = get_task_input_params(task)
             task_info = task.get_info()
+            task_time = task_info.time_metrics.computation_seconds.value
+            task_cost = task_info.estimated_computation_cost
             info.append({
                 "task_id": task_info.task_id,
                 "simulator": task_info.simulator,
                 "machine_type": task_info.executer.vm_type,
-                "computation_time": \
-                    task_info.time_metrics.computation_seconds.value,
-                "estimated_computation_cost": \
-                    task_info.estimated_computation_cost,
+                "computation_time": task_time,
+                "estimated_computation_cost": task_cost,
                 **task_input_params,
             })
 

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -199,11 +199,12 @@ class Benchmark(Project):
                 return json.load(file)
 
         def get_distinct(metrics):
-            lists = defaultdict(list)
-            for config in metrics:
-                for param, value in config.items():
-                    lists[param].append(value)
-            return {param for param in lists if len(set(lists[param])) > 1}
+            attrs_lsts = defaultdict(list)
+            for attrs in metrics:
+                for k, v in attrs.items():
+                    attrs_lsts[k].append(v)
+            filtered = {k for k, v in attrs_lsts.items() if len(set(v)) > 1}
+            return [{key: attrs[key] for key in filtered} for attrs in metrics]
 
         metrics = []
         tasks = self.get_tasks()
@@ -218,10 +219,8 @@ class Benchmark(Project):
                 "estimated computation cost": info.estimated_computation_cost,
                 **input_params,
             })
- 
+
         if distinct:
-            distinct_params = get_distinct(metrics)
-            metrics = [{param: config[param] for param in distinct_params}
-                       for config in metrics]
+            metrics = get_distinct(metrics)
 
         return metrics

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -184,8 +184,8 @@ class Benchmark(Project):
         execution time.
 
         This method retrieves input parameters and task information for each
-        run, and optionally filters the results to include only the parameters
-        that vary between runs.
+        run, and optionally summarizes the results by filtering only the
+        parameters that vary between runs.
         
         Args:
             summary (bool): If True, only the parameters that vary between 

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -215,7 +215,7 @@ class Benchmark(Project):
         info = []
         tasks = self.get_tasks()
         for task in tasks:
-            input_params = get_task_input_params(task)
+            task_input_params = get_task_input_params(task)
             task_info = task.get_info()
             info.append({
                 "task_id": task_info.task_id,
@@ -225,7 +225,7 @@ class Benchmark(Project):
                     task_info.time_metrics.computation_seconds.value,
                 "estimated_computation_cost": \
                     task_info.estimated_computation_cost,
-                **input_params,
+                **task_input_params,
             })
 
         return summarize(info) if summary else info

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -212,12 +212,12 @@ class Benchmark(Project):
             input_params = get_task_input_params(task)
             task_info = task.get_info()
             info.append({
-                "task id": task_info.task_id,
+                "task_id": task_info.task_id,
                 "simulator": task_info.simulator,
-                "machine type": task_info.executer.vm_type,
-                "computation time (s)": \
+                "machine_type": task_info.executer.vm_type,
+                "computation_time": \
                     task_info.time_metrics.computation_seconds.value,
-                "estimated computation cost (US$)": \
+                "estimated_computation_cost": \
                     task_info.estimated_computation_cost,
                 **input_params,
             })

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -206,30 +206,3 @@ class Benchmark(Project):
                 **input_params,
             })
         return metrics
-
-    def gather_detailed_data(self) -> dict:
-        """
-        Gathers comprehensive information about all tasks associated with the 
-        benchmark, including additional performance metrics and task metadata.
-
-        Returns:
-            dict: A dictionary organized by virtual machine type, containing
-                detailed information about each task associated with the
-                benchmark.
-        """
-        data = {}
-        tasks = self.get_tasks()
-        for task in tasks:
-            info = task.get_info()
-            vm_type = info.executer.vm_type
-            data.setdefault(vm_type, [])
-            input_filename = "input.json"
-            input_dir_path = task.download_inputs(filenames=[input_filename])
-            input_file_path = input_dir_path.joinpath(input_filename)
-            with open(input_file_path, mode="r", encoding="utf-8") as file:
-                input_json = json.load(file)
-            data[vm_type].append({
-                "task_info": info.to_dict(),
-                "task_input_metadata": input_json,
-            })
-        return data

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -215,8 +215,10 @@ class Benchmark(Project):
                 "task id": info.task_id,
                 "simulator": info.simulator,
                 "machine type": info.executer.vm_type,
-                "computation time": info.time_metrics.computation_seconds.value,
-                "estimated computation cost": info.estimated_computation_cost,
+                "computation time (s)": \
+                    info.time_metrics.computation_seconds.value,
+                "estimated computation cost (US$)": \
+                    info.estimated_computation_cost,
                 **input_params,
             })
 

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -198,7 +198,7 @@ class Benchmark(Project):
             with open(input_file_path, mode="r", encoding="utf-8") as file:
                 return json.load(file)
 
-        def get_distinct(metrics):
+        def filter_distinct(metrics):
             attrs_lsts = defaultdict(list)
             for attrs in metrics:
                 for k, v in attrs.items():
@@ -221,6 +221,6 @@ class Benchmark(Project):
             })
 
         if distinct:
-            metrics = get_distinct(metrics)
+            metrics = filter_distinct(metrics)
 
         return metrics

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -216,7 +216,7 @@ class Benchmark(Project):
         tasks = self.get_tasks()
         for task in tasks:
             task_input_params = get_task_input_params(task)
-            task_info = task.get_info()
+            task_info = task.info
             task_time = task_info.time_metrics.computation_seconds.value
             task_cost = task_info.estimated_computation_cost
             info.append({

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -165,7 +165,7 @@ class Benchmark(Project):
                 file.write(json_content)
         elif fmt == ExportFormat.CSV:
             with open(filename, mode="w", encoding="utf-8") as file:
-                fieldnames = metrics[0].keys() if not metrics else []
+                fieldnames = metrics[0].keys() if metrics else []
                 writer = csv.DictWriter(file, fieldnames=fieldnames)
                 writer.writeheader()
                 writer.writerows(metrics)

--- a/inductiva/_benchmarks/benchmark.py
+++ b/inductiva/_benchmarks/benchmark.py
@@ -221,9 +221,9 @@ class Benchmark(Project):
                 "task_id": task_info.task_id,
                 "simulator": task_info.simulator,
                 "machine_type": task_info.executer.vm_type,
-                "computation_time":  \
+                "computation_time": \
                     task_info.time_metrics.computation_seconds.value,
-                "estimated_computation_cost":  \
+                "estimated_computation_cost": \
                     task_info.estimated_computation_cost,
                 **task_input_params,
             })


### PR DESCRIPTION
This PR refactors the methods used to gather information about runs by consolidating them into a single method called ```runs_info```. This new method collects configuration and performance metrics for each run associated with the benchmark in a table-like format, including computation costs and execution time. It can also optionally summarize the results by filtering parameters to show only the ones that vary between runs.

### Example of running a benchmark on ```c2-standard``` machines with an increasing number of **vCPU**s:

```python
from inductiva._benchmarks.benchmark import Benchmark
from inductiva.simulators import AmrWind
from inductiva.utils import download_from_url
from inductiva.resources import MachineGroup

input_dir = download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "amr-wind-input-example.zip",
    unzip=True)

Benchmark(name="Test-Benchmark-AmrWind-on-c2-standard-Machines") \
    .set_default(simulator=AmrWind(),
                 input_dir=input_dir,
                 sim_config_filename="abl_amd_wenoz.inp") \
    .add_run(on=MachineGroup("c2-standard-4"), n_vcpus=4) \
    .add_run(on=MachineGroup("c2-standard-8"), n_vcpus=8) \
    .run(num_repeats=2) \
    .add_run(on=MachineGroup("c2-standard-16"), n_vcpus=16) \
    .add_run(on=MachineGroup("c2-standard-30"), n_vcpus=30) \
    .run(num_repeats=4) \
    .wait()
```

#### 1) Example of exporting detailed benchmarking information (i.e., ```summary=False```):

```python
from inductiva._benchmarks.benchmark import Benchmark

Benchmark(name="Test-Benchmark-AmrWind-on-c2-standard-Machines") \
    .export(fmt="csv", filename="verbose.csv", summary=False)
```

Output (i.e., file "verbose.csv"):

```csv
| task_id                   | simulator | machine_type   | computation_time | estimated_computation_cost | sim_dir | container_image                         | n_vcpus | use_hwthread | input_filename    |
|---------------------------|-----------|----------------|------------------|----------------------------|---------|-----------------------------------------|---------|--------------|-------------------|
| 922orctqep7sujoab66h9g6hc | amrwind   | c2-standard-30 | 2.191            | 0.000501753086             | sim_dir | docker://inductiva/kutu:amr-wind_v1.4.0 | 30      | True         | abl_amd_wenoz.inp |
| ezgsgxrzafkb3ivwf5dd405fu | amrwind   | c2-standard-30 | 2.215            | 0.000501753086             | sim_dir | docker://inductiva/kutu:amr-wind_v1.4.0 | 30      | True         | abl_amd_wenoz.inp |
| n4f4o6zisxcmzne0ynvc4nkko | amrwind   | c2-standard-30 | 2.202            | 0.000501753086             | sim_dir | docker://inductiva/kutu:amr-wind_v1.4.0 | 30      | True         | abl_amd_wenoz.inp |
| g37e85mbqzozvg5u67n7epbij | amrwind   | c2-standard-30 | 2.182            | 0.000627191358             | sim_dir | docker://inductiva/kutu:amr-wind_v1.4.0 | 30      | True         | abl_amd_wenoz.inp |
| 6a9eu2wcosvbrm08ihztk2ggc | amrwind   | c2-standard-16 | 2.154            | 0.000269041975             | sim_dir | docker://inductiva/kutu:amr-wind_v1.4.0 | 16      | True         | abl_amd_wenoz.inp |
| bquxzovvxm32tfsfvwao7173c | amrwind   | c2-standard-16 | 2.152            | 0.000269041975             | sim_dir | docker://inductiva/kutu:amr-wind_v1.4.0 | 16      | True         | abl_amd_wenoz.inp |
| n1v35penxy41ft7nc84g8eoss | amrwind   | c2-standard-16 | 2.14             | 0.000269041975             | sim_dir | docker://inductiva/kutu:amr-wind_v1.4.0 | 16      | True         | abl_amd_wenoz.inp |
| tn4qc5u3qz5ni0n9tosi7fig5 | amrwind   | c2-standard-16 | 3.149            | 0.000403562963             | sim_dir | docker://inductiva/kutu:amr-wind_v1.4.0 | 16      | True         | abl_amd_wenoz.inp |
| ck17zy799oui57ndg50o8f920 | amrwind   | c2-standard-8  | 3.176            | 0.000170080247             | sim_dir | docker://inductiva/kutu:amr-wind_v1.4.0 | 8       | True         | abl_amd_wenoz.inp |
| ch81ietekadrwm44k8igcu5u2 | amrwind   | c2-standard-8  | 4.152            | 0.000204096296             | sim_dir | docker://inductiva/kutu:amr-wind_v1.4.0 | 8       | True         | abl_amd_wenoz.inp |
| ikbnwnz18r7swa3r9fpez0y4r | amrwind   | c2-standard-4  | 3.131            | 8.6969136e-05              | sim_dir | docker://inductiva/kutu:amr-wind_v1.4.0 | 4       | True         | abl_amd_wenoz.inp |
| cyni3g35b6askhmksnpiesahc | amrwind   | c2-standard-4  | 4.151            | 0.000104362963             | sim_dir | docker://inductiva/kutu:amr-wind_v1.4.0 | 4       | True         | abl_amd_wenoz.inp |
```


#### 2) Example of exporting summarized benchmarking information (i.e., ```summary=True```):

```python
from inductiva._benchmarks.benchmark import Benchmark

Benchmark(name="Test-Benchmark-AmrWind-on-c2-standard-Machines") \
    .export(fmt="csv", filename="summary.csv")
```

Output (i.e., file "summary.csv"):

```csv
| machine_type   | computation_time | estimated_computation_cost | task_id                   | n_vcpus |
|----------------|------------------|----------------------------|---------------------------|---------|
| c2-standard-30 | 2.191            | 0.000501753086             | 922orctqep7sujoab66h9g6hc | 30      |
| c2-standard-30 | 2.215            | 0.000501753086             | ezgsgxrzafkb3ivwf5dd405fu | 30      |
| c2-standard-30 | 2.202            | 0.000501753086             | n4f4o6zisxcmzne0ynvc4nkko | 30      |
| c2-standard-30 | 2.182            | 0.000627191358             | g37e85mbqzozvg5u67n7epbij | 30      |
| c2-standard-16 | 2.154            | 0.000269041975             | 6a9eu2wcosvbrm08ihztk2ggc | 16      |
| c2-standard-16 | 2.152            | 0.000269041975             | bquxzovvxm32tfsfvwao7173c | 16      |
| c2-standard-16 | 2.14             | 0.000269041975             | n1v35penxy41ft7nc84g8eoss | 16      |
| c2-standard-16 | 3.149            | 0.000403562963             | tn4qc5u3qz5ni0n9tosi7fig5 | 16      |
| c2-standard-8  | 3.176            | 0.000170080247             | ck17zy799oui57ndg50o8f920 | 8       |
| c2-standard-8  | 4.152            | 0.000204096296             | ch81ietekadrwm44k8igcu5u2 | 8       |
| c2-standard-4  | 3.131            | 8.6969136e-05              | ikbnwnz18r7swa3r9fpez0y4r | 4       |
| c2-standard-4  | 4.151            | 0.000104362963             | cyni3g35b6askhmksnpiesahc | 4       |
```