### PR TITLE
Add ```wait_for_quotas``` parameter to ```Benchmark.run```

### DIFF
--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -143,7 +143,7 @@ class Benchmark(Project):
         """
         with self:
             for simulator, input_dir, machine_group, kwargs in self.runs:
-                machine_group.start(wait_on_pending_quota=False)
+                machine_group.start(wait_for_quotas=False)
                 for _ in range(num_repeats):
                     simulator.run(input_dir=input_dir,
                                   on=machine_group,

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -127,7 +127,7 @@ class Benchmark(Project):
         ))
         return self
 
-    def run(self, num_repeats: int = 2) -> Self:
+    def run(self, num_repeats: int = 2, wait_for_quotas: bool = False) -> Self:
         """
         Executes all added runs.
 
@@ -136,14 +136,17 @@ class Benchmark(Project):
 
         Args:
             num_repeats (int): The number of times to repeat each simulation
-            run (default is 2).
+                run (default is 2).
+            wait_for_quotas (bool): Indicates whether to wait for the quotas to
+                be available before starting each resource (default is
+                False).
 
         Returns:
             Self: The current instance for method chaining.
         """
         with self:
             for simulator, input_dir, machine_group, kwargs in self.runs:
-                machine_group.start(wait_for_quotas=False)
+                machine_group.start(wait_for_quotas=wait_for_quotas)
                 for _ in range(num_repeats):
                     simulator.run(input_dir=input_dir,
                                   on=machine_group,

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -137,9 +137,11 @@ class Benchmark(Project):
         Args:
             num_repeats (int): The number of times to repeat each simulation
                 run (default is 2).
-            wait_for_quotas (bool): Indicates whether to wait for the quotas to
-                be available before starting each resource (default is
-                False).
+            wait_for_quotas (bool): Indicates whether to wait for quotas to 
+                become available before starting each resource. If `True`, the 
+                program will actively wait in a loop, periodically sleeping and 
+                checking for quotas. If `False`, the program crashes if quotas 
+                are not available (default is `False`).
 
         Returns:
             Self: The current instance for method chaining.

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -146,7 +146,8 @@ class Benchmark(Project):
         """
         with self:
             for simulator, input_dir, machine_group, kwargs in self.runs:
-                machine_group.start(wait_for_quotas=wait_for_quotas)
+                if not machine_group.started():
+                    machine_group.start(wait_for_quotas=wait_for_quotas)
                 for _ in range(num_repeats):
                     simulator.run(input_dir=input_dir,
                                   on=machine_group,

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -148,7 +148,7 @@ class Benchmark(Project):
         """
         with self:
             for simulator, input_dir, machine_group, kwargs in self.runs:
-                if not machine_group.started():
+                if not machine_group.started:
                     machine_group.start(wait_for_quotas=wait_for_quotas)
                 for _ in range(num_repeats):
                     simulator.run(input_dir=input_dir,

--- a/inductiva/resources/machine_cluster.py
+++ b/inductiva/resources/machine_cluster.py
@@ -101,14 +101,14 @@ class MPICluster(machines_base.BaseMachineGroup):
         return f"MPI Cluster {self.name} with {self.machine_type} " \
                f"x{self.num_machines} machines"
 
-    def start(self, wait_on_pending_quota: bool = False):
+    def start(self, wait_for_quotas: bool = False):
         """Start the MPI Cluster.
         Args:
-            wait_on_pending_quota: If True, the method will wait for quotas to
+            wait_for_quotas: If True, the method will wait for quotas to
               become available before starting the resource.
         """
         return super().start(
-            wait_on_pending_quota=wait_on_pending_quota,
+            wait_for_quotas=wait_for_quotas,
             is_elastic=self.__is_elastic,
             num_vms=self.num_machines,
             spot=self.__spot,

--- a/inductiva/resources/machines.py
+++ b/inductiva/resources/machines.py
@@ -119,16 +119,16 @@ class MachineGroup(machines_base.BaseMachineGroup):
     def __str__(self):
         return f"Machine Group {self.name} with {self.machine_type} machines"
 
-    def start(self, wait_on_pending_quota: bool = False):
+    def start(self, wait_for_quotas: bool = False):
         """Start the machine group.
         
         Args:
-            wait_on_pending_quota: If True, the method will wait for quotas to
+            wait_for_quotas: If True, the method will wait for quotas to
               become available before starting the resource.
         """
 
         return super().start(
-            wait_on_pending_quota=wait_on_pending_quota,
+            wait_for_quotas=wait_for_quotas,
             is_elastic=self.__is_elastic,
             num_vms=self.num_machines,
             spot=self.spot,
@@ -285,16 +285,16 @@ class ElasticMachineGroup(machines_base.BaseMachineGroup):
         return f"Elastic Machine Group {self.name} with {self.machine_type} " \
              "machines"
 
-    def start(self, wait_on_pending_quota: bool = False):
+    def start(self, wait_for_quotas: bool = False):
         """Start the elastic machine group.
 
         Args:
-            wait_on_pending_quota: If True, the method will wait for quotas to
+            wait_for_quotas: If True, the method will wait for quotas to
               become available before starting the resource.
         """
 
         return super().start(
-            wait_on_pending_quota=wait_on_pending_quota,
+            wait_for_quotas=wait_for_quotas,
             is_elastic=self.__is_elastic,
             num_vms=self.min_machines,
             min_vms=self.min_machines,

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -145,7 +145,7 @@ class BaseMachineGroup(ABC):
     @property
     def name(self):
         return self._name
-    
+
     @property
     def started(self):
         return self._started

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -315,11 +315,11 @@ class BaseMachineGroup(ABC):
 
         return is_cost_ok and is_vcpu_ok and is_instance_ok
 
-    def start(self, wait_on_pending_quota: bool = False, **kwargs):
+    def start(self, wait_for_quotas: bool = False, **kwargs):
         """Starts a machine group.
 
         Args:
-            wait_on_pending_quota: If True, the method will wait for quotas to
+            wait_for_quotas: If True, the method will wait for quotas to
               become available before starting the resource.
             **kwargs: Depending on the type of machine group to be started,
               this can be num_machines, max_machines, min_machines,
@@ -351,7 +351,7 @@ class BaseMachineGroup(ABC):
                      "the creation of the machine group. Please wait...")
         start_time = time.time()
 
-        if wait_on_pending_quota:
+        if wait_for_quotas:
             if not self.can_start_resource():
                 print("This machine will exceed the current quotas.\n"
                       "Will wait for quotas to become available.")

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -145,6 +145,10 @@ class BaseMachineGroup(ABC):
     @property
     def name(self):
         return self._name
+    
+    @property
+    def started(self):
+        return self._started
 
     @property
     def max_idle_time(self) -> datetime.timedelta:


### PR DESCRIPTION
Add a parameter to wait for quotas when running a benchmark, and refactor the parameter name from ```wait_on_pending_quota``` to ```wait_for_quotas``` for better clarity and conciseness.

Closes https://github.com/inductiva/tasks/issues/511.

Example:

```python
from inductiva.benchmarks import Benchmark
from inductiva.utils import download_from_url
from inductiva.simulators import AmrWind
from inductiva.resources import MachineGroup

input_dir = download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "amr-wind-input-example.zip",
    unzip=True)

Benchmark(name="test-benchmark") \
    .set_default(simulator=AmrWind(),
                 input_dir=input_dir,
                 sim_config_filename="abl_amd_wenoz.inp") \
    .add_run(on=MachineGroup("c2-standard-4"), n_vcpus=4) \
    .run(num_repeats=2, 
         wait_for_quotas=True) \
    .wait() \
    .terminate() \
    .export(fmt="csv")
```