### PR TITLE
Implement ```download``` in ```storage``` API

### DIFF
--- a/inductiva/_cli/cmd_storage/download.py
+++ b/inductiva/_cli/cmd_storage/download.py
@@ -21,13 +21,18 @@ def register(parser):
         "The `inductiva storage download` command allows you to download files "
         "or folders from your remote storage.\n"
         "Specify the remote path, the local destination, and whether or not to "
-        "uncompress the content after downloading.\n"
-    )
-    subparser.add_argument("path", type=str,
+        "uncompress the content after downloading.\n")
+    subparser.add_argument("path",
+                           type=str,
                            help="The remote path to the file or folder.")
-    subparser.add_argument("-d", "--dest", type=str, default="",
+    subparser.add_argument("-d",
+                           "--dest",
+                           type=str,
+                           default="",
                            help="Local directory to save the content.")
-    subparser.add_argument("-u", "--uncompress", action="store_true",
+    subparser.add_argument("-u",
+                           "--uncompress",
+                           action="store_true",
                            help="Uncompress the content after download.")
 
     subparser.set_defaults(func=download)

--- a/inductiva/_cli/cmd_storage/download.py
+++ b/inductiva/_cli/cmd_storage/download.py
@@ -22,10 +22,10 @@ def register(parser):
         "or folders from your remote storage.\n"
         "Specify the remote path, the local destination, and whether or not to "
         "uncompress the content after downloading.\n")
-    subparser.add_argument("--remote_path",
+    subparser.add_argument("remote_path",
                            type=str,
                            help="The remote path to the file or folder.")
-    subparser.add_argument("--local_dir",
+    subparser.add_argument("local_dir",
                            type=str,
                            default="",
                            help="Local directory to save the content.")

--- a/inductiva/_cli/cmd_storage/download.py
+++ b/inductiva/_cli/cmd_storage/download.py
@@ -6,7 +6,7 @@ from inductiva import storage
 
 def download(args):
     """Download a file or folder from remote storage."""
-    storage.download(args.path, args.dest, args.uncompress)
+    storage.download(args.remote_path, args.local_dir, args.uncompress)
 
 
 def register(parser):
@@ -22,11 +22,10 @@ def register(parser):
         "or folders from your remote storage.\n"
         "Specify the remote path, the local destination, and whether or not to "
         "uncompress the content after downloading.\n")
-    subparser.add_argument("path",
+    subparser.add_argument("--remote_path",
                            type=str,
                            help="The remote path to the file or folder.")
-    subparser.add_argument("-d",
-                           "--dest",
+    subparser.add_argument("--local_dir",
                            type=str,
                            default="",
                            help="Local directory to save the content.")

--- a/inductiva/_cli/cmd_storage/download.py
+++ b/inductiva/_cli/cmd_storage/download.py
@@ -1,0 +1,33 @@
+"""Download storage contents via CLI."""
+
+import argparse
+from inductiva import storage
+
+
+def download(args):
+    """Download a file or folder from remote storage."""
+    storage.download(args.path, args.dest, args.uncompress)
+
+
+def register(parser):
+    """Register the download command for the user's remote storage."""
+
+    subparser = parser.add_parser("download",
+                                  aliases=["dl"],
+                                  help="Download storage file or folder.",
+                                  formatter_class=argparse.RawTextHelpFormatter)
+
+    subparser.description = (
+        "The `inductiva storage download` command allows you to download files "
+        "or folders from your remote storage.\n"
+        "Specify the remote path, the local destination, and whether or not to "
+        "uncompress the content after downloading.\n"
+    )
+    subparser.add_argument("path", type=str,
+                           help="The remote path to the file or folder.")
+    subparser.add_argument("-d", "--dest", type=str, default="",
+                           help="Local directory to save the content.")
+    subparser.add_argument("-u", "--uncompress", action="store_true",
+                           help="Uncompress the content after download.")
+
+    subparser.set_defaults(func=download)

--- a/inductiva/_cli/cmd_storage/download.py
+++ b/inductiva/_cli/cmd_storage/download.py
@@ -27,6 +27,7 @@ def register(parser):
                            help="The remote path to the file or folder.")
     subparser.add_argument("local_dir",
                            type=str,
+                           nargs="?",
                            default="",
                            help="Local directory to save the content.")
     subparser.add_argument("-u",

--- a/inductiva/storage/__init__.py
+++ b/inductiva/storage/__init__.py
@@ -2,6 +2,7 @@
 from .storage import (
     ExportDestination,
     StorageOperation,
+    download,
     export,
     get_signed_urls,
     get_space_used,

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -13,6 +13,7 @@ import tqdm
 
 import inductiva
 from inductiva import constants
+from inductiva import utils
 from inductiva.api import methods
 from inductiva.client import exceptions, models
 from inductiva.client.apis.tags import storage_api
@@ -295,6 +296,51 @@ def upload(
                 raise e
 
     logging.info("Input uploaded successfully.")
+
+
+def download(remote_path: str, local_dir: str = "", uncompress: bool = True):
+    """
+    Downloads a file or folder from storage to a local directory, optionally 
+    uncompressing the contents.
+
+    Args:
+        remote_path (str): The path of the file or folder on the remote server
+            to download.
+        local_dir (str, optional): The local directory where the file or folder
+            will be saved. Defaults to the current working directory.
+        uncompress (bool, optional): Whether to uncompress the downloaded file 
+            or folder if it is compressed. Defaults to True.
+    """
+    def _resolve_local_path(url, remote_path, local_dir):
+        remote_absolute_path = urllib.parse.urlparse(url).path
+        index = remote_absolute_path.find(remote_path)
+        remote_relative_path = remote_absolute_path[index:]
+
+        resolved_dirname = local_dir \
+            if remote_path == remote_relative_path \
+            else os.path.join(local_dir, os.path.dirname(remote_relative_path))
+
+        resolved_filename = os.path.basename(remote_relative_path)
+        resolved_path = os.path.join(resolved_dirname, resolved_filename)
+        if resolved_dirname:
+            os.makedirs(name=resolved_dirname, exist_ok=True)
+        return resolved_path
+
+    urls = get_signed_urls(paths=[remote_path], operation="download")
+    api_instance = storage_api.StorageApi(inductiva.api.get_client())
+    pool_manager = api_instance.api_client.rest_client.pool_manager
+    for url in urls:
+        response = pool_manager.request(method="GET", url=url,
+                                        preload_content=False)
+        resolved_path = _resolve_local_path(url, remote_path, local_dir)
+        logging.info("Downloading file to %s ...", resolved_path)
+        utils.data.download_file(response, resolved_path)
+        if uncompress:
+            uncompress_dir, ext = os.path.splitext(resolved_path)
+            # TODO: Improve the check for zip file
+            if ext != ".zip": continue
+            utils.data.uncompress_zip(resolved_path, uncompress_dir)
+            os.remove(resolved_path)
 
 
 def _list_files(root_path: str) -> Tuple[List[str], int]:

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -312,6 +312,15 @@ def download(remote_path: str, local_dir: str = "", uncompress: bool = True):
             will be saved. Defaults to the current working directory.
         uncompress (bool, optional): Whether to uncompress the downloaded file 
             or folder if it is compressed. Defaults to True.
+
+    Example:
+        # Download a folder from a remote server to the current directory
+        inductiva.storage.download(remote_path="/path/to/remote/folder/")
+    
+        # Download a file and save it to a local directory without uncompressing
+        inductiva.storage.download(remote_path="/path/to/remote/file.zip",
+                                   local_dir="/local/directory",
+                                   uncompress=False)
     """
     def _resolve_local_path(url, remote_path, local_dir):
         remote_absolute_path = urllib.parse.urlparse(url).path
@@ -356,10 +365,10 @@ def download(remote_path: str, local_dir: str = "", uncompress: bool = True):
     pool_manager = api_instance.api_client.rest_client.pool_manager
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        total = sum(executor.map(_get_file_size, urls))
+        total_bytes = sum(executor.map(_get_file_size, urls))
 
     with tqdm.tqdm(
-        total=total,
+        total=total_bytes,
         unit="B",
         unit_scale=True,
         unit_divisor=1000,  # Use 1 KB = 1000 bytes

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -322,6 +322,7 @@ def download(remote_path: str, local_dir: str = "", uncompress: bool = True):
                                    local_dir="/local/directory",
                                    uncompress=False)
     """
+
     def _resolve_local_path(url, remote_path, local_dir):
         remote_absolute_path = urllib.parse.urlparse(url).path
         index = remote_absolute_path.find(remote_path)
@@ -336,8 +337,8 @@ def download(remote_path: str, local_dir: str = "", uncompress: bool = True):
         if resolved_dirname:
             os.makedirs(name=resolved_dirname, exist_ok=True)
         return resolved_path
-    
-    def _get_file_size(url):
+
+    def _get_size(url):
         response = pool_manager.urlopen("HEAD", url)
         size = int(response.getheader("Content-Length"))
         response.release_conn()
@@ -356,7 +357,8 @@ def download(remote_path: str, local_dir: str = "", uncompress: bool = True):
         if uncompress:
             uncompress_dir, ext = os.path.splitext(resolved_path)
             # TODO: Improve the check for ZIP file
-            if ext != ".zip": return
+            if ext != ".zip":
+                return
             utils.data.uncompress_zip(resolved_path, uncompress_dir)
             os.remove(resolved_path)
 
@@ -365,14 +367,14 @@ def download(remote_path: str, local_dir: str = "", uncompress: bool = True):
     pool_manager = api_instance.api_client.rest_client.pool_manager
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        total_bytes = sum(executor.map(_get_file_size, urls))
+        total_bytes = sum(executor.map(_get_size, urls))
 
     with tqdm.tqdm(
-        total=total_bytes,
-        unit="B",
-        unit_scale=True,
-        unit_divisor=1000,  # Use 1 KB = 1000 bytes
-        desc=f"Downloading {len(urls)} files from {remote_path}",
+            total=total_bytes,
+            unit="B",
+            unit_scale=True,
+            unit_divisor=1000,  # Use 1 KB = 1000 bytes
+            desc=f"Downloading {len(urls)} files from {remote_path}",
     ) as progress_bar:
         with concurrent.futures.ThreadPoolExecutor() as executor:
             progress_bar_lock = threading.Lock()

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -1022,7 +1022,7 @@ class Task:
 
         if uncompress:
             logging.info("Uncompressing the files to %s...", dir_path)
-            data.uncompress_task_outputs(zip_path, dir_path)
+            data.uncompress_zip(zip_path, dir_path)
             if rm_downloaded_zip_archive:
                 zip_path.unlink()
 

--- a/inductiva/tests/utils/test_files_utils.py
+++ b/inductiva/tests/utils/test_files_utils.py
@@ -211,7 +211,7 @@ def test_uncompress_task_outputs(tmp_path: pathlib.Path):
         zip_f.writestr("output.json", json.dumps(["result"]))
         zip_f.writestr("artifacts/file.txt", "Hello, World!")
 
-    data.uncompress_task_outputs(zip_path, output_dir)
+    data.uncompress_zip(zip_path, output_dir)
 
     assert (output_dir / "artifacts/file.txt").exists()
     assert (output_dir / "output.json").exists()

--- a/inductiva/utils/data.py
+++ b/inductiva/utils/data.py
@@ -370,7 +370,7 @@ def download_file(
     response.release_conn()
 
 
-def uncompress_task_outputs(zip_path: pathlib.Path, output_dir: pathlib.Path):
+def uncompress_zip(zip_path: pathlib.Path, output_dir: pathlib.Path):
     """Uncompress a ZIP archive containing the outputs of a task.
 
     If the archive contains the directory called artifacts, it means that the


### PR DESCRIPTION
- Implemented the ```inductiva.storage.download``` function for downloading files or folders from remote storage.
- Developed the corresponding CLI command to interact with the ```download``` function, allowing users to specify a remote path (```remote_path```), local directory (```local_dir```), and the option to uncompress content (```uncompress```).

Closes https://github.com/inductiva/tasks/issues/189

Example Usage (CLI):

```bash
inductiva storage download <remote_path> [<local_dir>] [--uncompress]
```