### PR TITLE
Disable google-crc32c warning

### DIFF
--- a/inductiva/tasks/file_tracker.py
+++ b/inductiva/tasks/file_tracker.py
@@ -4,11 +4,14 @@ import json
 import uuid
 import enum
 import logging
+import warnings
 
 aiortc_imported = True
 
 try:
-    import aiortc
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        import aiortc
 except ImportError:
     aiortc_imported = False
 


### PR DESCRIPTION
Hide warning that shows when importing `aiortc` due to `google-crc32c` in Python 3.13, since it doesn't affect us.