### PR TITLE
Increase request timeout in list_available_images function

### DIFF
--- a/inductiva/simulators/methods.py
+++ b/inductiva/simulators/methods.py
@@ -43,7 +43,7 @@ def list_available_images():
     url = f"{DOCKERHUB_URL}?page_size=100"
 
     while url is not None:
-        resp = requests.get(url, timeout=10)
+        resp = requests.get(url, timeout=120)
         data = resp.json()
 
         for tag in data["results"]:


### PR DESCRIPTION
This error is happening regularly during e2e tests.

```
../tests/user_flow/test_fds_sim.py:16: in test_fds_sim
    fds = inductiva.simulators.FDS()
/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/inductiva/simulators/fds.py:23: in __init__
    super().__init__(version=version, use_dev=use_dev)
/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/inductiva/simulators/simulator.py:64: in __init__
    self._image_uri = self._get_image_uri()
/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/inductiva/simulators/simulator.py:142: in _get_image_uri
    available = list_available_images()
/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/inductiva/simulators/methods.py:46: in list_available_images
    resp = requests.get(url, timeout=10)

...

        except (_SSLError, _HTTPError) as e:
            if isinstance(e, _SSLError):
                # This branch is for urllib3 versions earlier than v1.22
                raise SSLError(e, request=request)
            elif isinstance(e, ReadTimeoutError):
>               raise ReadTimeout(e, request=request)
E               requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='hub.docker.com', port=443): Read timed out. (read timeout=10)
```