### PR TITLE
Updated Reuse Files tutorial with the feature to reference output of other tasks

### DIFF
--- a/tutorials/how_to/index.md
+++ b/tutorials/how_to/index.md
@@ -15,6 +15,6 @@ manage_tasks
 run-parallel_simulations
 set-up-elastic-machine-group
 set-up-mpi-cluster
-reuse-input-files
+reuse-files
 run-benchmarks
 ```

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -94,7 +94,7 @@ how_to/set-up-mpi-cluster
 how_to/manage-remote-storage
 how_to/manage_tasks
 how_to/manage_and_retrieve_results
-how_to/reuse-input-files
+how_to/reuse-files
 how_to/run-benchmarks
 
 ```


### PR DESCRIPTION
This PR documents the ability to reference files from other tasks outputs to the existing Reuse Input Files Across Multiple Simulations tutorial.

I renamed the existing tutorial as Reuse Files Across Multiple Simulations since now it is also possible to reuse output files.