### PR TITLE
Add ```path``` option to ```download_from_url``` for specifying unzip location

### DIFF
--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -190,8 +190,8 @@ def download_from_url(
 
     # Unzip all files as they were zipped.
     if unzip and zipfile.is_zipfile(downloaded_to):
-        resulting_path = pathlib.Path(path) if path \
-            else downloaded_to.with_suffix()
+        resulting_path = pathlib.Path(path) \
+            if path else downloaded_to.with_suffix("")
         logging.info("■ Uncompressing the downloaded archive to %s",
                      resulting_path)
         _unzip(zip_path=downloaded_to, unzip_path=resulting_path)

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -117,7 +117,7 @@ def get_sorted_files(data_dir: str,
     return files
 
 
-def _unzip(zip_path: pathlib.Path, unzip_path: Optional[str] = None):
+def _unzip(zip_path: pathlib.Path, unzip_path: Optional[pathlib.Path] = None):
     """Unzip a zip archive and remove the .zip."""
 
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
@@ -142,7 +142,11 @@ def tqdm_refreshhook(tqdm_bar):
     return update_to
 
 
-def download_from_url(url: str, unzip: bool = False) -> str:
+def download_from_url(
+    url: str,
+    unzip: bool = False,
+    path: Optional[str] = None,
+) -> str:
     """Download a file from an URL.
 
     This function downloads from a set of files from an url.
@@ -152,6 +156,9 @@ def download_from_url(url: str, unzip: bool = False) -> str:
     Args:
         url: The URL to download the file from.
         unzip: Whether to unzip the file after downloading.
+        path: The directory path where the file should be saved. If None, 
+            the file will be saved in the current working directory.
+
     Returns:
         The path to the downloaded file.
     """
@@ -183,7 +190,8 @@ def download_from_url(url: str, unzip: bool = False) -> str:
 
     # Unzip all files as they were zipped.
     if unzip and zipfile.is_zipfile(downloaded_to):
-        resulting_path = pathlib.Path(downloaded_to).with_suffix("")
+        resulting_path = pathlib.Path(path) if path \
+            else downloaded_to.with_suffix()
         logging.info("■ Uncompressing the downloaded archive to %s",
                      resulting_path)
         _unzip(zip_path=downloaded_to, unzip_path=resulting_path)

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -191,8 +191,7 @@ def download_from_url(
     # Unzip all files as they were zipped.
     if unzip and zipfile.is_zipfile(downloaded_to):
         resulting_path = (pathlib.Path(path)
-                          if path
-                          else downloaded_to.with_suffix(""))
+                          if path else downloaded_to.with_suffix(""))
         logging.info("■ Uncompressing the downloaded archive to %s",
                      resulting_path)
         _unzip(zip_path=downloaded_to, unzip_path=resulting_path)

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -117,13 +117,13 @@ def get_sorted_files(data_dir: str,
     return files
 
 
-def _unzip(zip_path: pathlib.Path):
+def _unzip(zip_path: pathlib.Path, unzip_path: Optional[str] = None):
     """Unzip a zip archive and remove the .zip."""
 
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
         for member in tqdm(zip_ref.infolist(), desc="Extracting "):
             try:
-                zip_ref.extract(member)
+                zip_ref.extract(member, path=unzip_path)
             except zipfile.error as e:
                 print(f"Error extracting {member.filename}: {e}")
                 pass
@@ -186,7 +186,7 @@ def download_from_url(url: str, unzip: bool = False) -> str:
         resulting_path = pathlib.Path(downloaded_to).with_suffix("")
         logging.info("■ Uncompressing the downloaded archive to %s",
                      resulting_path)
-        _unzip(downloaded_to)
+        _unzip(zip_path=downloaded_to, unzip_path=resulting_path)
         logging.info("")
 
     return str(resulting_path.absolute())

--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -190,8 +190,9 @@ def download_from_url(
 
     # Unzip all files as they were zipped.
     if unzip and zipfile.is_zipfile(downloaded_to):
-        resulting_path = pathlib.Path(path) \
-            if path else downloaded_to.with_suffix("")
+        resulting_path = (pathlib.Path(path)
+                          if path
+                          else downloaded_to.with_suffix(""))
         logging.info("■ Uncompressing the downloaded archive to %s",
                      resulting_path)
         _unzip(zip_path=downloaded_to, unzip_path=resulting_path)


### PR DESCRIPTION
This PR adds a ```path``` argument to the ```download_from_url``` function, providing users the option to specify where to unzip downloaded files.

If no ```path``` is provided, the files will be extracted into a subfolder named after the zip file. For example, if the zip file is named ```files.zip```, the extracted files will be placed in a ```files/``` directory. If the user specifies ```path="."```, the files will be extracted directly into the current directory, without being placed in a subfolder.

**QA**:

```python
import inductiva

local_path = inductiva.utils.download_from_url(
    url="https://zenodo.org/records/4091612/files/model_input.zip",
    unzip=True)

# ■ Uncompressing the downloaded archive to model_input

local_path = inductiva.utils.download_from_url(
    url="https://zenodo.org/records/4091612/files/model_input.zip",
    unzip=True,
    path="other_name")

# ■ Uncompressing the downloaded archive to other_name

local_path = inductiva.utils.download_from_url(
    url="https://zenodo.org/records/4091612/files/model_input.zip",
    unzip=True,
    path=".")

# ■ Uncompressing the downloaded archive to .
```