### PR TITLE
Add task-runner tutorial to index

### DIFF
--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -96,7 +96,7 @@ how_to/manage_tasks
 how_to/manage_and_retrieve_results
 how_to/reuse-files
 how_to/run-benchmarks
-
+how_to/use-local-task-runner
 ```
 
 ```{toctree}


### PR DESCRIPTION
This PR adds the task-runner tutorial to the index in the parent folder. 