### PR TITLE
Fix: use ```storage_input_path``` and ```storage_output_path```

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -129,7 +129,7 @@ def notify_upload_complete(api_endpoint,
 
 
 def upload_input(api_instance: TasksApi, task_id, original_params,
-                 type_annotations):
+                 type_annotations, storage_path_prefix):
     """Uploads the inputs of a given task to the API.
 
     Args:
@@ -142,8 +142,11 @@ def upload_input(api_instance: TasksApi, task_id, original_params,
     input_zip_path, zip_file_size = prepare_input(task_id, original_params,
                                                   type_annotations)
 
-    # TODO: the input filename shouldn't be hardcoded
-    url = storage.get_signed_urls([f"{task_id}/input.zip"], "upload")[0]
+    remote_input_zip_path = f"{storage_path_prefix}/{task_id}/input.zip"
+    url = storage.get_signed_urls(
+        paths=[remote_input_zip_path],
+        operation="upload",
+    )[0]
 
     with tqdm.tqdm(total=zip_file_size,
                    unit="B",
@@ -360,6 +363,7 @@ def submit_task(api_instance,
             original_params=params,
             task_id=task_id,
             type_annotations=type_annotations,
+            storage_path_prefix=storage_path_prefix,
         )
 
     return task_id

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -869,9 +869,10 @@ class Task:
             each file (name, size, compressed size). It can also be used to
             print that information in a formatted way.
         """
-        # TODO: the output filename shouldn't be hardcoded
-        archive_info = storage.get_zip_contents(path=f"{self.id}/output.zip",
-                                                zip_relative_path="artifacts/")
+        archive_info = storage.get_zip_contents(
+            path=self.info.storage_output_path,
+            zip_relative_path="artifacts/"
+        )
 
         output_files = [
             output_info.FileInfo(
@@ -899,9 +900,10 @@ class Task:
 
     def _request_download_output_url(self) -> Optional[str]:
         try:
-            # TODO: the output filename shouldn't be hardcoded
-            url = storage.get_signed_urls([f"{self.id}/output.zip"],
-                                          "download")[0]
+            url = storage.get_signed_urls(
+                paths=[self.info.storage_output_path],
+                operation="download"
+            )[0]
         except exceptions.ApiException as e:
             if not self._called_from_wait:
 
@@ -924,8 +926,10 @@ class Task:
         return url
 
     def _request_download_input_url(self) -> str:
-        # TODO: the input filename shouldn't be hardcoded
-        return storage.get_signed_urls([f"{self.id}/input.zip"], "download")[0]
+        return storage.get_signed_urls(
+            paths=[self.info.storage_input_path],
+            operation="download"
+        )[0]
 
     def get_output_url(self) -> Optional[str]:
         """Get a public URL to download the output files of the task.


### PR DESCRIPTION
Replaces the raw strings with the ```storage_input_path``` and ```storage_output_path``` fields of the tasks and solves issue related with ```storage_dir```.