### PR TITLE
Bump minimum supported Python version to 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
   certifi >= 14.5.14
   frozendict
@@ -28,7 +28,7 @@ install_requires =
   fsspec
   requests
   aiohttp
-  aiortc; python_version < '3.13'
+  aiortc
 
 [options.extras_require]
 task-runner =
@@ -36,9 +36,9 @@ task-runner =
 
 [options.package_data]
 inductiva = assets/**
-inductiva.localization = 
+inductiva.localization =
   translations/**
-inductiva.resources = 
+inductiva.resources =
   machine_types.yaml
 
 [options.packages.find]


### PR DESCRIPTION
Making Python 3.9 the minimum supported version since 3.8 has reached [end-of-life](https://devguide.python.org/versions/) and some of our dependencies no longer support it (e.g., `aiortc`).