### PR TITLE
Fix bug in benchmarking GROMACS on local machine

### DIFF
--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -210,7 +210,8 @@ class Benchmark(Project):
             for attrs in info:
                 for k, v in attrs.items():
                     attrs_lsts[k].append(v)
-            filtered = {k for k, v in attrs_lsts.items() if len(set(v)) > 1}
+            filtered = {k for k, v in attrs_lsts.items() \
+                        if len(v) != 0 and len(v) != v.count(v[0])}
             return [{key: attrs[key] for key in filtered} for attrs in info]
 
         info = []

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -208,11 +208,11 @@ class Benchmark(Project):
         def summarize(info):
             attrs_lsts = defaultdict(list)
             for attrs in info:
-                for k, v in attrs.items():
-                    attrs_lsts[k].append(v)
-            filtered = {k for k, v in attrs_lsts.items() \
-                        if len(v) != 0 and len(v) != v.count(v[0])}
-            return [{key: attrs[key] for key in filtered} for attrs in info]
+                for attr, value in attrs.items():
+                    attrs_lsts[attr].append(value)
+            filtered = {attr for attr, values in attrs_lsts.items() \
+                        if values and len(values) != values.count(values[0])}
+            return [{attr: attrs[attr] for attr in filtered} for attrs in info]
 
         info = []
         tasks = self.get_tasks()


### PR DESCRIPTION
This PR fixes a bug identified during the bug bash when running benchmarks on local machines.

Closes inductiva/tasks#404.

**QA**: Benchmarking GROMACS on Oxygen vs. C2-Standard-16 (GCP).

```python
from inductiva.benchmarks import Benchmark
from inductiva.resources import machine_groups, MachineGroup
from inductiva.simulators import GROMACS
from inductiva.utils import download_from_url

input_dir = download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "gromacs-input-example.zip", True)

commands = [
    "gmx solvate -cs tip4p -box 2.3 -o conf.gro -p topol.top",
    ("gmx grompp -f energy_minimization.mdp -o min.tpr -pp min.top "
     "-po min.mdp -c conf.gro -p topol.top"),
    "gmx mdrun -s min.tpr -o min.trr -c min.gro -e min.edr -g min.log",
    ("gmx grompp -f positions_decorrelation.mdp -o decorr.tpr "
     "-pp decorr.top -po decorr.mdp -c min.gro"),
    ("gmx mdrun -s decorr.tpr -o decorr.trr -x  -c decorr.gro "
     "-e decorr.edr -g decorr.log"),
    ("gmx grompp -f simulation.mdp -o eql.tpr -pp eql.top "
     "-po eql.mdp -c decorr.gro"),
    ("gmx mdrun -s eql.tpr -o eql.trr -x trajectory.xtc -c eql.gro "
     "-e eql.edr -g eql.log")
]

Benchmark(name="benchmark-gromacs-on-oxygen") \
    .set_default(simulator=GROMACS(),
                 input_dir=input_dir,
                 commands=commands) \
    .add_run(on=machine_groups.get_by_name("my-oxygen")) \
    .add_run(on=MachineGroup("c2-standard-16"), n_vcpus=16) \
    .run(num_repeats=2)
```

To export the benchmarking results, run:

```python
from inductiva.benchmarks import Benchmark

Benchmark(name="benchmark-gromacs-on-oxygen").wait().export(fmt="csv")
```