### PR TITLE
Add command to the swan simulator

### DIFF
--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -26,12 +26,13 @@ class SWAN(simulators.Simulator):
         input_dir: str,
         sim_config_filename: str,
         *,
+        remote_assets: Optional[List[str]] = None,
+        resubmit_on_preemption: bool = False,
         on: types.ComputationalResources,
+        storage_dir: Optional[str] = "",
         n_vcpus: Optional[int] = None,
         use_hwthread: bool = True,
-        storage_dir: Optional[str] = "",
-        resubmit_on_preemption: bool = False,
-        remote_assets: Optional[List[str]] = None,
+        command: str = "swanrun",
         **kwargs,
     ) -> tasks.Task:
         """Run the simulation.
@@ -50,7 +51,12 @@ class SWAN(simulators.Simulator):
                 previous execution attempts were preempted. Only applicable when
                 using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
+            command: The command to run the simulation. Default is 'swanrun'.
+                The user can also specify 'swan.exe'.
         """
+        if command != "swanrun" or command != "swan.exe":
+            raise ValueError("Invalid command. Use 'swanrun' or 'swan.exe'.")
+        
         return super().run(input_dir,
                            on=on,
                            input_filename=sim_config_filename,


### PR DESCRIPTION
https://github.com/inductiva/tasks/issues/492

This PR allows the user to run swanrun or swan.exe.

By default it will use swanrun.

`swanrun` needs the flag -input
`swan.exe` takes no flags but needs the input file to be called INPUT (that should be responsibility of the user).

I had to remove the mpiexecuter since i need to build the command.
