### PR TITLE
Improve ```storage.download``` operation

### DIFF
--- a/inductiva/_cli/cmd_storage/download.py
+++ b/inductiva/_cli/cmd_storage/download.py
@@ -20,7 +20,8 @@ def register(parser):
 
     subparser.description = (
         "The `inductiva storage download` command allows you to download files "
-        "or folders from your remote storage.\n"
+        "or folders from your remote storage, maintaining the original storage "
+        "path structure.\n"
         "Specify the remote path, the local destination (optional), and whether"
         " to decompress the content after downloading (default: enabled).\n")
     subparser.add_argument(

--- a/inductiva/_cli/cmd_storage/download.py
+++ b/inductiva/_cli/cmd_storage/download.py
@@ -6,7 +6,7 @@ from inductiva import storage
 
 def download(args):
     """Download a file or folder from remote storage."""
-    storage.download(args.remote_path, args.local_dir, args.uncompress)
+    storage.download(args.remote_path, args.local_dir, args.decompress)
 
 
 def register(parser):
@@ -22,7 +22,7 @@ def register(parser):
         "The `inductiva storage download` command allows you to download files "
         "or folders from your remote storage.\n"
         "Specify the remote path, the local destination (optional), and whether"
-        " to uncompress the content after downloading (default: enabled).\n")
+        " to decompress the content after downloading (default: enabled).\n")
     subparser.add_argument(
         "remote_path",
         type=str,
@@ -37,10 +37,9 @@ def register(parser):
               "Defaults to the current working directory if not specified."),
     )
     subparser.add_argument(
-        "-u",
-        "--uncompress",
+        "--decompress",
         action="store_true",
-        help=("Uncompress the downloaded file or folder if it is compressed. "
+        help=("Decompress the downloaded file or folder if it is compressed. "
               "This option is enabled by default."),
     )
 

--- a/inductiva/_cli/cmd_storage/download.py
+++ b/inductiva/_cli/cmd_storage/download.py
@@ -40,6 +40,7 @@ def register(parser):
     subparser.add_argument(
         "--decompress",
         action="store_true",
+        default=True,
         help=("Decompress the downloaded file or folder if it is compressed. "
               "This option is enabled by default."),
     )

--- a/inductiva/_cli/cmd_storage/download.py
+++ b/inductiva/_cli/cmd_storage/download.py
@@ -12,27 +12,36 @@ def download(args):
 def register(parser):
     """Register the download command for the user's remote storage."""
 
-    subparser = parser.add_parser("download",
-                                  aliases=["dl"],
-                                  help="Download storage file or folder.",
-                                  formatter_class=argparse.RawTextHelpFormatter)
+    subparser = parser.add_parser(
+        "download",
+        aliases=["dl"],
+        help="Download a file or folder from remote storage.",
+        formatter_class=argparse.RawTextHelpFormatter)
 
     subparser.description = (
         "The `inductiva storage download` command allows you to download files "
         "or folders from your remote storage.\n"
-        "Specify the remote path, the local destination, and whether or not to "
-        "uncompress the content after downloading.\n")
-    subparser.add_argument("remote_path",
-                           type=str,
-                           help="The remote path to the file or folder.")
-    subparser.add_argument("local_dir",
-                           type=str,
-                           nargs="?",
-                           default="",
-                           help="Local directory to save the content.")
-    subparser.add_argument("-u",
-                           "--uncompress",
-                           action="store_true",
-                           help="Uncompress the content after download.")
+        "Specify the remote path, the local destination (optional), and whether"
+        " to uncompress the content after downloading (default: enabled).\n")
+    subparser.add_argument(
+        "remote_path",
+        type=str,
+        help="The remote path to the file or folder to download.",
+    )
+    subparser.add_argument(
+        "local_dir",
+        type=str,
+        nargs="?",
+        default="",
+        help=("The local directory where the downloaded content will be saved. "
+              "Defaults to the current working directory if not specified."),
+    )
+    subparser.add_argument(
+        "-u",
+        "--uncompress",
+        action="store_true",
+        help=("Uncompress the downloaded file or folder if it is compressed. "
+              "This option is enabled by default."),
+    )
 
     subparser.set_defaults(func=download)

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -369,8 +369,9 @@ def download(remote_path: str, local_dir: str = "", decompress: bool = True):
     with concurrent.futures.ThreadPoolExecutor() as executor:
         total_bytes = sum(executor.map(_get_size, urls))
 
-    n = len(urls)
-    desc = f"Downloading {n} file{'s' if n != 1 else ''} from {remote_path}"
+    num_files = len(urls)
+    text_file = f"file{'s' if num_files != 1 else ''}"
+    desc = f"Downloading {num_files} {text_file} from {remote_path}"
 
     with tqdm.tqdm(
             total=total_bytes,
@@ -382,6 +383,11 @@ def download(remote_path: str, local_dir: str = "", decompress: bool = True):
         with concurrent.futures.ThreadPoolExecutor() as executor:
             progress_bar_lock = threading.Lock()
             _ = executor.map(_download_file, urls)
+
+    text_dir = f"\"{local_dir}\"" if local_dir \
+        else "the current working directory"
+    logging.info("Successfully downloaded %d %s to %s.", num_files, text_file,
+                 text_dir)
 
 
 def _list_files(root_path: str) -> Tuple[List[str], int]:

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -378,7 +378,7 @@ def download(remote_path: str, local_dir: str = "", decompress: bool = True):
             _ = list(executor.map(_download_file, urls))
 
     logging.info("Successfully downloaded %d %s to \"%s\".", num_files,
-                 text_file, local_dir or remote_path)
+                 text_file, os.path.join(local_dir, remote_path))
 
 
 def _list_files(root_path: str) -> Tuple[List[str], int]:

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -377,8 +377,8 @@ def download(remote_path: str, local_dir: str = "", decompress: bool = True):
             progress_bar_lock = threading.Lock()
             _ = list(executor.map(_download_file, urls))
 
-    logging.info("Successfully downloaded %d %s to \"%s\".", 
-                 num_files, text_file, local_dir or remote_path)
+    logging.info("Successfully downloaded %d %s to \"%s\".", num_files,
+                 text_file, local_dir or remote_path)
 
 
 def _list_files(root_path: str) -> Tuple[List[str], int]:

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -300,27 +300,27 @@ def upload(
     logging.info("Input uploaded successfully.")
 
 
-def download(remote_path: str, local_dir: str = "", uncompress: bool = True):
+def download(remote_path: str, local_dir: str = "", decompress: bool = True):
     """
     Downloads a file or folder from storage to a local directory, optionally 
-    uncompressing the contents.
+    decompressing the contents.
 
     Args:
         remote_path (str): The path of the file or folder on the remote server
             to download.
         local_dir (str, optional): The local directory where the file or folder
             will be saved. Defaults to the current working directory.
-        uncompress (bool, optional): Whether to uncompress the downloaded file 
+        decompress (bool, optional): Whether to decompress the downloaded file 
             or folder if it is compressed. Defaults to True.
 
     Example:
         # Download a folder from a remote server to the current directory
         inductiva.storage.download(remote_path="/path/to/remote/folder/")
     
-        # Download a file and save it to a local directory without uncompressing
+        # Download a file and save it to a local directory without decompressing
         inductiva.storage.download(remote_path="/path/to/remote/file.zip",
                                    local_dir="/local/directory",
-                                   uncompress=False)
+                                   decompress=False)
     """
 
     def _resolve_local_path(url, remote_path, local_dir):
@@ -354,12 +354,12 @@ def download(remote_path: str, local_dir: str = "", uncompress: bool = True):
                     progress_bar.update(len(chunk))
         response.release_conn()
 
-        if uncompress:
-            uncompress_dir, ext = os.path.splitext(resolved_path)
+        if decompress:
+            decompress_dir, ext = os.path.splitext(resolved_path)
             # TODO: Improve the check for ZIP file
             if ext != ".zip":
                 return
-            utils.data.uncompress_zip(resolved_path, uncompress_dir)
+            utils.data.uncompress_zip(resolved_path, decompress_dir)
             os.remove(resolved_path)
 
     urls = get_signed_urls(paths=[remote_path], operation="download")

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -369,12 +369,15 @@ def download(remote_path: str, local_dir: str = "", uncompress: bool = True):
     with concurrent.futures.ThreadPoolExecutor() as executor:
         total_bytes = sum(executor.map(_get_size, urls))
 
+    n = len(urls)
+    desc = f"Downloading {n} file{'s' if n != 1 else ''} from {remote_path}"
+
     with tqdm.tqdm(
             total=total_bytes,
             unit="B",
             unit_scale=True,
             unit_divisor=1000,  # Use 1 KB = 1000 bytes
-            desc=f"Downloading {len(urls)} files from {remote_path}",
+            desc=desc,
     ) as progress_bar:
         with concurrent.futures.ThreadPoolExecutor() as executor:
             progress_bar_lock = threading.Lock()


### PR DESCRIPTION
- Improves log statements

```bash
(inductiva-dev-env) ➜  inductiva git:(hp-improve-download) ✗ inductiva storage download gromacs_dir                              
Downloading 6 files from "gromacs_dir": 100%|██████████████████████████████████████████████████████████████████████| 946k/946k [00:00<00:00, 3.34MB/s]
Successfully downloaded 6 files to "gromacs_dir".

(inductiva-dev-env) ➜  inductiva git:(hp-improve-download) ✗ inductiva storage download gromacs_dir downloads
Downloading 6 files from "gromacs_dir": 100%|██████████████████████████████████████████████████████████████████████| 946k/946k [00:00<00:00, 3.70MB/s]
Successfully downloaded 6 files to "downloads/gromacs_dir".

(inductiva-dev-env) ➜  inductiva git:(hp-improve-download) ✗ inductiva storage download gromacs_dir/energy_minimization.mdp 
Downloading 1 file from "gromacs_dir/energy_minimization.mdp": 100%|█████████████████████████████████████████████████| 884/884 [00:00<00:00, 11.1kB/s]
Successfully downloaded 1 file to "gromacs_dir/energy_minimization.mdp".

(inductiva-dev-env) ➜  inductiva git:(hp-improve-download) ✗ inductiva storage download gromacs_dir/energy_minimization.mdp downloads
Downloading 1 file from "gromacs_dir/energy_minimization.mdp": 100%|█████████████████████████████████████████████████| 884/884 [00:00<00:00, 12.7kB/s]
Successfully downloaded 1 file to "downloads/gromacs_dir/energy_minimization.mdp".
```

- Improved docstring with default values and better descriptions.
- Replaced ```uncompress``` with ```decompress```.
- When downloading a single file, it now mimics the full remote path.
