### PR TITLE
Export output files of a task to a remote URL

### DIFF
--- a/inductiva/storage/__init__.py
+++ b/inductiva/storage/__init__.py
@@ -1,2 +1,2 @@
 """Storage related functions."""
-from .storage import get_space_used, listdir, upload, upload_from_url, remove_workspace
+from .storage import get_space_used, listdir, upload, upload_from_url, remove_workspace, export, StorageOperation

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -1,4 +1,5 @@
 """Methods to interact with the user storage resources."""
+import time
 import logging
 import os
 import tqdm
@@ -8,14 +9,14 @@ import urllib
 import inductiva
 from inductiva import constants
 from inductiva.api import methods
-from inductiva.client import exceptions
+from inductiva.client import exceptions, models
 from inductiva.client.apis.tags import storage_api
 from inductiva.utils import format_utils
 
 
 def _print_storage_size_and_cost() -> int:
     """ Print the storage size and cost.
-    
+
     return the storage size in bytes.
     """
     api = storage_api.StorageApi(inductiva.api.get_client())
@@ -134,12 +135,12 @@ def upload_from_url(
     Upload a file from a given URL to a specified remote directory.
 
     If no file name is provided, the function extracts the name from the URL.
-    
+
     Args:
-        url (str): The URL of the file to be uploaded. 
+        url (str): The URL of the file to be uploaded.
         remote_dir (str): The path to the remote directory where the file will
             be stored.
-        file_name (str, optional): The name to save the uploaded file as. 
+        file_name (str, optional): The name to save the uploaded file as.
             If not specified, the name will be extracted from the URL.
     """
     api_instance = storage_api.StorageApi(inductiva.api.get_client())
@@ -266,3 +267,59 @@ def remove_workspace(remote_dir) -> bool:
         remote_dir = remote_dir + "/"
     api.delete_file(query_params={"path": remote_dir},)
     logging.info("Workspace file(s) removed successfully.")
+
+
+class StorageOperation():
+    def __init__(self, api, id):
+        self._api = api
+        self.id = id
+
+    def _update_from_api_response(self, response):
+        self._name = response["name"]
+        self._status = response["status"]
+        self._attributes = response["attributes"]
+        self._start_time = response["start_time"]
+        self._end_time = response["end_time"]
+        self._error_message = response["error_message"]
+
+    @classmethod
+    def from_api_response(cls, api, response):
+
+        op = cls(api, response["id"])
+
+        op._update_from_api_response(
+            response,
+        )
+        return op
+
+    def _refresh(self):
+        resp = self._api.get_operation(
+            path_params={"operation_id": self.id}).body
+
+        self._update_from_api_response(resp)
+
+    def wait(self):
+        while self._status == models.OperationStatus.RUNNING:
+            self._refresh()
+            time.sleep(2)
+
+        if self._status == models.OperationStatus.FAILED:
+            logging.error(f"Operation failed: {self._error_message}")
+        else:
+            logging.info(f"Operation completed successfully.")
+
+        return self._status
+
+
+def export(path: str, dest_url: str) -> StorageOperation:
+    api = storage_api.StorageApi(inductiva.api.get_client())
+    resp = api.export_files(body={
+        "path": path,
+        "dest_url": dest_url,
+    })
+
+    logging.info("Started export operation ...")
+    operation = StorageOperation.from_api_response(api, resp.body)
+
+    return operation
+

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from ..localization import translator as __
 
 import inductiva
+from inductiva import storage
 from inductiva import constants
 from inductiva.client import exceptions, models
 from inductiva import api
@@ -90,6 +91,8 @@ class TaskInfo:
         self.status_alias = None
         self.simulator = None
         self.storage_path = None
+        self.storage_input_path = None
+        self.storage_output_path = None
         self.container_image = None
         self.project = None
         self.create_time = None
@@ -1229,7 +1232,7 @@ class Task:
 
     def remove_remote_files(self, verbose: bool = True) -> bool:
         """Removes all files associated with the task from remote storage.
-        
+
         Returns:
             True if the files were removed successfully, False otherwise.
         """
@@ -1271,3 +1274,17 @@ class Task:
 
     def print_summary(self, fhandle=sys.stdout):
         print(self._get_summary(), file=fhandle)
+
+    def export_output(self, dest_url: str, wait: bool = True) -> storage.StorageOperation:
+        """Export the output files of the task to a remote storage location.
+
+        Args:
+            dest_url: URL of the location to store the output files.
+            wait: Whether to wait for the operation to complete.
+        """
+        operation = inductiva.storage.export(self.get_info().storage_output_path, dest_url)
+
+        if wait:
+            operation.wait()
+
+        return operation

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -1275,14 +1275,24 @@ class Task:
     def print_summary(self, fhandle=sys.stdout):
         print(self._get_summary(), file=fhandle)
 
-    def export_output(self, dest_url: str, wait: bool = True) -> storage.StorageOperation:
-        """Export the output files of the task to a remote storage location.
+    def export_output(
+        self,
+        dest_url: str,
+        wait: bool = True,
+    ) -> storage.StorageOperation:
+        """Export the output files ZIP of the task to a remote storage location.
 
         Args:
-            dest_url: URL of the location to store the output files.
+            dest_url: URL to upload the output files. The output ZIP will be
+                uploaded via an HTTP PUT request.
             wait: Whether to wait for the operation to complete.
         """
-        operation = inductiva.storage.export(self.get_info().storage_output_path, dest_url)
+        output_path = self.get_info().storage_output_path
+        if output_path is None:
+            raise RuntimeError(
+                "Can't determine the path to the output files to export task.")
+
+        operation = inductiva.storage.export(output_path, dest_url)
 
         if wait:
             operation.wait()


### PR DESCRIPTION
Adds a method to export the output files of a task to a remote storage location.

### Usage:

To export an arbitrary file from inductiva storage:
```python
operation = inductiva.storage.export("path/in/inductiva/storage", "https://www.signedurl.com")
operation.wait()
```

To export the output ZIP of a task:
```python
task = inductiva.tasks.Task(task_id)
task.export_output("https://www.signedurl.com", wait=True)
```

### Current limitations:

- Only works with individual files and https URLs. 
- If the provided URL is an AWS S3 URL, there's a 5Gb limit (on AWS side) on the upload size.

