### PR TITLE
Handle null `max_idle_time` and `auto_terminate_ts` for local machine groups

### DIFF
--- a/inductiva/_cli/cmd_resources/list.py
+++ b/inductiva/_cli/cmd_resources/list.py
@@ -118,11 +118,15 @@ def _machine_group_list_to_str(machine_group_list) -> str:
             if isinstance(machine_group, resources.MPICluster):
                 resource_type = machines_base.ResourceType.MPI.value
         num_active_machines = machine_group.active_machines_to_str()
+
+        idle_time = f"{machine_group.idle_time}"
+        if machine_group.max_idle_time:
+            idle_time += f"/{machine_group.max_idle_time}"
+
         rows.append([
             machine_group.name, machine_group.machine_type, is_elastic,
             resource_type, num_active_machines, machine_group.data_disk_gb,
-            spot, machine_group.create_time,
-            f"{machine_group.idle_time}/{machine_group.max_idle_time}",
+            spot, machine_group.create_time, idle_time,
             machine_group.quota_usage.get("max_price_hour")
         ])
 

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -157,7 +157,7 @@ class BaseMachineGroup(ABC):
     @property
     def available_vcpus(self):
         """Returns the maximum number of vCPUs that can be used on a task.
-        
+
         On a machine group with 2 machines, each with 4 vCPUs, this will return
         4.
         On an elastic machine group, this will also return 4.
@@ -199,8 +199,7 @@ class BaseMachineGroup(ABC):
     def _seconds_to_timedelta(
             value: Optional[float] = None) -> Optional[datetime.timedelta]:
         """Converts seconds to a timedelta object."""
-        return datetime.timedelta(
-            seconds=float(value)) if value is not None else None
+        return datetime.timedelta(seconds=float(value)) if value else None
 
     @staticmethod
     def _convert_auto_terminate_ts(
@@ -234,8 +233,11 @@ class BaseMachineGroup(ABC):
             timestamp: Optional[str]) -> Optional[datetime.datetime]:
         """Converts an ISO format string back to a datetime object. It ensures
         the datetime is timezone aware."""
-        if timestamp is not None:
+        if timestamp:
             dt = datetime.datetime.fromisoformat(str(timestamp))
+            if dt.year == 9999:
+                return None
+
             if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
                 raise ValueError("The datetime string must be timezone aware.")
             return dt


### PR DESCRIPTION
To avoid breaking changes, and since the client was not handling null values correctly, the API is sending 0 instead of null 
 for `max_idle_time`, and `datetime.datetime.max` instead of null for `auto_terminate_ts`. 
This PR updates the client to handle null values correctly, so that later we can have the API sending the appropriate null values without breaking the client.