### PR TITLE
Refactor ```storage.get_zip_contents``` Function

### DIFF
--- a/inductiva/storage/__init__.py
+++ b/inductiva/storage/__init__.py
@@ -1,2 +1,2 @@
 """Storage related functions."""
-from .storage import get_space_used, listdir, upload, upload_from_url, remove_workspace, export, StorageOperation, get_signed_urls, get_zip_contents
+from .storage import get_space_used, listdir, upload, upload_from_url, remove_workspace, export, StorageOperation, get_signed_urls, get_zip_contents, ZipArchiveInfo, ZipFileInfo

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -142,12 +142,14 @@ def get_signed_urls(
     }).body
     return signed_urls
 
+
 @dataclass
 class ZipFileInfo:
     """Represents information about a file within a ZIP archive."""
     name: str
     size: int
     compressed_size: int
+
 
 @dataclass
 class ZipArchiveInfo:

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -870,18 +870,19 @@ class Task:
             print that information in a formatted way.
         """
         # TODO: the output filename shouldn't be hardcoded
-        archive_info = storage.get_zip_contents(path=f"{self.id}/output.zip")
+        archive_info = storage.get_zip_contents(path=f"{self.id}/output.zip",
+                                                zip_relative_path="artifacts/")
 
         output_files = [
             output_info.FileInfo(
-                name=file_info["name"],
-                size=int(file_info["size"]),
-                compressed_size=int(file_info["compressed_size"]),
-            ) for file_info in archive_info["contents"]
+                name=file_info.name,
+                size=file_info.size,
+                compressed_size=file_info.compressed_size,
+            ) for file_info in archive_info.files
         ]
 
         return output_info.TaskOutputInfo(
-            total_size_bytes=int(archive_info["size"]),
+            total_size_bytes=archive_info.size,
             files=output_files,
         )
 

--- a/inductiva/tests/tasks/test_task.py
+++ b/inductiva/tests/tasks/test_task.py
@@ -2,7 +2,7 @@
 import inductiva
 import pytest
 from unittest.mock import Mock, patch
-from inductiva import constants
+from inductiva import constants, storage
 from inductiva.client import exceptions
 import inductiva.client
 from inductiva.client.model.task_status_code import TaskStatusCode
@@ -184,25 +184,15 @@ def test__get_output_info(mock_get_zip_contents):
     """
     Check if the output info is correctly returned.
     """
-    mock_get_zip_contents.return_value = {
-        "size":
-            320,
-        "contents": [
-            {
-                "name": "file1.txt",
-                "size": 100,
-                "compressed_size": 50
-            },
-            {
-                "name": "file2.txt",
-                "size": 200,
-                "compressed_size": 100
-            },
+    mock_get_zip_contents.return_value = storage.ZipArchiveInfo(
+        size=320,
+        files=[
+            storage.ZipFileInfo(name="file1.txt", size=100, compressed_size=50),
+            storage.ZipFileInfo(name="file2.txt", size=200, compressed_size=100)
         ]
-    }
+    )
     task = inductiva.tasks.Task("123")
     output_info = task.get_output_info()
-
     assert output_info.n_files == 2
     assert output_info.total_size_bytes == 320
     assert output_info.total_compressed_size_bytes == 150

--- a/inductiva/tests/tasks/test_task.py
+++ b/inductiva/tests/tasks/test_task.py
@@ -189,8 +189,7 @@ def test__get_output_info(mock_get_zip_contents):
         files=[
             storage.ZipFileInfo(name="file1.txt", size=100, compressed_size=50),
             storage.ZipFileInfo(name="file2.txt", size=200, compressed_size=100)
-        ]
-    )
+        ])
     task = inductiva.tasks.Task("123")
     output_info = task.get_output_info()
     assert output_info.n_files == 2


### PR DESCRIPTION
This PR improves the ```storage.get_zip_contents``` function, adding documentation as well.

- Example 1: Retrieve file information from the output ZIP file using the **tasks** API.

```python
task = inductiva.tasks.Task("m3p1ariitkg5wvdkt685ctao9")
task.get_output_info()
# Output: TaskOutputInfo(files=[FileInfo(name='benchPEP-h.tpr', size=306724888, compressed_size=217880493), FileInfo(name='stderr.txt', size=919, compressed_size=544), FileInfo(name='md.log', size=16958, compressed_size=6400), FileInfo(name='ener.edr', size=None, compressed_size=2), FileInfo(name='stdout.txt', size=166, compressed_size=128)], total_size_bytes=217889071)
```

- Example 2: Retrieve file information from the output ZIP file using the **storage** API.

```python
# Need to pass artifacts/
inductiva.storage.get_zip_contents("m3p1ariitkg5wvdkt685ctao9/output.zip", zip_relative_path="artifacts")
# Output: ZipArchiveInfo(size=217889071, files=[ZipFileInfo(name='benchPEP-h.tpr', size=306724888, compressed_size=217880493), ZipFileInfo(name='stderr.txt', size=919, compressed_size=544), ZipFileInfo(name='md.log', size=16958, compressed_size=6400), ZipFileInfo(name='ener.edr', size=None, compressed_size=2), ZipFileInfo(name='stdout.txt', size=166, compressed_size=128)])

# If artifacts/ is not passed, the root is listed
inductiva.storage.get_zip_contents("m3p1ariitkg5wvdkt685ctao9/output.zip", zip_relative_path="")
# Output: ZipArchiveInfo(size=217889071, files=[ZipFileInfo(name='output.json', size=2, compressed_size=4), ZipFileInfo(name='artifacts/', size=None, compressed_size=None)])
```

- Example 3: Retrieve file information from other ZIP file using the **storage** API.

```python
inductiva.storage.get_zip_contents("hjqp1hvckj81whezn91g5mmo4/input.zip")
# Output: ZipArchiveInfo(size=2544, files=[ZipFileInfo(name='sim_dir/', size=None, compressed_size=None), ZipFileInfo(name='input.json', size=988, compressed_size=324)])

# Provide a `zip_relative_path` to navigate within the ZIP file.
inductiva.storage.get_zip_contents("hjqp1hvckj81whezn91g5mmo4/input.zip", zip_relative_path="sim_dir")
# Output: ZipArchiveInfo(size=2544, files=[ZipFileInfo(name='topol.top', size=113, compressed_size=91), ZipFileInfo(name='simulation.mdp', size=1450, compressed_size=493), ZipFileInfo(name='positions_decorrelation.mdp', size=1343, compressed_size=446), ZipFileInfo(name='energy_minimization.mdp', size=884, compressed_size=466)])
```