### PR TITLE
Add ```benchmarks``` to init file

### DIFF
--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -13,6 +13,7 @@ from inductiva.client.api_client import ApiClient
 from inductiva.api.methods import get_client
 
 from . import constants
+from . import benchmarks
 from . import simulators
 from . import resources
 from . import projects


### PR DESCRIPTION
Allows users to run a benchmark without needing to explicitly import the benchmarks module

```python
import inductiva

benchmark = inductiva.benchmarks.Benchmark(name="benchmark")

# ...
```