### PR TITLE
Check if sim_config_filename is an absolute path

### DIFF
--- a/inductiva/simulators/snl_swan.py
+++ b/inductiva/simulators/snl_swan.py
@@ -80,6 +80,11 @@ class SnlSwan(simulators.Simulator):
         commands = []
 
         path_config_filename = Path(sim_config_filename)
+
+        if path_config_filename.is_absolute():
+            raise ValueError("sim_config_filename must be a path relative to "
+                             "the input directory.")
+
         working_dir = path_config_filename.parent
         config_file_only = path_config_filename.name
 

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -75,6 +75,11 @@ class SWAN(simulators.Simulator):
         commands = []
 
         path_config_filename = Path(sim_config_filename)
+
+        if path_config_filename.is_absolute():
+            raise ValueError("sim_config_filename must be a path relative to "
+                             "the input directory.")
+
         working_dir = path_config_filename.parent
         config_file_only = path_config_filename.name
 
@@ -107,7 +112,6 @@ class SWAN(simulators.Simulator):
             swan_exe_command = Command(f"swan.exe {sim_config_filename}",
                                        mpi_config=mpi_config)
             commands.append(swan_exe_command)
-
         return super().run(input_dir,
                            on=on,
                            storage_dir=storage_dir,

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -72,6 +72,11 @@ class SWASH(simulators.Simulator):
         commands = []
 
         path_config_filename = Path(sim_config_filename)
+
+        if path_config_filename.is_absolute():
+            raise ValueError("sim_config_filename must be a path relative to "
+                             "the input directory.")
+
         working_dir = path_config_filename.parent
         config_file_only = path_config_filename.name
 


### PR DESCRIPTION
If sim_config_filename is an absolute path the working_dir will also be an absolute path and that will give an error on the task runner.