### PR TITLE
Update Resource Type value on tasks list

### DIFF
--- a/inductiva/tasks/methods.py
+++ b/inductiva/tasks/methods.py
@@ -43,8 +43,12 @@ def to_dict(list_of_tasks: Iterable[Task]) -> Mapping[str, List[Any]]:
         if task.info.executer is None:
             resource_type = None
         else:
+            if task.info.executer.vm_type == "n/a":
+                vm_type = task.info.executer.vm_name
+            else:
+                vm_type = task.info.executer.vm_type
             resource_type = (f"{task.info.executer.host_type} "
-                             f"{task.info.executer.vm_type}")
+                             f"{vm_type}")
             if task.info.executer.n_mpi_hosts > 1:
                 resource_type += f" x{task.info.executer.n_mpi_hosts}"
 


### PR DESCRIPTION
Related to https://github.com/inductiva/tasks/issues/690#issuecomment-2586860349

Resource type was showing `LOCAL n/a` for example, on tasks list.
Now it shows `vm_name` instead `vm_type`, if `vm_type === n/a`