### PR TITLE
Kill task if `upload_file` is interrupted by user

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -138,29 +138,36 @@ def upload_input(api_instance: TasksApi, task_id, original_params,
         original_params: Params of the request passed by the user.
         type_annotations: Annotations of the params' types.
     """
+    try:
+        # Use the blocking task context
+        with blocking_task_context(api_instance, task_id):
+            input_zip_path, zip_file_size = prepare_input(task_id, original_params,
+                                                        type_annotations)
 
-    input_zip_path, zip_file_size = prepare_input(task_id, original_params,
-                                                  type_annotations)
+            remote_input_zip_path = f"{storage_path_prefix}/{task_id}/input.zip"
+            url = storage.get_signed_urls(
+                paths=[remote_input_zip_path],
+                operation="upload",
+            )[0]
 
-    remote_input_zip_path = f"{storage_path_prefix}/{task_id}/input.zip"
-    url = storage.get_signed_urls(
-        paths=[remote_input_zip_path],
-        operation="upload",
-    )[0]
+            with tqdm.tqdm(total=zip_file_size,
+                        unit="B",
+                        unit_scale=True,
+                        unit_divisor=1000) as progress_bar:
+                upload_file(api_instance, input_zip_path, "PUT", url, progress_bar)
+                notify_upload_complete(
+                    api_instance.notify_input_uploaded,
+                    path_params={"task_id": task_id},
+                )
 
-    with tqdm.tqdm(total=zip_file_size,
-                   unit="B",
-                   unit_scale=True,
-                   unit_divisor=1000) as progress_bar:
-        upload_file(api_instance, input_zip_path, "PUT", url, progress_bar)
-        notify_upload_complete(
-            api_instance.notify_input_uploaded,
-            path_params={"task_id": task_id},
-        )
-
-    logging.info("Local input directory successfully uploaded.")
-    logging.info("")
-    os.remove(input_zip_path)
+            logging.info("Local input directory successfully uploaded.")
+            logging.info("")
+    except KeyboardInterrupt:
+        raise RuntimeError("Upload was interrupted by user.")
+    except Exception as e:
+        raise RuntimeError(f"Upload failed: {e}")
+    finally:
+        os.remove(input_zip_path)
 
 
 def block_until_finish(api_instance: TasksApi, task_id: str) -> str:

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -138,37 +138,29 @@ def upload_input(api_instance: TasksApi, task_id, original_params,
         original_params: Params of the request passed by the user.
         type_annotations: Annotations of the params' types.
     """
-    try:
-        # Use the blocking task context
-        with blocking_task_context(api_instance, task_id):
-            input_zip_path, zip_file_size = prepare_input(
-                task_id, original_params, type_annotations)
+    # Use the blocking task context
+    with blocking_task_context(api_instance, task_id):
+        input_zip_path, zip_file_size = prepare_input(task_id, original_params,
+                                                      type_annotations)
 
-            remote_input_zip_path = f"{storage_path_prefix}/{task_id}/input.zip"
-            url = storage.get_signed_urls(
-                paths=[remote_input_zip_path],
-                operation="upload",
-            )[0]
+        remote_input_zip_path = f"{storage_path_prefix}/{task_id}/input.zip"
+        url = storage.get_signed_urls(
+            paths=[remote_input_zip_path],
+            operation="upload",
+        )[0]
 
-            with tqdm.tqdm(total=zip_file_size,
-                           unit="B",
-                           unit_scale=True,
-                           unit_divisor=1000) as progress_bar:
-                upload_file(api_instance, input_zip_path, "PUT", url,
-                            progress_bar)
-                notify_upload_complete(
-                    api_instance.notify_input_uploaded,
-                    path_params={"task_id": task_id},
-                )
+        with tqdm.tqdm(total=zip_file_size,
+                       unit="B",
+                       unit_scale=True,
+                       unit_divisor=1000) as progress_bar:
+            upload_file(api_instance, input_zip_path, "PUT", url, progress_bar)
+            notify_upload_complete(
+                api_instance.notify_input_uploaded,
+                path_params={"task_id": task_id},
+            )
 
-            logging.info("Local input directory successfully uploaded.")
-            logging.info("")
-    except KeyboardInterrupt:
-        raise RuntimeError("Upload was interrupted by user.")
-    except Exception as e:
-        raise RuntimeError(f"Upload failed: {e}")
-    finally:
-        os.remove(input_zip_path)
+        logging.info("Local input directory successfully uploaded.")
+        logging.info("")
 
 
 def block_until_finish(api_instance: TasksApi, task_id: str) -> str:

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -141,8 +141,8 @@ def upload_input(api_instance: TasksApi, task_id, original_params,
     try:
         # Use the blocking task context
         with blocking_task_context(api_instance, task_id):
-            input_zip_path, zip_file_size = prepare_input(task_id, original_params,
-                                                        type_annotations)
+            input_zip_path, zip_file_size = prepare_input(
+                task_id, original_params, type_annotations)
 
             remote_input_zip_path = f"{storage_path_prefix}/{task_id}/input.zip"
             url = storage.get_signed_urls(
@@ -151,10 +151,11 @@ def upload_input(api_instance: TasksApi, task_id, original_params,
             )[0]
 
             with tqdm.tqdm(total=zip_file_size,
-                        unit="B",
-                        unit_scale=True,
-                        unit_divisor=1000) as progress_bar:
-                upload_file(api_instance, input_zip_path, "PUT", url, progress_bar)
+                           unit="B",
+                           unit_scale=True,
+                           unit_divisor=1000) as progress_bar:
+                upload_file(api_instance, input_zip_path, "PUT", url,
+                            progress_bar)
                 notify_upload_complete(
                     api_instance.notify_input_uploaded,
                     path_params={"task_id": task_id},

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -138,34 +138,31 @@ def upload_input(api_instance: TasksApi, task_id, original_params,
         original_params: Params of the request passed by the user.
         type_annotations: Annotations of the params' types.
     """
-    # Use the blocking task context
-    with blocking_task_context(api_instance, task_id):
-        try:
-            input_zip_path, zip_file_size = prepare_input(
-                task_id, original_params, type_annotations)
+    try:
+        input_zip_path, zip_file_size = prepare_input(task_id, original_params,
+                                                      type_annotations)
 
-            remote_input_zip_path = f"{storage_path_prefix}/{task_id}/input.zip"
-            url = storage.get_signed_urls(
-                paths=[remote_input_zip_path],
-                operation="upload",
-            )[0]
+        remote_input_zip_path = f"{storage_path_prefix}/{task_id}/input.zip"
+        url = storage.get_signed_urls(
+            paths=[remote_input_zip_path],
+            operation="upload",
+        )[0]
 
-            with tqdm.tqdm(total=zip_file_size,
-                           unit="B",
-                           unit_scale=True,
-                           unit_divisor=1000) as progress_bar:
-                upload_file(api_instance, input_zip_path, "PUT", url,
-                            progress_bar)
-                notify_upload_complete(
-                    api_instance.notify_input_uploaded,
-                    path_params={"task_id": task_id},
-                )
+        with tqdm.tqdm(total=zip_file_size,
+                       unit="B",
+                       unit_scale=True,
+                       unit_divisor=1000) as progress_bar:
+            upload_file(api_instance, input_zip_path, "PUT", url, progress_bar)
+            notify_upload_complete(
+                api_instance.notify_input_uploaded,
+                path_params={"task_id": task_id},
+            )
 
-            logging.info("Local input directory successfully uploaded.")
-            logging.info("")
+        logging.info("Local input directory successfully uploaded.")
+        logging.info("")
 
-        finally:
-            os.remove(input_zip_path)
+    finally:
+        os.remove(input_zip_path)
 
 
 def block_until_finish(api_instance: TasksApi, task_id: str) -> str:
@@ -362,14 +359,15 @@ def submit_task(api_instance,
         ))
 
     if task_submitted_info["status"] == "pending-input":
-
-        upload_input(
-            api_instance=api_instance,
-            original_params=params,
-            task_id=task_id,
-            type_annotations=type_annotations,
-            storage_path_prefix=storage_path_prefix,
-        )
+        # Use the blocking task context
+        with blocking_task_context(api_instance, task_id):
+            upload_input(
+                api_instance=api_instance,
+                original_params=params,
+                task_id=task_id,
+                type_annotations=type_annotations,
+                storage_path_prefix=storage_path_prefix,
+            )
 
     return task_id
 


### PR DESCRIPTION
references [#874](https://github.com/inductiva/tasks/issues/874)

**Before**:

https://github.com/user-attachments/assets/58536816-e2dd-42ba-a1a4-e5d6e80ecc24

**Now:**

https://github.com/user-attachments/assets/d75582ca-bd0e-4f3f-a199-0ced6faa88ae


