### PR TITLE
Updating yapf and pylint rules on GitHub action

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Lint with pylint
       if: ${{ always() }}
       run: |
-        find . -type f -not -path "./third_party/*" -name '*.py' | xargs pylint
+        find . -type f -not -path "./inductiva/client/*" -name '*.py' | xargs pylint
     - name: Test with pytest
       if: ${{ always() }}
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,8 +38,8 @@ jobs:
         if [[ -f requirements.txt ]]; then python -m pip install -r requirements.txt; fi
     - name: Check formatting with yapf
       if: ${{ always() }}
-      run: |
-        yapf . --diff --recursive --parallel --exclude=third_party
+      run: # Exclude the auto-generated Python client folder from yapf formatting
+        yapf . --diff --recursive --parallel --exclude=inductiva/client 
     - name: Lint with pylint
       if: ${{ always() }}
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,11 +38,11 @@ jobs:
         if [[ -f requirements.txt ]]; then python -m pip install -r requirements.txt; fi
     - name: Check formatting with yapf
       if: ${{ always() }}
-      run: # Exclude the auto-generated Python client folder from yapf formatting
+      run: # We exclude the auto-generated Python client folder from yapf validation
         yapf . --diff --recursive --parallel --exclude=inductiva/client 
     - name: Lint with pylint
       if: ${{ always() }}
-      run: |
+      run: # We exclude the auto-generated Python client folder from pylint validation
         find . -type f -not -path "./inductiva/client/*" -name '*.py' | xargs pylint
     - name: Test with pytest
       if: ${{ always() }}


### PR DESCRIPTION
Excluding the auto-generated code by OpenAPI from the yapf analysis, because we are not supposed to touch that code, and yapf will just spend a lot of time on that analysis and generate a lot of output.
Also excluded the folder from pylint.

Old times:
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/11e767a7-2109-4219-9444-c77eb2ae76fa">

New times:
<img width="1307" alt="image" src="https://github.com/user-attachments/assets/729e4ac9-333d-444b-bdf7-b7c737dd7eec">

Not quite sure why with pylint there was no noticeable speed up, but I tested locally the find command, and it seems to be properly excluding the client folder, before passing to xargs pylint...

In any case, the total duration of the GitHub action, seems to have been cut in half! :)