### PR TITLE
Fix ```--decompress``` flag on CLI

### DIFF
--- a/inductiva/_cli/cmd_storage/download.py
+++ b/inductiva/_cli/cmd_storage/download.py
@@ -40,7 +40,6 @@ def register(parser):
     subparser.add_argument(
         "--decompress",
         action="store_true",
-        default=True,
         help=("Decompress the downloaded file or folder if it is compressed. "
               "This option is enabled by default."),
     )


### PR DESCRIPTION
Users couldn't choose not to decompress files when downloading.

Example without automatic decompression:

```bash
inductiva storage download kjazsmk7jxao6e0a71e2neh1d/input.zip
```

Example with automatic decompression:

```bash
inductiva storage download kjazsmk7jxao6e0a71e2neh1d/input.zip --decompress
```

