### PR TITLE
Fix ```set_default``` method to merge ```kwargs``` instead of replacing them

### DIFF
--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -73,7 +73,7 @@ class Benchmark(Project):
         self.simulator = simulator or self.simulator
         self.input_dir = input_dir or self.input_dir
         self.on = on or self.on
-        self.kwargs = kwargs or self.kwargs
+        self.kwargs = {**self.kwargs, **kwargs}
         return self
 
     def add_run(

--- a/inductiva/tests/benchmarks/test_benchmark.py
+++ b/inductiva/tests/benchmarks/test_benchmark.py
@@ -48,6 +48,7 @@ def test_benchmark_set_default_kwargs(benchmark):
     Benchmark.set_default(self=benchmark, c=4)
     assert benchmark.kwargs == {"a": 1, "b": 2, "c": 4}
 
+
 def test_benchmark_multiple_set_default(benchmark):
     Benchmark.set_default(self=benchmark, simulator="sim", a=1)
     Benchmark.set_default(self=benchmark, a=1, b=2)

--- a/inductiva/tests/benchmarks/test_benchmark.py
+++ b/inductiva/tests/benchmarks/test_benchmark.py
@@ -45,7 +45,8 @@ def test_benchmark_set_default_kwargs(benchmark):
     assert benchmark.kwargs == {"a": 1, "b": 2}
     Benchmark.set_default(self=benchmark, c=3)
     assert benchmark.kwargs == {"a": 1, "b": 2, "c": 3}
-
+    Benchmark.set_default(self=benchmark, c=4)
+    assert benchmark.kwargs == {"a": 1, "b": 2, "c": 4}
 
 def test_benchmark_multiple_set_default(benchmark):
     Benchmark.set_default(self=benchmark, simulator="sim", a=1)

--- a/inductiva/tests/benchmarks/test_benchmark.py
+++ b/inductiva/tests/benchmarks/test_benchmark.py
@@ -40,6 +40,13 @@ def test_benchmark_partial_set_default(benchmark):
     assert benchmark.kwargs == {}
 
 
+def test_benchmark_set_default_kwargs(benchmark):
+    Benchmark.set_default(self=benchmark, a=1, b=2)
+    assert benchmark.kwargs == {"a": 1, "b": 2}
+    Benchmark.set_default(self=benchmark, c=3)
+    assert benchmark.kwargs == {"a": 1, "b": 2, "c": 3}
+
+
 def test_benchmark_multiple_set_default(benchmark):
     Benchmark.set_default(self=benchmark, simulator="sim", a=1)
     Benchmark.set_default(self=benchmark, a=1, b=2)


### PR DESCRIPTION
Fixes an issue in the ```set_default``` method related to how the ```kwargs``` attribute is updated. Previously, the ```kwargs``` attribute was being completely replaced when updated, leading to the loss of existing values. This change ensures that ```kwargs``` is properly merged or overridden rather than replaced entirely.