### PR TITLE
Use status on fail

### DIFF
--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -1136,6 +1136,7 @@ class Task:
 
     async def tail_file(self, filename: str) -> str:
         """Get the last 10 lines of a file in the task's working directory."""
+        # pylint: disable=C3001
         formatter = lambda message: self._format_list_of_lines(
             message, filename, sep="\n", endl="")
         return await self._file_operation(Operations.TAIL,

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -1106,7 +1106,7 @@ class Task:
             download_partial_files=data.download_partial_inputs,
         )
 
-    async def _file_operation(self, operation: Operations, formatter: function,
+    async def _file_operation(self, operation: Operations, formatter: Callable,
                               **kwargs) -> str:
         """Perform file operations on the task that is currently running.
 
@@ -1127,20 +1127,20 @@ class Task:
         if message["status"] != "success":
             return message["message"]
 
-        return formatter(message)
+        return formatter(message["message"])
 
     async def list_files(self) -> str:
         """List the files in the task's working directory."""
-        return await self._file_operation(Operations.LIST,
-                                          self._format_directory_listing)
+        return await self._file_operation(
+            Operations.LIST, formatter=self._format_directory_listing)
 
     async def tail_file(self, filename: str) -> str:
         """Get the last 10 lines of a file in the task's working directory."""
         formatter = lambda message: self._format_list_of_lines(
-            message, filename, sep="", endl="")
+            message, filename, sep="\n", endl="")
         return await self._file_operation(Operations.TAIL,
-                                          filename=filename,
-                                          formatter=formatter)
+                                          formatter=formatter,
+                                          filename=filename)
 
     class _PathParams(TypedDict):
         """Util class for type checking path params."""

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -1106,7 +1106,7 @@ class Task:
             download_partial_files=data.download_partial_inputs,
         )
 
-    async def _file_operation(self, operation: Operations, **kwargs) -> str:
+    async def _file_operation(self, operation: Operations, formatter: function, **kwargs) -> str:
         """Perform file operations on the task that is currently running.
 
         Args:
@@ -1122,17 +1122,23 @@ class Task:
             return "Failed to connect to the task."
         message = await future_message
         await file_tracker.cleanup()
-        return message
+
+        if message["status"] != "success":
+            return message["message"]
+
+        return formatter(message)
 
     async def list_files(self) -> str:
         """List the files in the task's working directory."""
-        message = await self._file_operation(Operations.LIST)
-        return self._format_directory_listing(message)
+        return await self._file_operation(Operations.LIST, self._format_directory_listing)
+
 
     async def tail_file(self, filename: str) -> str:
         """Get the last 10 lines of a file in the task's working directory."""
-        message = await self._file_operation(Operations.TAIL, filename=filename)
-        return self._format_list_of_lines(message, filename, sep="\n", endl="")
+        formatter = lambda message : self._format_list_of_lines(
+            message, filename, sep="", endl="")
+        return await self._file_operation(Operations.TAIL, filename=filename, formatter=formatter)
+
 
     class _PathParams(TypedDict):
         """Util class for type checking path params."""

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -1106,7 +1106,8 @@ class Task:
             download_partial_files=data.download_partial_inputs,
         )
 
-    async def _file_operation(self, operation: Operations, formatter: function, **kwargs) -> str:
+    async def _file_operation(self, operation: Operations, formatter: function,
+                              **kwargs) -> str:
         """Perform file operations on the task that is currently running.
 
         Args:
@@ -1130,15 +1131,16 @@ class Task:
 
     async def list_files(self) -> str:
         """List the files in the task's working directory."""
-        return await self._file_operation(Operations.LIST, self._format_directory_listing)
-
+        return await self._file_operation(Operations.LIST,
+                                          self._format_directory_listing)
 
     async def tail_file(self, filename: str) -> str:
         """Get the last 10 lines of a file in the task's working directory."""
-        formatter = lambda message : self._format_list_of_lines(
+        formatter = lambda message: self._format_list_of_lines(
             message, filename, sep="", endl="")
-        return await self._file_operation(Operations.TAIL, filename=filename, formatter=formatter)
-
+        return await self._file_operation(Operations.TAIL,
+                                          filename=filename,
+                                          formatter=formatter)
 
     class _PathParams(TypedDict):
         """Util class for type checking path params."""

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -1136,9 +1136,13 @@ class Task:
 
     async def tail_file(self, filename: str) -> str:
         """Get the last 10 lines of a file in the task's working directory."""
+
         def formatter(message):
-            return self._format_list_of_lines(
-                message, filename, sep="\n", endl="\n")
+            return self._format_list_of_lines(message,
+                                              filename,
+                                              sep="\n",
+                                              endl="\n")
+
         return await self._file_operation(Operations.TAIL,
                                           formatter=formatter,
                                           filename=filename)

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -1136,9 +1136,9 @@ class Task:
 
     async def tail_file(self, filename: str) -> str:
         """Get the last 10 lines of a file in the task's working directory."""
-        # pylint: disable=C3001
-        formatter = lambda message: self._format_list_of_lines(
-            message, filename, sep="\n", endl="")
+        def formatter(message):
+            return self._format_list_of_lines(
+                message, filename, sep="\n", endl="\n")
         return await self._file_operation(Operations.TAIL,
                                           formatter=formatter,
                                           filename=filename)


### PR DESCRIPTION
This PR uses the status sent by the file-tracker and prints the fail message to the user. 