### PR TITLE
Set ```wait_for_quotas=True``` by default

### DIFF
--- a/docs/intro_to_api/benchmarking.md
+++ b/docs/intro_to_api/benchmarking.md
@@ -64,7 +64,7 @@ Adds a new run to the benchmark. This allows you to specify the simulation param
 ##### **`run`**
 
 ```py
-run(num_repeats: int = 2, wait_for_quotas: bool = False) -> Self
+run(num_repeats: int = 2, wait_for_quotas: bool = True) -> Self
 ```
 
 Runs all the added benchmarking simulations. Each simulation can be repeated multiple times.

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -126,7 +126,7 @@ class Benchmark(projects.Project):
         ))
         return self
 
-    def run(self, num_repeats: int = 2, wait_for_quotas: bool = False) -> Self:
+    def run(self, num_repeats: int = 2, wait_for_quotas: bool = True) -> Self:
         """
         Executes all added runs.
 
@@ -140,7 +140,7 @@ class Benchmark(projects.Project):
                 become available before starting each resource. If `True`, the 
                 program will actively wait in a loop, periodically sleeping and 
                 checking for quotas. If `False`, the program crashes if quotas 
-                are not available (default is `False`).
+                are not available (default is `True`).
 
         Returns:
             Self: The current instance for method chaining.


### PR DESCRIPTION
@catarinalegria encountered the problem of hitting the quota limits again while running a benchmark from the tutorials. This is due to the limits being low, which may also affect new users. It would be better to set ```wait_for_quotas=True``` by default, as you suggested earlier, @Pbarbosa92, to prevent raising an exception on the client side.