### PR TITLE
Add auto_terminate_minutes to machines

### DIFF
--- a/inductiva/resources/machine_cluster.py
+++ b/inductiva/resources/machine_cluster.py
@@ -22,6 +22,7 @@ class MPICluster(machines_base.BaseMachineGroup):
         data_disk_gb: int = 10,
         max_idle_time: Optional[datetime.timedelta] = None,
         auto_terminate_ts: Optional[datetime.datetime] = None,
+        auto_terminate_minutes: Optional[int] = None,
         register: bool = True,
     ) -> None:
         """Create a MPICluster object.
@@ -45,6 +46,10 @@ class MPICluster(machines_base.BaseMachineGroup):
               resource will be terminated.
             auto_terminate_ts: Moment in which the resource will be
               automatically terminated.
+            auto_terminate_minutes: Duration, in minutes, the machine will be
+                kept alive. After auto_terminate_minutes minutes the machine
+                will be terminated.
+            
         """
         if num_machines < 1:
             raise ValueError(
@@ -56,6 +61,7 @@ class MPICluster(machines_base.BaseMachineGroup):
             data_disk_gb=data_disk_gb,
             max_idle_time=max_idle_time,
             auto_terminate_ts=auto_terminate_ts,
+            auto_terminate_minutes=auto_terminate_minutes,
             register=register,
         )
 

--- a/inductiva/resources/machines.py
+++ b/inductiva/resources/machines.py
@@ -25,6 +25,7 @@ class MachineGroup(machines_base.BaseMachineGroup):
         auto_resize_disk_max_gb: Optional[int] = None,
         max_idle_time: Optional[datetime.timedelta] = None,
         auto_terminate_ts: Optional[datetime.datetime] = None,
+        auto_terminate_minutes: Optional[int] = None,
         register: bool = True,
     ) -> None:
         """Create a MachineGroup object.
@@ -62,6 +63,9 @@ class MachineGroup(machines_base.BaseMachineGroup):
               resource will be terminated.
             auto_terminate_ts: Moment in which the resource will be
               automatically terminated.
+            auto_terminate_minutes: Duration, in minutes, the machine will be
+                kept alive. After auto_terminate_minutes minutes the machine
+                will be terminated.
         """
         if num_machines < 1:
             raise ValueError(
@@ -75,6 +79,7 @@ class MachineGroup(machines_base.BaseMachineGroup):
             max_idle_time=max_idle_time,
             threads_per_core=threads_per_core,
             auto_terminate_ts=auto_terminate_ts,
+            auto_terminate_minutes=auto_terminate_minutes,
             auto_resize_disk_max_gb=auto_resize_disk_max_gb,
         )
 
@@ -141,6 +146,7 @@ class ElasticMachineGroup(machines_base.BaseMachineGroup):
         auto_resize_disk_max_gb: Optional[int] = None,
         max_idle_time: Optional[datetime.timedelta] = None,
         auto_terminate_ts: Optional[datetime.datetime] = None,
+        auto_terminate_minutes: Optional[int] = None,
         register: bool = True,
     ) -> None:
         """Create an ElasticMachineGroup object.
@@ -181,6 +187,9 @@ class ElasticMachineGroup(machines_base.BaseMachineGroup):
               resource will be terminated.
             auto_terminate_ts: Moment in which the resource will be
               automatically terminated.
+            auto_terminate_minutes: Duration, in minutes, the machine will be
+                kept alive. After auto_terminate_minutes minutes the machine
+                will be terminated.
         """
         if min_machines < 0:
             raise ValueError(
@@ -197,6 +206,7 @@ class ElasticMachineGroup(machines_base.BaseMachineGroup):
             max_idle_time=max_idle_time,
             threads_per_core=threads_per_core,
             auto_terminate_ts=auto_terminate_ts,
+            auto_terminate_minutes=auto_terminate_minutes,
             auto_resize_disk_max_gb=auto_resize_disk_max_gb,
         )
 

--- a/inductiva/resources/machines_base.py
+++ b/inductiva/resources/machines_base.py
@@ -43,6 +43,7 @@ class BaseMachineGroup(ABC):
         auto_resize_disk_max_gb: int = 500,
         max_idle_time: Optional[Union[datetime.timedelta, int]] = None,
         auto_terminate_ts: Optional[datetime.datetime] = None,
+        auto_terminate_minutes: Optional[int] = None,
         register: bool = True,
         allow_auto_start: bool = True,
     ) -> None:
@@ -72,6 +73,9 @@ class BaseMachineGroup(ABC):
                 representing the number of minutes.
             auto_terminate_ts: Moment in which the resource will be
               automatically terminated.
+            auto_terminate_minutes: Duration, in minutes, the machine will be
+                kept alive. After auto_terminate_minutes minutes the machine
+                will be terminated.
             register: Bool that indicates if a machine group should be register
                 or if it was already registered. If set to False by users on
                 initialization, then, the machine group will not be able to be
@@ -130,6 +134,12 @@ class BaseMachineGroup(ABC):
         self._estimated_cost = None
         self._max_idle_time = max_idle_time
         self.allow_auto_start = allow_auto_start
+
+        if isinstance(auto_terminate_minutes, int):
+            time_delta_minutes = datetime.timedelta(
+                minutes=auto_terminate_minutes)
+            self._auto_terminate_ts = datetime.datetime.now(
+            ) + time_delta_minutes
 
         if isinstance(max_idle_time, int):
             if max_idle_time <= 0:


### PR DESCRIPTION
This pr adds a new argument `auto_terminate_minutes`. This argument will do the exact same as `auto_terminate_ts` but it should be just an int representing the amount of minutes a machine should be kept alive.

This is just to make user experience better.

Added a warning telling the user `auto_terminate_ts` will be deprecated. 