### PR TITLE
Fixed bug with kwargs on simulators

### DIFF
--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -58,12 +58,12 @@ class AmrWind(simulators.Simulator):
             remote_assets: Additional remote files that will be copied to
                 the simulation directory.
         """
-
-        kwargs["use_hwthread_cpus"] = use_hwthread
+        mpi_kwargs={}
+        mpi_kwargs["use_hwthread_cpus"] = use_hwthread
         if n_vcpus is not None:
-            kwargs["np"] = n_vcpus
+            mpi_kwargs["np"] = n_vcpus
 
-        mpi_config = MPIConfig(version="4.1.6", **kwargs)
+        mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
         commands = [
             Command(f"amr_wind {sim_config_filename}", mpi_config=mpi_config)
         ]

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -58,7 +58,7 @@ class AmrWind(simulators.Simulator):
             remote_assets: Additional remote files that will be copied to
                 the simulation directory.
         """
-        mpi_kwargs={}
+        mpi_kwargs = {}
         mpi_kwargs["use_hwthread_cpus"] = use_hwthread
         if n_vcpus is not None:
             mpi_kwargs["np"] = n_vcpus

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -56,7 +56,7 @@ class CaNS(simulators.Simulator):
                 the simulation directory.
             other arguments: See the documentation of the base class.
         """
-        mpi_kwargs={}
+        mpi_kwargs = {}
         mpi_kwargs["use_hwthread_cpus"] = use_hwthread
         if n_vcpus is not None:
             mpi_kwargs["np"] = n_vcpus

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -56,12 +56,12 @@ class CaNS(simulators.Simulator):
                 the simulation directory.
             other arguments: See the documentation of the base class.
         """
-
-        kwargs["use_hwthread_cpus"] = use_hwthread
+        mpi_kwargs={}
+        mpi_kwargs["use_hwthread_cpus"] = use_hwthread
         if n_vcpus is not None:
-            kwargs["np"] = n_vcpus
+            mpi_kwargs["np"] = n_vcpus
 
-        mpi_config = MPIConfig(version="4.1.6", **kwargs)
+        mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
         commands = [
             Command(f"cans {sim_config_filename}", mpi_config=mpi_config)
         ]

--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -55,12 +55,12 @@ class FDS(simulators.Simulator):
                 using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
         """
-
-        kwargs["use_hwthread_cpus"] = use_hwthread
+        mpi_kwargs = {}
+        mpi_kwargs["use_hwthread_cpus"] = use_hwthread
         if n_vcpus is not None:
-            kwargs["np"] = n_vcpus
+            mpi_kwargs["np"] = n_vcpus
 
-        mpi_config = MPIConfig(version="4.1.6", **kwargs)
+        mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
         commands = [
             Command(
                 "/opt/fds/Build/ompi_gnu_linux/fds_ompi_gnu_linux "

--- a/inductiva/simulators/fvcom.py
+++ b/inductiva/simulators/fvcom.py
@@ -100,12 +100,12 @@ class FVCOM(simulators.Simulator):
             model = f"_{model.lower()}"
 
         cmd = f"fvcom{model} {case_name} {create_namelist} --dbg={debug}"
-
-        kwargs["use_hwthread_cpus"] = use_hwthread
+        mpi_kwargs = {}
+        mpi_kwargs["use_hwthread_cpus"] = use_hwthread
         if n_vcpus is not None:
-            kwargs["np"] = n_vcpus
+            mpi_kwargs["np"] = n_vcpus
 
-        mpi_config = MPIConfig(version="4.1.6", **kwargs)
+        mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
         commands = [Command(cmd, mpi_config=mpi_config)]
 
         return super().run(input_dir,

--- a/inductiva/simulators/nwchem.py
+++ b/inductiva/simulators/nwchem.py
@@ -56,12 +56,12 @@ class NWChem(simulators.Simulator):
             remote_assets: Additional remote files that will be copied to
                 the simulation directory.
         """
-
-        kwargs["use_hwthread_cpus"] = use_hwthread
+        mpi_kwargs = {}
+        mpi_kwargs["use_hwthread_cpus"] = use_hwthread
         if n_vcpus is not None:
-            kwargs["np"] = n_vcpus
+            mpi_kwargs["np"] = n_vcpus
 
-        mpi_config = MPIConfig(version="4.1.6", **kwargs)
+        mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
         commands = [
             Command(f"nwchem {sim_config_filename}", mpi_config=mpi_config)
         ]

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -55,12 +55,12 @@ class REEF3D(simulators.Simulator):
                 the simulation directory.
             other arguments: See the documentation of the base class.
         """
-
-        kwargs["use_hwthread_cpus"] = use_hwthread
+        mpi_kwargs = {}
+        mpi_kwargs["use_hwthread_cpus"] = use_hwthread
         if n_vcpus is not None:
-            kwargs["np"] = n_vcpus
+            mpi_kwargs["np"] = n_vcpus
 
-        mpi_config = MPIConfig(version="4.1.6", **kwargs)
+        mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
         commands = [
             "/DIVEMesh/bin/DiveMESH",
             Command("/REEF3D/bin/REEF3D", mpi_config=mpi_config)

--- a/inductiva/simulators/schism.py
+++ b/inductiva/simulators/schism.py
@@ -54,12 +54,12 @@ class SCHISM(simulators.Simulator):
             remote_assets: Additional remote files that will be copied to
                 the simulation directory.
         """
-
-        kwargs["use_hwthread_cpus"] = use_hwthread
+        mpi_kwargs = {}
+        mpi_kwargs["use_hwthread_cpus"] = use_hwthread
         if n_vcpus is not None:
-            kwargs["np"] = n_vcpus
+            mpi_kwargs["np"] = n_vcpus
 
-        mpi_config = MPIConfig(version="4.1.6", **kwargs)
+        mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
 
         commands = [
             "mkdir -p outputs",

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -98,12 +98,12 @@ class SWAN(simulators.Simulator):
         # works with clusters
         elif command == "swan.exe":
 
-            kwargs = {}
+            mpi_kwargs = {}
             if n_vcpus is not None:
-                kwargs["np"] = n_vcpus
-            kwargs["use_hwthread_cpus"] = use_hwthread
+                mpi_kwargs["np"] = n_vcpus
+            mpi_kwargs["use_hwthread_cpus"] = use_hwthread
 
-            mpi_config = MPIConfig(version="4.1.6", **kwargs)
+            mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
             swan_exe_command = Command(f"swan.exe {sim_config_filename}",
                                        mpi_config=mpi_config)
             commands.append(swan_exe_command)

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -95,12 +95,12 @@ class SWASH(simulators.Simulator):
         # works with clusters
         elif command == "swash.exe":
 
-            kwargs = {}
+            mpi_kwargs = {}
             if n_vcpus is not None:
-                kwargs["np"] = n_vcpus
-            kwargs["use_hwthread_cpus"] = use_hwthread
+                mpi_kwargs["np"] = n_vcpus
+            mpi_kwargs["use_hwthread_cpus"] = use_hwthread
 
-            mpi_config = MPIConfig(version="4.1.6", **kwargs)
+            mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
             swash_exe_command = Command(f"swash.exe {sim_config_filename}",
                                         mpi_config=mpi_config)
             commands.append(swash_exe_command)

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -56,11 +56,12 @@ class XBeach(simulators.Simulator):
                 the simulation directory.
             other arguments: See the documentation of the base class.
         """
-        kwargs["use_hwthread_cpus"] = use_hwthread
+        mpi_kwargs = {}
+        mpi_kwargs["use_hwthread_cpus"] = use_hwthread
         if n_vcpus is not None:
-            kwargs["np"] = n_vcpus
+            mpi_kwargs["np"] = n_vcpus
 
-        mpi_config = MPIConfig(version="4.1.6", **kwargs)
+        mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
         commands = [
             Command(f"xbeach {sim_config_filename}", mpi_config=mpi_config)
         ]


### PR DESCRIPTION
kwargs was already being used by the simulator as an argument and i was also using kwargs as a dict for the mpiconfig. This was resulting in any extra named argument to the simulator to be passed as a flag to the mpiconfig.