### PR TITLE
Fix program crash when exporting task info in non-terminal states

### DIFF
--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -218,12 +218,14 @@ class Benchmark(Project):
         for task in tasks:
             task_input_params = get_task_input_params(task)
             task_info = task.info
+            task_machine_type = task_info.executer.vm_type \
+                if task_info.executer else None
             task_time = task_info.time_metrics.computation_seconds.value
             task_cost = task_info.estimated_computation_cost
             info.append({
                 "task_id": task_info.task_id,
                 "simulator": task_info.simulator,
-                "machine_type": task_info.executer.vm_type,
+                "machine_type": task_machine_type,
                 "computation_time": task_time,
                 "estimated_computation_cost": task_cost,
                 **task_input_params,


### PR DESCRIPTION
This PR prevents the program from crashing when exporting task information in non-terminal states by adding an additional check for ```None```.

- Example (i.e., call ```export``` without calling ```wait``` previously):

```python
from inductiva.benchmarks import Benchmark
from inductiva.simulators import AmrWind
from inductiva.resources import MachineGroup
from inductiva.utils import download_from_url

input_dir = download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "amr-wind-input-example.zip",
    unzip=True)

Benchmark(name="test-simple-benchmark") \
    .set_default(simulator=AmrWind(),
                 input_dir=input_dir,
                 sim_config_filename="abl_amd_wenoz.inp") \
    .add_run(on=MachineGroup("c2-standard-4"), n_vcpus=4) \
    .run(num_repeats=1) \
    .export(fmt="csv")
```

Closes inductiva/tasks#517