### PR TITLE
Distinguish user-agent of the requests

### DIFF
--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -98,6 +98,7 @@ def get_api_agent():
         return f"CLI/{__version__}/python"
     return f"Client/{__version__}/python"
 
+
 def compare_client_and_backend_versions(client_version: str):
     """ Compares the provided client version 7with the backend API version.
 
@@ -114,12 +115,11 @@ def compare_client_and_backend_versions(client_version: str):
     - RuntimeError: If the API cannot be reached, or if the client version is
       incompatible with the backend version, or for other general failures.
     """
-    
+
     api_config = Configuration(host=api_url)
 
     with get_client(api_config) as client:
         api_instance = VersionApi(client)
-        client.user_agent = get_api_agent()
         query_params = {"client_version": client_version}
 
         try:

--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -10,6 +10,7 @@ from inductiva.client.configuration import Configuration
 from inductiva.client.exceptions import ApiException
 from inductiva._cli.cmd_user.info import get_info
 from inductiva.client.api_client import ApiClient
+from inductiva.api.methods import get_client
 
 from . import simulators
 from . import resources
@@ -92,6 +93,11 @@ def _set_key_and_check_version():
 _check_for_available_package_update()
 
 
+def get_api_agent():
+    if logs.is_cli():
+        return f"CLI/{__version__}/python"
+    return f"Client/{__version__}/python"
+
 def compare_client_and_backend_versions(client_version: str):
     """ Compares the provided client version 7with the backend API version.
 
@@ -108,10 +114,12 @@ def compare_client_and_backend_versions(client_version: str):
     - RuntimeError: If the API cannot be reached, or if the client version is
       incompatible with the backend version, or for other general failures.
     """
+    
     api_config = Configuration(host=api_url)
 
-    with ApiClient(api_config) as client:
+    with get_client(api_config) as client:
         api_instance = VersionApi(client)
+        client.user_agent = get_api_agent()
         query_params = {"client_version": client_version}
 
         try:

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -34,12 +34,17 @@ def get_api_config() -> Configuration:
     return api_config
 
 
-def get_client() -> ApiClient:
+def get_client(api_config: Configuration = None) -> ApiClient:
     """Returns an ApiClient instance."""
-    api_config = get_api_config()
 
-    return ApiClient(api_config)
+    if api_config is None:
+        api_config = get_api_config()
 
+    client = ApiClient(api_config)
+
+    client.user_agent = inductiva.get_api_agent()
+
+    return client
 
 def submit_request(api_instance: TasksApi,
                    request: TaskRequest) -> TaskSubmittedInfo:
@@ -424,14 +429,12 @@ def invoke_async_api(simulator: str,
         Returns the task id.
     """
 
-    api_config = get_api_config()
-
     request_params = get_validate_request_params(
         original_params=params,
         type_annotations=type_annotations,
     )
-
-    with ApiClient(api_config) as client:
+    
+    with get_client() as client:
         api_instance = TasksApi(client)
 
         task_id = submit_task(api_instance=api_instance,

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -46,6 +46,7 @@ def get_client(api_config: Configuration = None) -> ApiClient:
 
     return client
 
+
 def submit_request(api_instance: TasksApi,
                    request: TaskRequest) -> TaskSubmittedInfo:
     """Submits a task request to the API.
@@ -433,7 +434,7 @@ def invoke_async_api(simulator: str,
         original_params=params,
         type_annotations=type_annotations,
     )
-    
+
     with get_client() as client:
         api_instance = TasksApi(client)
 

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -34,7 +34,7 @@ def get_api_config() -> Configuration:
     return api_config
 
 
-def get_client(api_config: Configuration = None) -> ApiClient:
+def get_client(api_config: Optional[Configuration] = None) -> ApiClient:
     """Returns an ApiClient instance."""
 
     if api_config is None:

--- a/inductiva/tasks/methods.py
+++ b/inductiva/tasks/methods.py
@@ -4,12 +4,11 @@ import json
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Union
 
 import inductiva
-from inductiva import api
 from inductiva import projects
 from inductiva.client import models
 from inductiva.tasks.task import Task
 from inductiva.utils import format_utils
-from inductiva.client import ApiClient, ApiException
+from inductiva.client import ApiException
 from inductiva.client.apis.tags.tasks_api import TasksApi
 
 

--- a/inductiva/tasks/methods.py
+++ b/inductiva/tasks/methods.py
@@ -69,7 +69,6 @@ def _fetch_tasks_from_api(
 
     Tags can be filtered by a status. Results are paginated indexed from 1.
     """
-    
 
     with inductiva.api.methods.get_client() as client:
         api_instance = TasksApi(client)

--- a/inductiva/tasks/methods.py
+++ b/inductiva/tasks/methods.py
@@ -69,9 +69,9 @@ def _fetch_tasks_from_api(
 
     Tags can be filtered by a status. Results are paginated indexed from 1.
     """
-    api_config = api.get_api_config()
+    
 
-    with ApiClient(api_config) as client:
+    with inductiva.api.methods.get_client() as client:
         api_instance = TasksApi(client)
 
         query_params = {

--- a/inductiva/users/methods.py
+++ b/inductiva/users/methods.py
@@ -10,9 +10,8 @@ from inductiva.client.apis.tags.users_api import UsersApi
 def _fetch_quotas_from_api() -> Dict[str, Dict[str, Any]]:
     """Get information about a user's quotas.
     """
-    api_config = api.get_api_config()
 
-    with ApiClient(api_config) as client:
+    with api.get_client() as client:
         api_instance = UsersApi(client)
 
         resp = api_instance.get_user_quotas(skip_deserialization=True).response
@@ -44,8 +43,7 @@ def get_info() -> Dict[str, Any]:
         Dict with the user information.
     """
 
-    api_config = api.get_api_config()
-    with (ApiClient(api_config)) as client:
+    with api.get_client() as client:
         api_instance = UsersApi(client)
         request = api_instance.get_user_info()
     return request.body
@@ -69,8 +67,7 @@ def get_costs(start_year: int,
         raise ValueError("If end_month is provided, "
                          "end_year must also be provided.")
 
-    api_config = api.get_api_config()
-    with (ApiClient(api_config)) as client:
+    with api.get_client() as client:
         api_instance = UsersApi(client)
 
         query_params = {"start_year": start_year, "start_month": start_month}

--- a/inductiva/users/methods.py
+++ b/inductiva/users/methods.py
@@ -3,7 +3,6 @@ import json
 from typing import Any, Dict
 
 from inductiva import api
-from inductiva.client import ApiClient
 from inductiva.client.apis.tags.users_api import UsersApi
 
 


### PR DESCRIPTION
We now change the user_agent of the  api_client based if the user is using the cli vs a script.

We also did a minor refactoring. Some places where using the `get_client` method and other places where creating the `ApiClient` by hand. I changed the code to use `get_client` everywhere and by doing so I only have to change the user_agent in one place.

Issue: https://github.com/inductiva/tasks/issues/655