### PR TITLE
Add context about storage costs

### DIFF
--- a/tutorials/how_to/use-local-task-runner.md
+++ b/tutorials/how_to/use-local-task-runner.md
@@ -1,6 +1,6 @@
 # Use the Local Task-Runner
 
-The local task-runner allows you to execute simulations on your own computer. This feature is particularly useful for testing and running simulations at minimal cost, as you only pay for storage while utilizing your local computational resources for free.
+The local task-runner allows you to execute simulations on your own computer. This feature is particularly useful for testing and running simulations at minimal cost, as you only pay for storage while utilizing your local computational resources for free. The storage costs come from saving the simulation inputs and results in the cloud for future access.
 
 In this tutorial, we’ll guide you through setting up and using the local task-runner to execute simulations. By the end of this tutorial, you’ll know how to configure, launch, and run simulations locally with ease.
 

--- a/tutorials/how_to/use-local-task-runner.md
+++ b/tutorials/how_to/use-local-task-runner.md
@@ -73,6 +73,20 @@ If you don’t specify a hostname, it defaults to your computer’s name.
 
 The task-runner is limited to one instance per computer, but you can add multiple task-runners to the same machine group.
 
+### Run the Task-Runner in background
+
+If you wish to run the task-runner in background the `--detach` flag can be useful:
+
+```bash
+$ inductiva task-runner launch <machine-group-name> --detach
+```
+This command will start the task-runner in the background, allowing you to close your SSH connection without interrupting the process.
+
+To terminate a task-runner running in background, use the `remove` command:
+```bash
+$ inductiva task-runner remove
+```
+
 ## Step 2: Run a Simulation Locally
 Once the task-runner is active, you can run simulations on your local machine. Below is an example using the GROMACS simulator.
 

--- a/tutorials/how_to/use-local-task-runner.md
+++ b/tutorials/how_to/use-local-task-runner.md
@@ -80,7 +80,7 @@ If you wish to run the task-runner in background the `--detach` flag can be usef
 ```bash
 $ inductiva task-runner launch <machine-group-name> --detach
 ```
-This command will start the task-runner in the background, allowing you to close your SSH connection without interrupting the process.
+This command will start the task-runner in background, allowing you to close your SSH connection without interrupting the process.
 
 To terminate a task-runner running in background, use the `remove` command:
 ```bash


### PR DESCRIPTION
This PR adds a sentence to the tutorial expaining the storage costs associated with running simulations on the local task-runner.

EDIT: Added a new paragraph explaining how to use the `--detach` flag