### PR TITLE
First turn off machine and download outputs after

### DIFF
--- a/examples/amr_wind/amr_wind.py
+++ b/examples/amr_wind/amr_wind.py
@@ -21,8 +21,8 @@ task = amr_wind.run(input_dir=input_dir,
                     n_vcpus=4)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/cans/cans.py
+++ b/examples/cans/cans.py
@@ -21,8 +21,8 @@ task = cans.run(input_dir=input_dir,
                 n_vcpus=4)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/dualsphysics/dualsphysics.py
+++ b/examples/dualsphysics/dualsphysics.py
@@ -27,8 +27,8 @@ task = dualsphysics.run(input_dir=input_dir,
                         on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/fds/fds.py
+++ b/examples/fds/fds.py
@@ -18,8 +18,8 @@ task = fds.run(input_dir=input_dir,
                on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/fvcom/fvcom.py
+++ b/examples/fvcom/fvcom.py
@@ -23,8 +23,8 @@ task = fvcom.run(input_dir=input_dir,
                  on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/gromacs/gromacs.py
+++ b/examples/gromacs/gromacs.py
@@ -30,8 +30,8 @@ gromacs = inductiva.simulators.GROMACS()
 task = gromacs.run(input_dir=input_dir, commands=commands, on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/nwchem/nwchem.py
+++ b/examples/nwchem/nwchem.py
@@ -18,8 +18,8 @@ task = nwchem.run(input_dir=input_dir,
                   on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/openfast/openfast.py
+++ b/examples/openfast/openfast.py
@@ -21,8 +21,8 @@ openfast = inductiva.simulators.OpenFAST()
 task = openfast.run(input_dir=input_dir, commands=commands, on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/openfoam_esi/openfoam_esi.py
+++ b/examples/openfoam_esi/openfoam_esi.py
@@ -20,8 +20,8 @@ task = openfoam.run(input_dir=input_dir,
                     on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/openfoam_foundation/openfoam_foundation.py
+++ b/examples/openfoam_foundation/openfoam_foundation.py
@@ -20,6 +20,6 @@ task = openfoam.run(input_dir=input_dir,
                     on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()

--- a/examples/quantum_espresso/quantum_espresso.py
+++ b/examples/quantum_espresso/quantum_espresso.py
@@ -28,8 +28,8 @@ qe = inductiva.simulators.QuantumEspresso()
 task = qe.run(input_dir, commands=commands, on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/reef3d/reef3d.py
+++ b/examples/reef3d/reef3d.py
@@ -15,8 +15,8 @@ reef3d = inductiva.simulators.REEF3D()
 task = reef3d.run(input_dir=input_dir, on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/schism/schism.py
+++ b/examples/schism/schism.py
@@ -20,8 +20,8 @@ task = schism.run(input_dir=input_dir,
                   on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/splishsplash/splishsplash.py
+++ b/examples/splishsplash/splishsplash.py
@@ -18,8 +18,8 @@ task = splishsplash.run(input_dir=input_dir,
                         on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/swan/swan.py
+++ b/examples/swan/swan.py
@@ -32,8 +32,8 @@ task = swan.run(input_dir=input_dir,
 
 # Wait for the simulation to finish and download the results
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/swash/swash.py
+++ b/examples/swash/swash.py
@@ -22,8 +22,8 @@ task = swash.run(input_dir=input_dir,
                  on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/examples/xbeach/xbeach.py
+++ b/examples/xbeach/xbeach.py
@@ -20,8 +20,8 @@ task = xbeach.run(input_dir=input_dir,
                   on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 
 task.print_summary()

--- a/tutorials/generating-synthetic-data/synthetic-data-generation-2.md
+++ b/tutorials/generating-synthetic-data/synthetic-data-generation-2.md
@@ -117,10 +117,10 @@ task = splishsplash.run(input_dir=input_dir,
 
 # Wait for the simulation to complete and download the outputs
 task.wait()
-task.download_outputs()
-
 # Terminate the machine group
 machine_group.terminate()
+
+task.download_outputs()
 ```
 This script will upload the input data from our local directory to the API server and schedule a simulation `task` for execution. We will be able check details about the `task`, including its ID and the machine group assigned for its computation, by observing the stdout of your terminal:
 

--- a/tutorials/generating-synthetic-data/synthetic-data-generation-3.md
+++ b/tutorials/generating-synthetic-data/synthetic-data-generation-3.md
@@ -108,10 +108,11 @@ task = splishsplash.run(input_dir=input_dir,
                         on=my_machine_group)
 
 task.wait()
-task.download_outputs()
 
 # Terminate the machine group
 my_machine_group.terminate()
+
+task.download_outputs()
 ```
 
 Notice the significant reduction in runtime for this simulation: down from 30m to just **10m07s**, achieving an approximately 3-fold increase in speed! Remember that, in practice, speed ups are not linear with the number of vCPUs, so this is already quite an achievement with just a few lines of code.

--- a/tutorials/generating-synthetic-data/synthetic-data-generation-4.md
+++ b/tutorials/generating-synthetic-data/synthetic-data-generation-4.md
@@ -122,11 +122,12 @@ task = SPlisHSPlasH.run(input_dir=rendered_dir,
 
 # Wait for the simulation task to complete and download the results
 task.wait()
-task.download_outputs()
 
 # Ensure that the allocated resources are terminated
 # This is crucial to avoid incurring unnecessary costs from lingering resources
 machine_group.terminate()
+
+task.download_outputs()
 ```
 
 The result looks something like this:

--- a/tutorials/simulators/CustomImage.md
+++ b/tutorials/simulators/CustomImage.md
@@ -34,9 +34,9 @@ task = custom_simulator.run(input_dir=input_dir, commands=["fds mccaffrey.fds"],
                             on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 ```
 
 This basic example demonstrates how to run a custom Docker image. To leverage
@@ -70,9 +70,9 @@ task = custom_simulator.run(input_dir=input_dir, commands=[command],
                             on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 ```
 
 This example runs four instances of your image with the command `fds mccaffrey.fds`
@@ -102,9 +102,9 @@ task = custom_simulator.run(input_dir=input_dir, commands=[command],
                             on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 ```
 
 This runs:

--- a/tutorials/simulators/FVCOM.md
+++ b/tutorials/simulators/FVCOM.md
@@ -57,9 +57,9 @@ task = fvcom.run( input_dir=input_dir,
                   on=machine_group)
 
 task.wait()
-task.download_outputs()
-
 machine_group.terminate()
+
+task.download_outputs()
 ```
 
 ## Example Code

--- a/tutorials/simulators/OpenFOAM.md
+++ b/tutorials/simulators/OpenFOAM.md
@@ -129,8 +129,8 @@ task = openfoam.run(
             on=machine_group)
 
 task.wait()
-task.download_outputs()
 machine_group.terminate()
+task.download_outputs()
 
 task.print_summary()
 
@@ -193,21 +193,21 @@ We now have all we need to run our simulation.
                on=machine_group)
    ```
 
-2. **Wait and Download Outputs**:
+2. **Wait**:
 That is it. Our simulation is now running on the cloud. We can `wait` for the
 simulation to be over, or we can turn our computer off go for a coffe (☕️).
    ```python
    task.wait()
-   task.download_outputs()
    ```
 
-3. **Terminate Machine**:
+3. **Terminate Machine and download outputs**:
 Once our simulation is over we can/should terminate our machine to save on costs.
 If you forget, dont worry we got your back. By default, a machine will be
 automaticly terminated if no simulation runs on it for 30 minutes.
 
    ```python
    machine_group.terminate()
+   task.download_outputs()
    ```
 
 4. **Check your simulation summary**:


### PR DESCRIPTION
This PR changes the order of terminating machine and download outputs for our examples.

The download can take a while, so we first turn of the VM to save costs.

Issue https://github.com/inductiva/tasks/issues/688