### PR TITLE
Remove aiortc dependency

### DIFF
--- a/inductiva/tasks/file_tracker.py
+++ b/inductiva/tasks/file_tracker.py
@@ -3,14 +3,21 @@ import asyncio
 import json
 import uuid
 import enum
-import aiortc
 import logging
 
+aiortc_imported = True
+
+try:
+    import aiortc
+except ImportError:
+    aiortc_imported = False
+
 # STUN/TURN server configuration
-ICE_SERVERS = [
-    aiortc.RTCIceServer("stun:webrtc.inductiva.ai:3478"),
-    aiortc.RTCIceServer("turn:webrtc.inductiva.ai:3478")
-]
+if aiortc_imported:
+    ICE_SERVERS = [
+        aiortc.RTCIceServer("stun:webrtc.inductiva.ai:3478"),
+        aiortc.RTCIceServer("turn:webrtc.inductiva.ai:3478")
+    ]
 
 aiortc_logger = logging.getLogger("aioice")
 aiortc_logger.setLevel(logging.WARNING)
@@ -25,6 +32,9 @@ class FileTracker:
     """File Tracker class for connecting to a running task via WebRTC."""
 
     def __init__(self):
+        if not aiortc_imported:
+            raise NotImplementedError("Feature not available for this version.")
+
         self.pc = aiortc.RTCPeerConnection(
             aiortc.RTCConfiguration(iceServers=ICE_SERVERS))
         self._message = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
   fsspec
   requests
   aiohttp
+  aiortc; python_version < '3.13'
 
 [options.package_data]
 inductiva = assets/**

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ install_requires =
   fsspec
   requests
   aiohttp
-  aiortc
 
 [options.package_data]
 inductiva = assets/**


### PR DESCRIPTION
This PR removes the aiortc dependency for python versions greater or equal to 3.13. Related to inductiva/tasks#661. File-tracking feature is still "available" for versions below 3.13