### PR TITLE
Include GPU name when listing available machines in cli

### DIFF
--- a/inductiva/_cli/cmd_resources/list.py
+++ b/inductiva/_cli/cmd_resources/list.py
@@ -34,12 +34,11 @@ def pretty_print_machines_info(machines_dict):
             final_table["Memory (GB)"].append("")
             final_table["Price/Hour (USD)"].append("")
         first_line = False
-
         final_table["Machine Type"].append(machine_type)
         for i, vcpu in enumerate(details["vcpus"]):
             final_table["vCPUS"].append(vcpu)
             final_table["GPUS"].append(
-                details["gpus"][i] if details["gpus"] else "n/a")
+                f"{details['gpus'][i]} x {details['gpu_name']}" if details["gpus"] else "n/a")
             final_table["Memory (GB)"].append(details["memory"])
             final_table["Price/Hour (USD)"].append(details["price"])
 
@@ -72,12 +71,14 @@ def list_machine_types_available(args):
         price = machine.price
         vcpus = machine.num_cpus
         gpus = machine.num_gpus if machine.num_gpus else None
+        gpu_name = machine.gpu_name if machine.num_gpus else None
 
         machines_dict[machine_type] = {
             "vcpus": [],
             "gpus": [],
             "memory": memory,
-            "price": price
+            "price": price,
+            "gpu_name": gpu_name
         }
 
         machines_dict[machine_type]["vcpus"].append(int(vcpus))

--- a/inductiva/_cli/cmd_resources/list.py
+++ b/inductiva/_cli/cmd_resources/list.py
@@ -39,7 +39,8 @@ def pretty_print_machines_info(machines_dict):
         for i, vcpu in enumerate(details["vcpus"]):
             final_table["vCPUS"].append(vcpu)
             final_table["GPUS"].append(
-                f"{details['gpus'][i]} x {details['gpu_name']}" if details["gpus"] else "n/a")
+                f"{details['gpus'][i]} x {details['gpu_name']}"
+                if details["gpus"] else "n/a")
             final_table["Memory (GB)"].append(details["memory"])
             final_table["Price/Hour (USD)"].append(details["price"])
 

--- a/inductiva/_cli/cmd_resources/list.py
+++ b/inductiva/_cli/cmd_resources/list.py
@@ -34,6 +34,7 @@ def pretty_print_machines_info(machines_dict):
             final_table["Memory (GB)"].append("")
             final_table["Price/Hour (USD)"].append("")
         first_line = False
+
         final_table["Machine Type"].append(machine_type)
         for i, vcpu in enumerate(details["vcpus"]):
             final_table["vCPUS"].append(vcpu)


### PR DESCRIPTION
Similarly to what @luispcunha suggested in https://github.com/inductiva/console-web/pull/373, I think it looks nicer also showing the GPU name, wydt?

<img width="808" alt="image" src="https://github.com/user-attachments/assets/83ca4750-7c2d-4ec7-a56d-184b2f702754" />
