### PR TITLE
Revert to previous behavior if the user doesn't pass a path

### DIFF
--- a/inductiva/utils/files.py
+++ b/inductiva/utils/files.py
@@ -194,7 +194,7 @@ def download_from_url(
                           if path else downloaded_to.with_suffix(""))
         logging.info("■ Uncompressing the downloaded archive to %s",
                      resulting_path)
-        _unzip(zip_path=downloaded_to, unzip_path=resulting_path)
+        _unzip(downloaded_to, resulting_path if path else None)
         logging.info("")
 
     return str(resulting_path.absolute())


### PR DESCRIPTION
**Test**:

```python
import inductiva

local_path = inductiva.utils.download_from_url(
    url="https://zenodo.org/records/4091612/files/model_input.zip",
    unzip=True)

# ■ Uncompressing the downloaded archive to model_input

local_path = inductiva.utils.download_from_url(
    url="https://zenodo.org/records/4091612/files/model_input.zip",
    unzip=True,
    path="other_name")

# ■ Uncompressing the downloaded archive to other_name

local_path = inductiva.utils.download_from_url(
    url="https://zenodo.org/records/4091612/files/model_input.zip",
    unzip=True,
    path=".")

# ■ Uncompressing the downloaded archive to .

input_dir = inductiva.utils.download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "amr-wind-input-example.zip",
    unzip=True)

# ■ Uncompressing the downloaded archive to amr-wind-input-example

input_dir = inductiva.utils.download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "amr-wind-input-example.zip",
    unzip=True,
    path=".")

# ■ Uncompressing the downloaded archive to .

input_dir = inductiva.utils.download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "amr-wind-input-example.zip",
    unzip=True,
    path="nested-folder")

# ■ Uncompressing the downloaded archive to nested-folder
```