### PR TITLE
Speedup ```Benchmark.run```

### DIFF
--- a/inductiva/_cli/cmd_resources/terminate.py
+++ b/inductiva/_cli/cmd_resources/terminate.py
@@ -63,7 +63,7 @@ def terminate_machine_group(args):
     base_machine = cls.__new__(cls)
     rows = ["max_price_hour", "max_vcpus", "max_instances"]
     base_machine.quota_usage = {k: before_quotas[k]["in_use"] for k in rows}
-    base_machine.log_quota_usage("freed by resources")
+    logging.info(base_machine.quota_usage_table_str("freed by resources"))
 
     return 0
 

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -349,8 +349,9 @@ def task_info_str(
         info_str += f"\t· Version:               {simulator.version}\n"
         info_str += f"\t· Image:                 {simulator.image_uri}\n"
 
-    info_str += f"\t· Local input directory: {params["sim_dir"]}\n" \
-                 "\t· Submitting to the following computational resources:\n"
+    local_input_dir = params["sim_dir"]
+    info_str += (f"\t· Local input directory: {local_input_dir}\n"
+                 "\t· Submitting to the following computational resources:\n")
     if resource_pool is not None:
         info_str += f" \t\t· {resource_pool}\n"
     else:
@@ -402,13 +403,14 @@ def submit_task(api_instance,
     )
 
     task_id = task_submitted_info["id"]
-    logging.info(task_info_str(
-        task_id,
-        params,
-        resource_pool,
-        simulator_obj,
-        task_submitted_info,
-    ))
+    logging.info(
+        task_info_str(
+            task_id,
+            params,
+            resource_pool,
+            simulator_obj,
+            task_submitted_info,
+        ))
 
     if task_submitted_info["status"] == "pending-input":
 

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -333,37 +333,36 @@ def blocking_task_context(api_instance: TasksApi, task_id):
         signal.signal(signal.SIGINT, original_sig)
 
 
-def log_task_info(
+def task_info_str(
     task_id,
     params,
     resource_pool,
     simulator,
     task_submitted_info: TaskSubmittedInfo,
-):
-    """Logging the main components of a task submission."""
+) -> str:
+    """Generate a string with the main components of a task submission."""
 
-    logging.info("■ Task Information:")
-    logging.info("\t· ID:                    %s", task_id)
+    info_str = "■ Task Information:\n"
+    info_str += f"\t· ID:                    {task_id}\n"
     if simulator is not None:
-        logging.info("\t· Simulator:             %s", simulator.name)
-        logging.info("\t· Version:               %s", simulator.version)
-        logging.info("\t· Image:                 %s", simulator.image_uri)
+        info_str += f"\t· Simulator:             {simulator.name}\n"
+        info_str += f"\t· Version:               {simulator.version}\n"
+        info_str += f"\t· Image:                 {simulator.image_uri}\n"
 
-    logging.info("\t· Local input directory: %s", params["sim_dir"])
-    logging.info("\t· Submitting to the following computational resources:")
+    info_str += f"\t· Local input directory: {params["sim_dir"]}\n" \
+                 "\t· Submitting to the following computational resources:\n"
     if resource_pool is not None:
-        logging.info(" \t\t· %s", resource_pool)
+        info_str += f" \t\t· {resource_pool}\n"
     else:
-        logging.info(" \t\t· Default queue with %s machines.",
-                     constants.DEFAULT_QUEUE_MACHINE_TYPE)
+        info_str += " \t\t· Default queue with " \
+            f"{constants.DEFAULT_QUEUE_MACHINE_TYPE} machines.\n"
         ttl_seconds = task_submitted_info.get("time_to_live_seconds")
         if ttl_seconds is not None and isinstance(ttl_seconds, decimal.Decimal):
-            logging.info(
-                (" \t\t· Task will be killed after the computation time "
-                 "exceeds %s (h:m:s)."),
-                format_utils.seconds_formatter(ttl_seconds),
-            )
-    logging.info("")
+            ttl_seconds = format_utils.seconds_formatter(ttl_seconds)
+            info_str += f" \t\t· Task will be killed after the computation " \
+                        f"time exceeds {ttl_seconds} (h:m:s).\n"
+    info_str += "\n"
+    return info_str
 
 
 def submit_task(api_instance,
@@ -403,13 +402,13 @@ def submit_task(api_instance,
     )
 
     task_id = task_submitted_info["id"]
-    log_task_info(
+    logging.info(task_info_str(
         task_id,
         params,
         resource_pool,
         simulator_obj,
         task_submitted_info,
-    )
+    ))
 
     if task_submitted_info["status"] == "pending-input":
 

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -342,12 +342,12 @@ def task_info_str(
 ) -> str:
     """Generate a string with the main components of a task submission."""
 
-    info_str = "■ Task Information:\n"
-    info_str += f"\t· ID:                    {task_id}\n"
+    info_str = ("■ Task Information:\n"
+                f"\t· ID:                    {task_id}\n")
     if simulator is not None:
-        info_str += f"\t· Simulator:             {simulator.name}\n"
-        info_str += f"\t· Version:               {simulator.version}\n"
-        info_str += f"\t· Image:                 {simulator.image_uri}\n"
+        info_str += (f"\t· Simulator:             {simulator.name}\n"
+                     f"\t· Version:               {simulator.version}\n"
+                     f"\t· Image:                 {simulator.image_uri}\n")
 
     local_input_dir = params["sim_dir"]
     info_str += (f"\t· Local input directory: {local_input_dir}\n"
@@ -355,13 +355,13 @@ def task_info_str(
     if resource_pool is not None:
         info_str += f" \t\t· {resource_pool}\n"
     else:
-        info_str += " \t\t· Default queue with " \
-            f"{constants.DEFAULT_QUEUE_MACHINE_TYPE} machines.\n"
+        machine_type = constants.DEFAULT_QUEUE_MACHINE_TYPE
+        info_str += f" \t\t· Default queue with {machine_type} machines.\n"
         ttl_seconds = task_submitted_info.get("time_to_live_seconds")
         if ttl_seconds is not None and isinstance(ttl_seconds, decimal.Decimal):
             ttl_seconds = format_utils.seconds_formatter(ttl_seconds)
-            info_str += f" \t\t· Task will be killed after the computation " \
-                        f"time exceeds {ttl_seconds} (h:m:s).\n"
+            info_str += (f" \t\t· Task will be killed after the computation "
+                         f"time exceeds {ttl_seconds} (h:m:s).\n")
     info_str += "\n"
     return info_str
 

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -148,15 +148,16 @@ class Benchmark(Project):
             Self: The current instance for method chaining.
         """
         def _run(params):
-            simulator, input_dir, machine_group, kwargs = params
-            if not machine_group.started:
-                machine_group.start(wait_for_quotas=wait_for_quotas)
-            for _ in range(num_repeats):
-                simulator.run(input_dir=input_dir,
-                              on=machine_group,
-                              **kwargs)
+            with self:
+                simulator, input_dir, machine_group, kwargs = params
+                if not machine_group.started:
+                    machine_group.start(wait_for_quotas=wait_for_quotas)
+                for _ in range(num_repeats):
+                    simulator.run(input_dir=input_dir,
+                                  on=machine_group,
+                                  **kwargs)
 
-        with self, ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor() as executor:
             _ = executor.map(_run, self.runs)
         self.runs.clear()
         return self

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -147,6 +147,7 @@ class Benchmark(Project):
         Returns:
             Self: The current instance for method chaining.
         """
+
         def _run(params):
             with self:
                 simulator, input_dir, machine_group, kwargs = params

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -350,7 +350,7 @@ class BaseMachineGroup(ABC):
             )
 
         logging.info(f"Starting {self}. "
-                     "This may take a few minutes."
+                     "This may take a few minutes.\n"
                      "Note that stopping this local process will not interrupt "
                      "the creation of the machine group. Please wait...")
         start_time = time.time()
@@ -365,7 +365,7 @@ class BaseMachineGroup(ABC):
         self._api.start_vm_group(body=request_body)
         creation_time = format_utils.seconds_formatter(time.time() - start_time)
         self._started = True
-        logging.info(f"{self} successfully started in {creation_time}.\n"
+        logging.info(f"{self} successfully started in {creation_time}.\n\n"
                      "The machine group is using the following quotas:\n"
                      f"{self.quota_usage_table_str("used by resource")}")
         return True

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -349,10 +349,10 @@ class BaseMachineGroup(ABC):
                 **kwargs,
             )
 
-        logging.info(f"Starting {repr(self)}. "
-                     "This may take a few minutes.\n"
-                     "Note that stopping this local process will not interrupt "
-                     "the creation of the machine group. Please wait...")
+        logging.info(
+            "Starting %s. This may take a few minutes.\n"
+            "Note that stopping this local process will not interrupt "
+            "the creation of the machine group. Please wait...", repr(self))
         start_time = time.time()
 
         if wait_for_quotas:
@@ -366,9 +366,10 @@ class BaseMachineGroup(ABC):
         creation_time = format_utils.seconds_formatter(time.time() - start_time)
         self._started = True
         quota_usage_table_str = self.quota_usage_table_str("used by resource")
-        logging.info(f"{self} successfully started in {creation_time}.\n\n"
-                     "The machine group is using the following quotas:\n"
-                     f"{quota_usage_table_str}")
+        logging.info(
+            "%s successfully started in %s.\n\n"
+            "The machine group is using the following quotas:\n"
+            "%s", self, creation_time, quota_usage_table_str)
         return True
 
     def terminate(self, verbose: bool = True, **kwargs):

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -349,9 +349,9 @@ class BaseMachineGroup(ABC):
                 **kwargs,
             )
 
-        logging.info("Starting %s. "
-                     "This may take a few minutes.", repr(self))
-        logging.info("Note that stopping this local process will not interrupt "
+        logging.info(f"Starting {self}. "
+                     "This may take a few minutes."
+                     "Note that stopping this local process will not interrupt "
                      "the creation of the machine group. Please wait...")
         start_time = time.time()
 
@@ -365,10 +365,9 @@ class BaseMachineGroup(ABC):
         self._api.start_vm_group(body=request_body)
         creation_time = format_utils.seconds_formatter(time.time() - start_time)
         self._started = True
-        logging.info("%s successfully started in %s.", self, creation_time)
-        logging.info("")
-        logging.info("The machine group is using the following quotas:")
-        self.log_quota_usage("used by resource")
+        logging.info(f"{self} successfully started in {creation_time}.\n"
+                     "The machine group is using the following quotas:\n"
+                     f"{self.quota_usage_table_str("used by resource")}")
         return True
 
     def terminate(self, verbose: bool = True, **kwargs):
@@ -396,7 +395,7 @@ class BaseMachineGroup(ABC):
                              repr(self))
                 logging.info("Termination of the machine group "
                              "freed the following quotas:")
-                self.log_quota_usage("freed by resource")
+                logging.info(self.quota_usage_table_str("freed by resource"))
             return True
 
         except inductiva.client.ApiException as api_exception:
@@ -422,7 +421,7 @@ class BaseMachineGroup(ABC):
 
         return self._estimated_cost
 
-    def log_quota_usage(self, resource_usage_header: str):
+    def quota_usage_table_str(self, resource_usage_header: str) -> str:
         quotas = users.get_quotas()
         table = defaultdict(list)
         emph_formatter = format_utils.get_ansi_formatter()
@@ -446,7 +445,7 @@ class BaseMachineGroup(ABC):
             header_formatters=header_formatters,
         )
 
-        logging.info(table_str)
+        return table_str
 
     def _log_estimated_spot_vm_savings(self) -> None:
         if self.provider in (

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -365,9 +365,10 @@ class BaseMachineGroup(ABC):
         self._api.start_vm_group(body=request_body)
         creation_time = format_utils.seconds_formatter(time.time() - start_time)
         self._started = True
+        quota_usage_table_str = self.quota_usage_table_str("used by resource")
         logging.info(f"{self} successfully started in {creation_time}.\n\n"
                      "The machine group is using the following quotas:\n"
-                     f"{self.quota_usage_table_str("used by resource")}")
+                     f"{quota_usage_table_str}")
         return True
 
     def terminate(self, verbose: bool = True, **kwargs):

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -349,7 +349,7 @@ class BaseMachineGroup(ABC):
                 **kwargs,
             )
 
-        logging.info(f"Starting {self}. "
+        logging.info(f"Starting {repr(self)}. "
                      "This may take a few minutes.\n"
                      "Note that stopping this local process will not interrupt "
                      "the creation of the machine group. Please wait...")

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -50,10 +50,10 @@ def run_simulation(
     logging.info("■ Task %s submitted to the queue of the %s.", task_id,
                  computational_resources)
 
-    task = tasks.Task(task_id)
     if not isinstance(task_id, str):
         raise RuntimeError(
             f"Expected result to be a string with task_id, got {type(task_id)}")
+    task = tasks.Task(task_id)
 
     position = task.get_position_in_queue()
     if position is not None:

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -57,19 +57,17 @@ def run_simulation(
 
     position = task.get_position_in_queue()
     if position is not None:
-        logging.info("Number of tasks ahead in the queue: %s", position)
+        position_message = f"Number of tasks ahead in the queue: {position}."
     else:
-        logging.info("Task %s does not have queue information.", task_id)
+        position_message = f"Task {task_id} does not have queue information."
 
     logging.info(
+        f"{position_message}\n"
         "· Consider tracking the status of the task via CLI:"
-        "\n\tinductiva tasks list --id %s", task_id)
-    logging.info(
+        f"\n\tinductiva tasks list --id {task_id}\n"
         "· Or, tracking the logs of the task via CLI:"
-        "\n\tinductiva logs %s", task_id)
-    logging.info(
+        f"\n\tinductiva logs {task_id}\n"
         "· You can also get more information "
         "about the task via the CLI command:"
-        "\n\tinductiva tasks info %s", task_id)
-    logging.info("")
+        f"\n\tinductiva tasks info {task_id}\n\n")
     return task

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -57,16 +57,18 @@ def run_simulation(
 
     position = task.get_position_in_queue()
     if position is not None:
-        task_queue_status = f"Number of tasks ahead in the queue: {position}."
+        task_pos = f"Number of tasks ahead in the queue: {position}."
     else:
-        task_queue_status = f"Task {task_id} does not have queue information."
+        task_pos = f"Task {task_id} does not have queue information."
 
-    logging.info(f"{task_queue_status}\n"
-                 "· Consider tracking the status of the task via CLI:"
-                 f"\n\tinductiva tasks list --id {task_id}\n"
-                 "· Or, tracking the logs of the task via CLI:"
-                 f"\n\tinductiva logs {task_id}\n"
-                 "· You can also get more information "
-                 "about the task via the CLI command:"
-                 f"\n\tinductiva tasks info {task_id}\n\n")
+    logging.info(
+        "%s\n"
+        "· Consider tracking the status of the task via CLI:"
+        "\n\tinductiva tasks list --id %s\n"
+        "· Or, tracking the logs of the task via CLI:"
+        "\n\tinductiva logs %s\n"
+        "· You can also get more information "
+        "about the task via the CLI command:"
+        "\n\tinductiva tasks info %s\n\n", task_pos, task_id, task_id, task_id)
+
     return task

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -61,13 +61,12 @@ def run_simulation(
     else:
         position_message = f"Task {task_id} does not have queue information."
 
-    logging.info(
-        f"{position_message}\n"
-        "· Consider tracking the status of the task via CLI:"
-        f"\n\tinductiva tasks list --id {task_id}\n"
-        "· Or, tracking the logs of the task via CLI:"
-        f"\n\tinductiva logs {task_id}\n"
-        "· You can also get more information "
-        "about the task via the CLI command:"
-        f"\n\tinductiva tasks info {task_id}\n\n")
+    logging.info(f"{position_message}\n"
+                 "· Consider tracking the status of the task via CLI:"
+                 f"\n\tinductiva tasks list --id {task_id}\n"
+                 "· Or, tracking the logs of the task via CLI:"
+                 f"\n\tinductiva logs {task_id}\n"
+                 "· You can also get more information "
+                 "about the task via the CLI command:"
+                 f"\n\tinductiva tasks info {task_id}\n\n")
     return task

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -57,11 +57,11 @@ def run_simulation(
 
     position = task.get_position_in_queue()
     if position is not None:
-        position_message = f"Number of tasks ahead in the queue: {position}."
+        task_queue_status = f"Number of tasks ahead in the queue: {position}."
     else:
-        position_message = f"Task {task_id} does not have queue information."
+        task_queue_status = f"Task {task_id} does not have queue information."
 
-    logging.info(f"{position_message}\n"
+    logging.info(f"{task_queue_status}\n"
                  "· Consider tracking the status of the task via CLI:"
                  f"\n\tinductiva tasks list --id {task_id}\n"
                  "· Or, tracking the logs of the task via CLI:"

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -57,9 +57,9 @@ def run_simulation(
 
     position = task.get_position_in_queue()
     if position is not None:
-        task_pos = f"Number of tasks ahead in the queue: {position}."
+        pos_info = f"Number of tasks ahead in the queue: {position}."
     else:
-        task_pos = f"Task {task_id} does not have queue information."
+        pos_info = f"Task {task_id} does not have queue information."
 
     logging.info(
         "%s\n"
@@ -69,6 +69,6 @@ def run_simulation(
         "\n\tinductiva logs %s\n"
         "· You can also get more information "
         "about the task via the CLI command:"
-        "\n\tinductiva tasks info %s\n\n", task_pos, task_id, task_id, task_id)
+        "\n\tinductiva tasks info %s\n\n", pos_info, task_id, task_id, task_id)
 
     return task

--- a/inductiva/tests/benchmarks/test_benchmark.py
+++ b/inductiva/tests/benchmarks/test_benchmark.py
@@ -2,10 +2,8 @@
 from unittest import mock
 import pytest
 from pathlib import Path
+from inductiva import simulators, resources
 from inductiva.benchmarks import Benchmark
-from inductiva.resources import MachineGroup
-from inductiva.simulators import Simulator
-from inductiva import resources
 
 
 @pytest.fixture(name="benchmark")
@@ -108,10 +106,10 @@ def test_benchmark_multiple_add_runs(benchmark):
 
 
 def test_benchmark_run(benchmark):
-    simulator = mock.MagicMock(spec=Simulator)
+    simulator = mock.MagicMock(spec=simulators.Simulator)
     simulator.run = mock.MagicMock(return_value=None)
-    m4 = mock.MagicMock(spec=MachineGroup)
-    m8 = mock.MagicMock(spec=MachineGroup)
+    m4 = mock.MagicMock(spec=resources.MachineGroup)
+    m8 = mock.MagicMock(spec=resources.MachineGroup)
     m4.start = mock.MagicMock(return_value=None)
     m8.start = mock.MagicMock(return_value=None)
     Benchmark.set_default(self=benchmark,


### PR DESCRIPTION
This PR optimizes the performance of the ```Benchmark.run``` method by using multithreading to execute multiple API requests in parallel for starting machine groups and submitting tasks. Additionally, several logging statements that were previously spread across multiple locations have been consolidated into a single one. This change helps reduce log clutter caused by simultaneous execution of threads.

- Script to measure speedup:

```python
from inductiva.benchmarks import Benchmark
from inductiva.utils import download_from_url
from inductiva.simulators import AmrWind
from inductiva.resources import MachineGroup
import time

# Configure the benchmark with default parameters
input_dir = download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "amr-wind-input-example.zip",
    unzip=True)

benchmark = Benchmark(name="test-speedup-6") \
    .set_default(simulator=AmrWind(),
                 input_dir=input_dir,
                 sim_config_filename="abl_amd_wenoz.inp")

# Add multiple machines to measure execution time of the `run` method
machines = [
    MachineGroup("c2-standard-4"),
    MachineGroup("c2-standard-4"),
    MachineGroup("c2-standard-4"),
    MachineGroup("c2-standard-4"),
    MachineGroup("c2-standard-8"),
    MachineGroup("c2-standard-8"),
    MachineGroup("c2-standard-8"),
    MachineGroup("c2-standard-8"),
]

for machine in machines:
    benchmark.add_run(on=machine, n_vcpus=machine.n_vcpus.total)

# Measure the execution time of the `run` method
start = time.perf_counter()
benchmark.run(num_repeats=2)
end = time.perf_counter()

print("Exec. Time: {} seconds".format(round(end - start, 2)))
```

- Execution time results (on MacBook Air M3):

|          | **1 Machine (1st Run)** | **1 Machine (2nd Run)** | **4 Machines (1st Run)** | **4 Machines (2nd Run)** | **8 Machines (1st Run)** | **8 Machines (2nd Run)** |
|----------------------------|---------------------------|----------------------------|----------------------------|-----------------------------|----------------------------|-----------------------------|
| **Single Thread**           | 34.69s             | 34.06s              | 150.05s             | 154.08s              | 305.07s             | 322.25s              |
| **Multi Thread**            | 34.52s             | 33.93s              | 45.09s              | 45.61s               | 47.55s              | 48.62s               |
| **Speedup**                 | 1.01x                     | 1.00x                      | 3.33x                      | 3.38x                       | 6.42x                      | 6.63x                       |
