### PR TITLE
Installation instructions on README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 # Inductiva: a Python package for scaling simulations on the Cloud
 
 
-Welcome to the official Python library for the Inductiva API version **0.10**. 
+Welcome to the official Python library for the Inductiva API.
+
 The Inductiva API allows running a set of open-source physical
 simulators on the cloud, easily parallelizing simulations, each running
 on hundreds of CPU cores.
@@ -15,6 +16,22 @@ Inductiva simplifies the complexities of cloud resource management, and software
 configuration, offering a straightforward Python interface for running simulations
 on state-of-the-art hardware. This allows scientists and engineers to focus their
 time and energy on what matters: running simulations that solve real problems.
+
+# Getting started
+
+1. Register at:
+
+[https://console.inductiva.ai](https://console.inductiva.ai)
+
+2. Install the Inductiva Python Package
+```
+pip install inductiva
+```
+3. Authenticate with your API Key
+```
+inductiva auth login
+```
+
 
 To find out more, check our [documentation](https://docs.inductiva.ai/).
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ configuration, offering a straightforward Python interface for running simulatio
 on state-of-the-art hardware. This allows scientists and engineers to focus their
 time and energy on what matters: running simulations that solve real problems.
 
+
+# System Requirements
+
+- Python 3.x interpreter
+- pip (or pip3) to install the inductiva package
+  
 # Getting started
 
 1. Register at:

--- a/docs/preinstallation/system/system-requirements.md
+++ b/docs/preinstallation/system/system-requirements.md
@@ -8,7 +8,7 @@ We’ve gathered tips and feedback from users with different setups who’ve run
 into a few bumps while installing our API. The steps below are here to save 
 you time and help you sidestep the most common setup challenges!
 
-## Pre-requirements
+## System requirements
 
 - Step 1: Check if Python is Installed
 - Step 2: Update pip and Set Up Your PATH for Python

--- a/docs/preinstallation/system/system-requirements.md
+++ b/docs/preinstallation/system/system-requirements.md
@@ -1,6 +1,5 @@
-# System Requirements for Installing the Inductiva API
+# Getting Started: systems requirements and installation
 
-## Introduction
 
 Before diving into the installation process, it’s helpful to ensure your 
 system is primed and ready for the Inductiva API.
@@ -9,15 +8,30 @@ We’ve gathered tips and feedback from users with different setups who’ve run
 into a few bumps while installing our API. The steps below are here to save 
 you time and help you sidestep the most common setup challenges!
 
-## TL;DR
-Pre-Install Must-Dos:
+## Pre-requirements
+
 - Step 1: Check if Python is Installed
 - Step 2: Update pip and Set Up Your PATH for Python
 
-## Select your OS
+### Select your OS
 
 ```{toctree}
 :titlesonly:
 osx
 windows
+```
+
+## Installing the inductiva Python client and authenticating
+
+1. Register at:
+
+[https://console.inductiva.ai](https://console.inductiva.ai)
+
+2. Install the Inductiva Python Package
+```
+pip install inductiva
+```
+3. Authenticate with your API Key
+```
+inductiva auth login
 ```


### PR DESCRIPTION
Highlighting how easy is to install and authenticate directly on the README of the Python package and on the docs website, because so far this is only visible inside the web console.

 Note: also removed the hardcoded mention to the version of the package on the README, that easily gets outdated. We have a badge there to show the always up to date version, so...