### PR TITLE
Fix empty input dir

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -62,17 +62,21 @@ def submit_request(api_instance: TasksApi,
 
 
 def prepare_input(task_id, original_params, type_annotations):
-    inputs_size = files.get_path_size(original_params["sim_dir"])
-    logging.info("Preparing upload of the local input directory %s (%s).",
-                 original_params["sim_dir"],
-                 format_utils.bytes_formatter(inputs_size))
+    sim_dir = original_params["sim_dir"]
+    # If the input directory is the current directory, dont zip it
+    # still need to zip the input parameters though
+    if os.path.normpath(sim_dir) == os.path.curdir:
+        inputs_size = 0
+    else:
+        inputs_size = files.get_path_size(sim_dir)
+        logging.info("Preparing upload of the local input directory %s (%s).",
+                     sim_dir, format_utils.bytes_formatter(inputs_size))
 
-    logging.info("Packing input directory...")
-
-    if os.path.isfile(
-            os.path.join(original_params["sim_dir"],
-                         constants.TASK_OUTPUT_ZIP)):
-        raise ValueError(f"Invalid file name: '{constants.TASK_OUTPUT_ZIP}'")
+        if os.path.isfile(
+                os.path.join(original_params["sim_dir"],
+                             constants.TASK_OUTPUT_ZIP)):
+            raise ValueError(
+                f"Invalid file name: '{constants.TASK_OUTPUT_ZIP}'")
 
     input_zip_path = pack_input(
         params=original_params,

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -65,16 +65,12 @@ def prepare_input(task_id, original_params, type_annotations):
     sim_dir = original_params["sim_dir"]
     # If the input directory is the current directory, dont zip it
     # still need to zip the input parameters though
-    if os.path.normpath(sim_dir) == os.path.curdir:
-        inputs_size = 0
-    else:
+    if sim_dir:
         inputs_size = files.get_path_size(sim_dir)
         logging.info("Preparing upload of the local input directory %s (%s).",
                      sim_dir, format_utils.bytes_formatter(inputs_size))
 
-        if os.path.isfile(
-                os.path.join(original_params["sim_dir"],
-                             constants.TASK_OUTPUT_ZIP)):
+        if os.path.isfile(os.path.join(sim_dir, constants.TASK_OUTPUT_ZIP)):
             raise ValueError(
                 f"Invalid file name: '{constants.TASK_OUTPUT_ZIP}'")
 

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -63,7 +63,7 @@ def submit_request(api_instance: TasksApi,
 
 def prepare_input(task_id, original_params, type_annotations):
     sim_dir = original_params["sim_dir"]
-    # If the input directory is the current directory, dont zip it
+    # If the input directory is empty, do not zip it
     # still need to zip the input parameters though
     if sim_dir:
         inputs_size = files.get_path_size(sim_dir)

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -28,7 +28,7 @@ class AmrWind(simulators.Simulator):
         return "AMR-Wind"
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             sim_config_filename: str,
             *,
             on: types.ComputationalResources,

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -24,7 +24,7 @@ class CaNS(simulators.Simulator):
         self.simulator = "cans"
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             sim_config_filename: str,
             *,
             on: types.ComputationalResources,

--- a/inductiva/simulators/custom_image.py
+++ b/inductiva/simulators/custom_image.py
@@ -24,7 +24,7 @@ class CustomImage(simulators.Simulator):
         return self.container_image
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             commands: List[str],
             *,
             on: types.ComputationalResources,

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -23,7 +23,7 @@ class DualSPHysics(simulators.Simulator):
 
     def run(
         self,
-        input_dir: str,
+        input_dir: Optional[str],
         commands: types.Commands,
         *,
         on: types.ComputationalResources,

--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -22,7 +22,7 @@ class FDS(simulators.Simulator):
         self.simulator = "fds"
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             sim_config_filename: str,
             *,
             on: types.ComputationalResources,

--- a/inductiva/simulators/fenicsx.py
+++ b/inductiva/simulators/fenicsx.py
@@ -25,7 +25,7 @@ class FEniCSx(simulators.Simulator):
         return None
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             geometry_filename: str,
             bcs_filename: str,
             material_filename: str,

--- a/inductiva/simulators/fvcom.py
+++ b/inductiva/simulators/fvcom.py
@@ -24,7 +24,7 @@ class FVCOM(simulators.Simulator):
         self.simulator = "fvcom"
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             *,
             on: types.ComputationalResources,
             debug: int = 0,

--- a/inductiva/simulators/gromacs.py
+++ b/inductiva/simulators/gromacs.py
@@ -23,7 +23,7 @@ class GROMACS(simulators.Simulator):
 
     def run(
         self,
-        input_dir: str,
+        input_dir: Optional[str],
         commands: types.Commands,
         *,
         on: types.ComputationalResources,

--- a/inductiva/simulators/nwchem.py
+++ b/inductiva/simulators/nwchem.py
@@ -23,7 +23,7 @@ class NWChem(simulators.Simulator):
         self.simulator = "nwchem"
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             sim_config_filename: str,
             *,
             on: types.ComputationalResources,

--- a/inductiva/simulators/openfast.py
+++ b/inductiva/simulators/openfast.py
@@ -23,7 +23,7 @@ class OpenFAST(simulators.Simulator):
         self.simulator = "openfast"
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             commands: types.Commands,
             *,
             on: types.ComputationalResources,

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -48,7 +48,7 @@ class OpenFOAM(simulators.Simulator):
         return "OpenFOAM-" + self._distribution
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             commands: types.Commands,
             *,
             on: types.ComputationalResources,

--- a/inductiva/simulators/quantum_espresso.py
+++ b/inductiva/simulators/quantum_espresso.py
@@ -27,7 +27,7 @@ class QuantumEspresso(simulators.Simulator):
         return "Quantum-Espresso"
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             commands: List[str],
             *,
             use_hwthread: bool = True,

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -23,7 +23,7 @@ class REEF3D(simulators.Simulator):
         self.simulator = "reef3d"
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             *,
             on: Optional[types.ComputationalResources],
             n_vcpus: Optional[int] = None,

--- a/inductiva/simulators/schism.py
+++ b/inductiva/simulators/schism.py
@@ -22,7 +22,7 @@ class SCHISM(simulators.Simulator):
         self.simulator = "schism"
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             *,
             on: types.ComputationalResources,
             num_scribes: int = 1,

--- a/inductiva/simulators/simsopt.py
+++ b/inductiva/simulators/simsopt.py
@@ -25,7 +25,7 @@ class SIMSOPT(simulators.Simulator):
 
     def run(
         self,
-        input_dir: str,
+        input_dir: Optional[str],
         plasma_surface_filename: str,
         coil_coefficients_filename: str,
         coil_currents_filename: str,

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -104,9 +104,18 @@ class Simulator(ABC):
                 f"The provided path (\"{input_dir}\") is not a directory.")
         return input_dir_path
 
+    def _validate_input_files(self, input_dir, remote_assets):
+        if input_dir == "":
+            raise ValueError(
+                "input_dir cannot be an empty string. Use None instead.")
+
+        if not input_dir and not remote_assets:
+            raise ValueError(
+                "Either input_dir or remote_assets must be provided.")
+
     def run(
         self,
-        input_dir: str,
+        input_dir: Optional[str],
         *_args,
         on: types.ComputationalResources,
         storage_dir: Optional[str] = "",
@@ -133,7 +142,9 @@ class Simulator(ABC):
             **kwargs: Additional keyword arguments to be passed to the
                 simulation API method.
         """
-        input_dir_path = self._setup_input_dir(input_dir)
+        self._validate_input_files(input_dir, remote_assets)
+
+        input_dir_path = self._setup_input_dir(input_dir) if input_dir else None
 
         if on is None:
             raise ValueError(

--- a/inductiva/simulators/splishsplash.py
+++ b/inductiva/simulators/splishsplash.py
@@ -22,7 +22,7 @@ class SplishSplash(simulators.Simulator):
 
     def run(
         self,
-        input_dir: str,
+        input_dir: Optional[str],
         sim_config_filename: str,
         *,
         on: types.ComputationalResources,

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -23,7 +23,7 @@ class SWAN(simulators.Simulator):
 
     def run(
         self,
-        input_dir: str,
+        input_dir: Optional[str],
         sim_config_filename: str,
         *,
         on: types.ComputationalResources,

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -22,7 +22,7 @@ class SWASH(simulators.Simulator):
         self.simulator = "swash"
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             sim_config_filename: str,
             *,
             on: types.ComputationalResources,

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -22,7 +22,7 @@ class XBeach(simulators.Simulator):
         self.simulator = "xbeach"
 
     def run(self,
-            input_dir: str,
+            input_dir: Optional[str],
             *,
             on: types.ComputationalResources,
             n_vcpus: Optional[int] = None,

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -10,7 +10,7 @@ from inductiva.api import methods
 
 def run_simulation(
     simulator: str,
-    input_dir: pathlib.Path,
+    input_dir: Optional[pathlib.Path],
     *,
     computational_resources: types.ComputationalResources,
     resubmit_on_preemption: bool = False,

--- a/inductiva/utils/data.py
+++ b/inductiva/utils/data.py
@@ -75,7 +75,7 @@ def pack_param(name: str, value, param_type, dst_dir):
         dst_dir_name = name
         dst_fullpath = os.path.join(dst_dir, dst_dir_name)
 
-        if os.path.normpath(value) != os.path.curdir:
+        if value:
             shutil.copytree(value, dst_fullpath)
 
         logging.debug("Copied %s to %s", value, dst_fullpath)
@@ -396,12 +396,3 @@ def uncompress_task_outputs(zip_path: pathlib.Path, output_dir: pathlib.Path):
             )
         else:
             zip_f.extractall(output_dir)
-
-
-def create_empty_zip(zip_name):
-    """Create an empty ZIP archive."""
-    zip_path = os.path.join(tempfile.gettempdir(), zip_name)
-    with zipfile.ZipFile(zip_path, "w") as _:
-        pass
-
-    return zip_path

--- a/inductiva/utils/data.py
+++ b/inductiva/utils/data.py
@@ -75,7 +75,8 @@ def pack_param(name: str, value, param_type, dst_dir):
         dst_dir_name = name
         dst_fullpath = os.path.join(dst_dir, dst_dir_name)
 
-        shutil.copytree(value, dst_fullpath)
+        if os.path.normpath(value) != os.path.curdir:
+            shutil.copytree(value, dst_fullpath)
 
         logging.debug("Copied %s to %s", value, dst_fullpath)
         return str(dst_dir_name)
@@ -395,3 +396,12 @@ def uncompress_task_outputs(zip_path: pathlib.Path, output_dir: pathlib.Path):
             )
         else:
             zip_f.extractall(output_dir)
+
+
+def create_empty_zip(zip_name):
+    """Create an empty ZIP archive."""
+    zip_path = os.path.join(tempfile.gettempdir(), zip_name)
+    with zipfile.ZipFile(zip_path, "w") as _:
+        pass
+
+    return zip_path


### PR DESCRIPTION
closes https://github.com/inductiva/tasks/issues/504.

how to test:
```python
import inductiva

input_dir = inductiva.utils.files.download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "gromacs-input-example.zip", True)

inductiva.storage.upload(
    local_path=input_dir,
    remote_dir="gromacs-test",
)
machine_group = inductiva.resources.MachineGroup("c2-standard-4")
machine_group.start()

commands = [
    "gmx solvate -cs tip4p -box 2.3 -o conf.gro -p topol.top",
    ("gmx grompp -f energy_minimization.mdp -o min.tpr -pp min.top "
     "-po min.mdp -c conf.gro -p topol.top"),
    "gmx mdrun -s min.tpr -o min.trr -c min.gro -e min.edr -g min.log",
    ("gmx grompp -f positions_decorrelation.mdp -o decorr.tpr "
     "-pp decorr.top -po decorr.mdp -c min.gro"),
    ("gmx mdrun -s decorr.tpr -o decorr.trr -x  -c decorr.gro "
     "-e decorr.edr -g decorr.log"),
    ("gmx grompp -f simulation.mdp -o eql.tpr -pp eql.top "
     "-po eql.mdp -c decorr.gro"),
    ("gmx mdrun -s eql.tpr -o eql.trr -x trajectory.xtc -c eql.gro "
     "-e eql.edr -g eql.log")
]

gromacs = inductiva.simulators.GROMACS()

task = gromacs.run(input_dir="",
                   commands=commands,
                   on=machine_group,
                   remote_assets=["gromacs-test"])

task.wait()

task.download_outputs()
```