### PR TITLE
Ensure proper ContextVar copying across threads in benchmark

### DIFF
--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -150,14 +150,15 @@ class Benchmark(projects.Project):
             if not machine_group.started:
                 machine_group.start(wait_for_quotas=wait_for_quotas)
             for _ in range(num_repeats):
-                simulator.run(input_dir=input_dir,
-                              on=machine_group,
-                              **kwargs)
-        
+                simulator.run(input_dir=input_dir, on=machine_group, **kwargs)
+
+        def _initializer(ctx):
+            for var, val in ctx.items():
+                var.set(val)
+
         with self, concurrent.futures.ThreadPoolExecutor(
-            initializer=lambda ctx: [var.set(val) for var, val in ctx.items()],
-            initargs=(contextvars.copy_context(),)
-        ) as executor:
+                initializer=_initializer,
+                initargs=(contextvars.copy_context(),)) as executor:
             _ = list(executor.map(_run, self.runs))
         self.runs.clear()
         return self


### PR DESCRIPTION
This PR fixes a bug related to how the ```Project``` class (the base class of ```Benchmark```) is opened and closed, specifically involving the global variable ```_CURRENT_PROJECT``` (of type ```ContextVar``` in the ```projects``` module), which was not being correctly copied to threads during ```Benchmark.run()```.

The problem existed previously but was silently ignored due to exception handling in multithreading (see [this PR](https://github.com/inductiva/inductiva/pull/1713) for more details).

The solution involves copying the context of variables into each thread by using the ```initializer``` and ```initargs``` parameters when initializing the ```ThreadPoolExecutor```.

Additionally, with this change, the ```Benchmark``` is no longer opened multiple times on each thread. Instead, it is opened just once, before the threads begin executing.


**QA**:

```python
import time
from inductiva import benchmarks, resources, simulators, utils

input_dir = utils.download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "amr-wind-input-example.zip",
    unzip=True)

benchmark = (benchmarks.Benchmark(name="test-copy-context-threads")
    .set_default(simulator=simulators.AmrWind(),
                 input_dir=input_dir,
                 sim_config_filename="abl_amd_wenoz.inp")  
    .add_run(on=resources.MachineGroup("c2-standard-4"))
    .add_run(on=resources.MachineGroup("c2-standard-4"))
    .add_run(on=resources.MachineGroup("c2-standard-8"))
    .add_run(on=resources.MachineGroup("c2-standard-8")))

start = time.perf_counter()
benchmark.run(num_repeats=1)    
end = time.perf_counter()

print(f"Exec. time: {end - start}s") # Exec. time: 50.41791320798802s

benchmark.wait().terminate()
```