### PR TITLE
Add units to benchmark info keys

### DIFF
--- a/inductiva/benchmarks/__init__.py
+++ b/inductiva/benchmarks/__init__.py
@@ -1,2 +1,2 @@
 #pylint: disable=missing-module-docstring
-from .benchmark import Benchmark, ExportFormat, ColumnExportMode
+from .benchmark import Benchmark, ExportFormat, SelectMode

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -31,6 +31,14 @@ class SelectMode(enum.Enum):
 class Benchmark(Project):
     """Represents the benchmark runner."""
 
+    class InfoKey:
+        """Constant keys for the info used in the benchmark runs."""
+        TASK_ID = "task_id"
+        SIMULATOR = "simulator"
+        MACHINE_TYPE = "machine_type"
+        TIME = "computation_time"
+        COST = "estimated_computation_cost"
+
     def __init__(self, name: str, append: bool = True):
         """
         Initializes a new Benchmark instance.
@@ -238,11 +246,11 @@ class Benchmark(Project):
             task_time = task_info.time_metrics.computation_seconds.value
             task_cost = task_info.estimated_computation_cost
             info.append({
-                "task_id": task_info.task_id,
-                "simulator": task_info.simulator,
-                "machine_type": task_machine_type,
-                "computation_time": task_time,
-                "estimated_computation_cost": task_cost,
+                Benchmark.InfoKey.TASK_ID: task_info.task_id,
+                Benchmark.InfoKey.SIMULATOR: task_info.simulator,
+                Benchmark.InfoKey.MACHINE_TYPE: task_machine_type,
+                Benchmark.InfoKey.TIME: task_time,
+                Benchmark.InfoKey.COST: task_cost,
                 **task_input_params,
             })
 

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -10,6 +10,7 @@ from inductiva.simulators import Simulator
 from inductiva.projects import Project
 from inductiva.client import ApiException
 from inductiva.resources.machine_types import ProviderType
+from inductiva.utils.format_utils import CURRENCY_SYMBOL, TIME_UNIT
 from collections import defaultdict
 
 
@@ -36,8 +37,8 @@ class Benchmark(Project):
         TASK_ID = "task_id"
         SIMULATOR = "simulator"
         MACHINE_TYPE = "machine_type"
-        TIME = "computation_time"
-        COST = "estimated_computation_cost"
+        TIME = f"computation_time ({TIME_UNIT})"
+        COST = f"estimated_computation_cost ({CURRENCY_SYMBOL})"
 
     def __init__(self, name: str, append: bool = True):
         """

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -19,8 +19,11 @@ class ExportFormat(enum.Enum):
     CSV = "csv"
 
 
-class ColumnExportMode(enum.Enum):
-    """Enumeration of benchmark column export modes."""
+class SelectMode(enum.Enum):
+    """
+    Enumeration of supported data selection modes, specifying which data 
+    should be included in the benchmarking results.
+    """
     ALL = "all"
     DISTINCT = "distinct"
 
@@ -155,7 +158,7 @@ class Benchmark(Project):
         self,
         fmt: Union[ExportFormat, str] = ExportFormat.JSON,
         filename: Optional[str] = None,
-        columns: Union[ColumnExportMode, str] = ColumnExportMode.DISTINCT,
+        select: Union[SelectMode, str] = SelectMode.DISTINCT,
     ):
         """
         Exports the benchmark performance metrics in the specified format.
@@ -166,13 +169,13 @@ class Benchmark(Project):
             filename (Optional[str]): The name of the output file to save the
                 exported results. Defaults to the benchmark's name if not
                 provided.
-            columns (Union[ColumnExportMode, str]): The columns to include in
-                the exported results. Defaults to ColumnExportMode.DISTINCT that
+            select (Union[SelectMode, str]): The data to include in
+                the benchmarking results. Defaults to SelectMode.DISTINCT that
                 includes only the parameters that vary between different runs.
         """
         if isinstance(fmt, str):
             fmt = ExportFormat[fmt.upper()]
-        info = self.runs_info(columns=columns)
+        info = self.runs_info(select=select)
         filename = filename or f"{self.name}.{fmt.value}"
         if fmt == ExportFormat.JSON:
             with open(filename, mode="w", encoding="utf-8") as file:
@@ -189,7 +192,7 @@ class Benchmark(Project):
 
     def runs_info(
         self,
-        columns: Union[ColumnExportMode, str] = ColumnExportMode.DISTINCT,
+        select: Union[SelectMode, str] = SelectMode.DISTINCT,
     ) -> list:
         """
         Gathers the configuration and performance metrics for each run
@@ -197,8 +200,8 @@ class Benchmark(Project):
         execution time.
         
         Args:
-            columns (Union[ColumnExportMode, str]): The columns to include in
-                the exported results. Defaults to ColumnExportMode.DISTINCT that
+            select (Union[SelectMode, str]): The data to include in
+                the benchmarking results. Defaults to SelectMode.DISTINCT that
                 includes only the parameters that vary between different runs.
 
         Returns:
@@ -213,7 +216,7 @@ class Benchmark(Project):
             with open(input_file_path, mode="r", encoding="utf-8") as file:
                 return json.load(file)
 
-        def filter_distinct_columns(info):
+        def select_distinct(info):
             attrs_lsts = defaultdict(list)
             for attrs in info:
                 for attr, value in attrs.items():
@@ -222,8 +225,8 @@ class Benchmark(Project):
                         if values and len(values) != values.count(values[0])}
             return [{attr: attrs[attr] for attr in filtered} for attrs in info]
 
-        if isinstance(columns, str):
-            columns = ColumnExportMode[columns.upper()]
+        if isinstance(select, str):
+            select = SelectMode[select.upper()]
 
         info = []
         tasks = self.get_tasks()
@@ -243,8 +246,8 @@ class Benchmark(Project):
                 **task_input_params,
             })
 
-        return filter_distinct_columns(info) \
-            if columns == ColumnExportMode.DISTINCT \
+        return select_distinct(info) \
+            if select == SelectMode.DISTINCT \
             else info
 
     def terminate(self) -> Self:

--- a/inductiva/tests/benchmarks/test_benchmark.py
+++ b/inductiva/tests/benchmarks/test_benchmark.py
@@ -158,7 +158,7 @@ def test_benchmark_runs_info(benchmark):
 
     with mock.patch("builtins.open",
                     mock.mock_open(read_data='{"param": "value"}')):
-        info = Benchmark.runs_info(self=benchmark, columns="all")
+        info = Benchmark.runs_info(self=benchmark, select="all")
         assert info == [
             {
                 "task_id": "task1",
@@ -202,7 +202,7 @@ def test_benchmark_runs_info_summary(benchmark):
 
     with mock.patch("builtins.open",
                     mock.mock_open(read_data='{"param": "value"}')):
-        info = Benchmark.runs_info(self=benchmark, columns="distinct")
+        info = Benchmark.runs_info(self=benchmark, select="distinct")
         assert info == [
             {
                 "task_id": "task1",

--- a/inductiva/tests/benchmarks/test_benchmark.py
+++ b/inductiva/tests/benchmarks/test_benchmark.py
@@ -161,19 +161,19 @@ def test_benchmark_runs_info(benchmark):
         info = Benchmark.runs_info(self=benchmark, select="all")
         assert info == [
             {
-                "task_id": "task1",
-                "simulator": "sim1",
-                "machine_type": "vm1",
-                "computation_time": 100,
-                "estimated_computation_cost": 10,
+                Benchmark.InfoKey.TASK_ID: "task1",
+                Benchmark.InfoKey.SIMULATOR: "sim1",
+                Benchmark.InfoKey.MACHINE_TYPE: "vm1",
+                Benchmark.InfoKey.TIME: 100,
+                Benchmark.InfoKey.COST: 10,
                 "param": "value",
             },
             {
-                "task_id": "task2",
-                "simulator": "sim2",
-                "machine_type": "vm2",
-                "computation_time": 200,
-                "estimated_computation_cost": 20,
+                Benchmark.InfoKey.TASK_ID: "task2",
+                Benchmark.InfoKey.SIMULATOR: "sim2",
+                Benchmark.InfoKey.MACHINE_TYPE: "vm2",
+                Benchmark.InfoKey.TIME: 200,
+                Benchmark.InfoKey.COST: 20,
                 "param": "value",
             },
         ]
@@ -205,16 +205,16 @@ def test_benchmark_runs_info_summary(benchmark):
         info = Benchmark.runs_info(self=benchmark, select="distinct")
         assert info == [
             {
-                "task_id": "task1",
-                "machine_type": "vm1",
-                "computation_time": 100,
-                "estimated_computation_cost": 10,
+                Benchmark.InfoKey.TASK_ID: "task1",
+                Benchmark.InfoKey.MACHINE_TYPE: "vm1",
+                Benchmark.InfoKey.TIME: 100,
+                Benchmark.InfoKey.COST: 10,
             },
             {
-                "task_id": "task2",
-                "machine_type": "vm2",
-                "computation_time": 200,
-                "estimated_computation_cost": 20,
+                Benchmark.InfoKey.TASK_ID: "task2",
+                Benchmark.InfoKey.MACHINE_TYPE: "vm2",
+                Benchmark.InfoKey.TIME: 200,
+                Benchmark.InfoKey.COST: 20,
             },
         ]
 

--- a/inductiva/utils/format_utils.py
+++ b/inductiva/utils/format_utils.py
@@ -24,6 +24,9 @@ tabulate._table_formats["inductiva"] = TableFormat(
     with_header_hide=None,
 )
 
+CURRENCY_SYMBOL = "US$"
+TIME_UNIT = "s"
+
 
 class Emphasis(Enum):
     RED = "\033[31m"
@@ -282,10 +285,8 @@ def currency_formatter(amount: float) -> str:
     the BE. For now, we are using USD.
     """
 
-    currency_data = "US$"
-
     if amount == 0:
-        return f"0 {currency_data}"
+        return f"0 {CURRENCY_SYMBOL}"
 
     # Convert the value to a string with a maximum of 10 decimal places
     amount_str = f"{amount:.15f}"
@@ -301,6 +302,6 @@ def currency_formatter(amount: float) -> str:
     if amount < 0.1:
         # If the amount is less than 0.1, show all decimal places until the
         # first two non-zero decimal values (e.g., 0.00012345 -> 0.00012)
-        return f"{amount:.{decimal_places}f} {currency_data}"
+        return f"{amount:.{decimal_places}f} {CURRENCY_SYMBOL}"
 
-    return f"{amount:.2f} {currency_data}"
+    return f"{amount:.2f} {CURRENCY_SYMBOL}"


### PR DESCRIPTION
This PR adds units for currency and time to the benchmark information keys.

Example of the exported benchmarking data:

```
|task_id                  |computation_time (s)|estimated_computation_cost (US$)|
|-------------------------|--------------------|--------------------------------|
|j7gg0i95a6vmfha15en7wepz4|3.133               |0.000104330247                  |
|jnynsr3addwc12fx3h4uc0it7|4.132               |0.000146062346                  |
```

This PR also refactors the ```ColumnExportMode``` enum into the ```SelectMode``` enum. The new name is more intuitive and better reflects its broader applicability to both JSON and CSV formats.
