### PR TITLE
Add machine group info command

### DIFF
--- a/inductiva/_cli/cmd_resources/info.py
+++ b/inductiva/_cli/cmd_resources/info.py
@@ -1,0 +1,28 @@
+"""Prints a machine group information via CLI."""
+from typing import TextIO
+import argparse
+import sys
+
+from inductiva import resources, _cli
+
+def machine_group_info(args, fout: TextIO = sys.stdout):
+    """Prints a task information."""
+    machine_group_name = args.name
+    machine_group = resources.machine_groups.get_by_name(machine_group_name)
+    return 0
+
+
+def register(parser):
+    """Register the info machine group command."""
+    subparser = parser.add_parser("info",
+                                  help="Prints information related to a machine group.",
+                                  formatter_class=argparse.RawTextHelpFormatter)
+
+    subparser.description = ("The `inductiva resources info` command provides "
+                             "information about a machine group.")
+
+    _cli.utils.add_watch_argument(subparser)
+    subparser.add_argument("name",
+                           type=str,
+                           help="name of the machine group to get information about.")
+    subparser.set_defaults(func=machine_group_info)

--- a/inductiva/_cli/cmd_resources/info.py
+++ b/inductiva/_cli/cmd_resources/info.py
@@ -13,8 +13,7 @@ def machine_group_info(args, fout: TextIO = sys.stdout):
     machine_group = resources.machine_groups.get_by_name(machine_group_name)
     machines = machine_group.__dict__["machines"]
 
-    print(f"Showing machines of machine group: {machine_group_name}",
-          file=fout)
+    print(f"Showing machines of machine group: {machine_group_name}", file=fout)
 
     table_dict = resources.machine_groups.get_machine_dict(machines)
 

--- a/inductiva/_cli/cmd_resources/info.py
+++ b/inductiva/_cli/cmd_resources/info.py
@@ -4,25 +4,53 @@ import argparse
 import sys
 
 from inductiva import resources, _cli
+from inductiva.utils import format_utils
+
 
 def machine_group_info(args, fout: TextIO = sys.stdout):
     """Prints a task information."""
     machine_group_name = args.name
     machine_group = resources.machine_groups.get_by_name(machine_group_name)
+    machines = machine_group.__dict__["machines"]
+
+    print(f"Showing machines of machine group: {machine_group_name}.",
+          file=fout)
+
+    table_dict = resources.machine_groups.get_machine_dict(machines)
+
+    formatters = {
+        "Started": [format_utils.datetime_formatter,],
+        "Last seen": [format_utils.datetime_formatter,],
+    }
+
+    emph_formatter = format_utils.get_ansi_formatter()
+
+    header_formatters = [
+        lambda x: emph_formatter(x.upper(), format_utils.Emphasis.BOLD)
+    ]
+
+    print(format_utils.get_tabular_str(table_dict,
+                                       formatters=formatters,
+                                       header_formatters=header_formatters),
+          file=fout,
+          end="")
+
     return 0
 
 
 def register(parser):
     """Register the info machine group command."""
-    subparser = parser.add_parser("info",
-                                  help="Prints information related to a machine group.",
-                                  formatter_class=argparse.RawTextHelpFormatter)
+    subparser = parser.add_parser(
+        "info",
+        help="Prints information related to a machine group.",
+        formatter_class=argparse.RawTextHelpFormatter)
 
     subparser.description = ("The `inductiva resources info` command provides "
                              "information about a machine group.")
 
     _cli.utils.add_watch_argument(subparser)
-    subparser.add_argument("name",
-                           type=str,
-                           help="name of the machine group to get information about.")
+    subparser.add_argument(
+        "name",
+        type=str,
+        help="name of the machine group to get information about.")
     subparser.set_defaults(func=machine_group_info)

--- a/inductiva/_cli/cmd_resources/info.py
+++ b/inductiva/_cli/cmd_resources/info.py
@@ -13,7 +13,7 @@ def machine_group_info(args, fout: TextIO = sys.stdout):
     machine_group = resources.machine_groups.get_by_name(machine_group_name)
     machines = machine_group.__dict__["machines"]
 
-    print(f"Showing machines of machine group: {machine_group_name}.",
+    print(f"Showing machines of machine group: {machine_group_name}",
           file=fout)
 
     table_dict = resources.machine_groups.get_machine_dict(machines)

--- a/inductiva/resources/machine_cluster.py
+++ b/inductiva/resources/machine_cluster.py
@@ -90,6 +90,9 @@ class MPICluster(machines_base.BaseMachineGroup):
         machine_group = super().from_api_response(resp)
         machine_group.num_machines = int(resp["max_vms"])
         machine_group.__dict__["_active_machines"] = int(resp["num_vms"])
+        machine_group.__dict__["machines"] = [
+            dict(machine) for machine in resp["machines"]
+        ]
         machine_group.register = False
         return machine_group
 

--- a/inductiva/resources/machine_cluster.py
+++ b/inductiva/resources/machine_cluster.py
@@ -90,9 +90,7 @@ class MPICluster(machines_base.BaseMachineGroup):
         machine_group = super().from_api_response(resp)
         machine_group.num_machines = int(resp["max_vms"])
         machine_group.__dict__["_active_machines"] = int(resp["num_vms"])
-        machine_group.__dict__["machines"] = [
-            dict(machine) for machine in resp["machines"]
-        ]
+        machine_group.__dict__["machines"] = resp["machines"]
         machine_group.register = False
         return machine_group
 

--- a/inductiva/resources/machine_groups.py
+++ b/inductiva/resources/machine_groups.py
@@ -1,5 +1,6 @@
 """Functions to manage or retrieve user resources."""
 from typing import Optional
+from collections import defaultdict
 import logging
 
 import inductiva
@@ -31,6 +32,30 @@ def estimate_machine_cost(machine_type: str, spot: bool = False):
         estimated_cost = instance_price.body["on_demand_price"]
 
     return float(estimated_cost)
+
+
+def get_machine_dict(machines):
+    """Get a dictionary with the information of the machines."""
+    column_names = [
+        "Host Name",
+        "Started",
+        "Status",
+        "Last seen",
+        "Running task",
+    ]
+    table = defaultdict(list, {key: [] for key in column_names})
+    for machine in machines:
+        status = "Off" if isinstance(machine["terminated_at"],
+                                     str) else "Active"
+        task_id = machine["current_task_id"] if isinstance(
+            machine["current_task_id"], str) else None
+        table["Host Name"].append(machine["host_name"])
+        table["Started"].append(machine["started_at"])
+        table["Status"].append(status)
+        table["Last seen"].append(machine["last_seen_at"])
+        table["Running task"].append(task_id)
+
+    return table
 
 
 def _fetch_machine_groups_from_api():

--- a/inductiva/resources/machines.py
+++ b/inductiva/resources/machines.py
@@ -108,6 +108,7 @@ class MachineGroup(machines_base.BaseMachineGroup):
         machine_group.num_machines = int(resp["max_vms"])
         machine_group.provider = resp["provider_id"]
         machine_group.__dict__["_active_machines"] = int(resp["num_vms"])
+        machine_group.__dict__["machines"] = resp["machines"]
         machine_group.spot = bool(resp["spot"])
         machine_group.register = False
         return machine_group
@@ -269,6 +270,7 @@ class ElasticMachineGroup(machines_base.BaseMachineGroup):
         machine_group.max_machines = int(resp["max_vms"])
         machine_group.min_machines = int(resp["min_vms"])
         machine_group.__dict__["_active_machines"] = int(resp["num_vms"])
+        machine_group.__dict__["machines"] = resp["machines"]
         return machine_group
 
     def active_machines_to_str(self) -> str:

--- a/inductiva/tests/resources/test_machine_groups.py
+++ b/inductiva/tests/resources/test_machine_groups.py
@@ -15,6 +15,7 @@ BASE_RESPONSE = {
     "min_vms": 1,
     "provider_id": "GCP",
     "started": False,
+    "machines": [],
 }
 
 RESPONSE_1 = {**BASE_RESPONSE, **{"type": "standard", "is_elastic": False}}


### PR DESCRIPTION
This PR adds a new command 
`inductiva resources info <name>` that presents detailed information about machines in a machine group. 

Example result:
![image](https://github.com/user-attachments/assets/d5ccd879-0328-4aa6-a8fd-25d1c2f81dd9)
