### PR TITLE
Fix silent exceptions in ```benchmark.run``` due to multithreading

### DIFF
--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -155,7 +155,7 @@ class Benchmark(projects.Project):
                                   **kwargs)
 
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            _ = executor.map(_run, self.runs)
+            _ = list(executor.map(_run, self.runs))
         self.runs.clear()
         return self
 


### PR DESCRIPTION
This PR resolves the problem of exceptions being silently ignored in the ```benchmark.run``` method due to multithreading. By using ```list()``` to consume the results from the threads, any exceptions raised during execution are now properly propagated.