### PR TITLE
We now print empty spaces to clear the line first

### DIFF
--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -675,6 +675,7 @@ class Task:
             self.id, self.id)
 
         requires_newline = False
+        previous_duration_l = 0
 
         while True:
             # status = self.get_status()
@@ -699,7 +700,14 @@ class Task:
             # Print timer
             elif (status != models.TaskStatusCode.SUBMITTED and
                   not task_info.is_terminal):
-                print(f"Duration: {duration}", end="\r")
+
+                #clear precious line
+                print(" " * previous_duration_l, end="\r")
+
+                duration = f"Duration: {duration}"
+                print(duration, end="\r")
+
+                previous_duration_l = len(duration)
 
             prev_status = status
 


### PR DESCRIPTION
This PR prints empty spaces during the task wait in order to fully clear a line before printing a new one