### PR TITLE
Refactor ```summary``` flag to use ```ColumnExportMode``` enum

### DIFF
--- a/inductiva/benchmarks/__init__.py
+++ b/inductiva/benchmarks/__init__.py
@@ -1,2 +1,2 @@
 #pylint: disable=missing-module-docstring
-from .benchmark import Benchmark
+from .benchmark import Benchmark, ExportFormat, ColumnExportMode

--- a/inductiva/tests/benchmarks/test_benchmark.py
+++ b/inductiva/tests/benchmarks/test_benchmark.py
@@ -148,7 +148,7 @@ def test_benchmark_runs_info(benchmark):
 
     with mock.patch("builtins.open",
                     mock.mock_open(read_data='{"param": "value"}')):
-        info = Benchmark.runs_info(self=benchmark, summary=False)
+        info = Benchmark.runs_info(self=benchmark, columns="all")
         assert info == [
             {
                 "task_id": "task1",
@@ -192,7 +192,7 @@ def test_benchmark_runs_info_summary(benchmark):
 
     with mock.patch("builtins.open",
                     mock.mock_open(read_data='{"param": "value"}')):
-        info = Benchmark.runs_info(self=benchmark, summary=True)
+        info = Benchmark.runs_info(self=benchmark, columns="distinct")
         assert info == [
             {
                 "task_id": "task1",


### PR DESCRIPTION
This PR refactors the ```summary``` flag by replacing it with the ```ColumnExportMode``` enum, providing a clearer and more structured way to specify which benchmark columns to export.

- Example 1:

```python
Benchmark(name="test").export(columns=ColumnExportMode.DISTINCT)
```

or

```python
Benchmark(name="test").export(columns="distinct")
```

- Example 2:

```python
Benchmark(name="test").export(columns=ColumnExportMode.ALL)
```

or

```python
Benchmark(name="test").export(columns="all")
```

Closes inductiva/tasks#508