### PR TITLE
Templating render_dir overwrite=True deletes previous target dir

### DIFF
--- a/docs/intro_to_api/templating.md
+++ b/docs/intro_to_api/templating.md
@@ -153,11 +153,8 @@ side: 1
 
 By default, the `TemplateManager` *will not overwrite* any existing files in the
 destination directory. Calls to the `render_dir` method will fail if
-any of the destination files already exist. Rendering and coping actions are
-transactional, meaning that the entire action will fail if any destination file
-exists. For example, consecutive calls to the same method will fail in the second
-call. This behavior is intended to prevent accidental overwriting of
-files that may have been generated in a previous run.
+any file already exist in the `target_dir`. This behavior is intended to prevent
+accidental overwriting of files that may have been generated in a previous run.
 
-To enforce the overwriting of existing files, you can set the `overwrite` argument
+To enforce deleting existing files, you can set the `overwrite` argument
 to `True` when calling the `renderdir` method.

--- a/inductiva/templating/helpers.py
+++ b/inductiva/templating/helpers.py
@@ -44,25 +44,3 @@ def get_dir_structure(template_dir: str):
             "files": [f for f in files if not is_template(f)],
         } for root, _, files in os.walk(template_dir, topdown=True)
     }
-
-
-def check_prerender_dir(source_dir_struct, target_dir: str):
-    """Check if the destination filenames exist.
-
-    Check if the destination filenames exist and raise a FileExistsError if
-    any of them already exists. For template files, the extension is
-    stripped before checking.
-
-    Args:
-        source_dir_struct (dict): The structure of the source directory,
-            as returned by `get_dir_structure`.
-        target_dir (pathlib.Path): The destination directory.
-    """
-    target_dir = pathlib.Path(target_dir)
-    for subdir, contents in source_dir_struct.items():
-        dest_subdir = target_dir / subdir
-        for file in contents["files"] + contents["templates"]:
-            raw_target_name = str(dest_subdir / file)
-            target_name = strip_extension(raw_target_name)
-            if os.path.exists(target_name):
-                raise FileExistsError(f"File {target_name} already exists.")

--- a/inductiva/templating/helpers.py
+++ b/inductiva/templating/helpers.py
@@ -1,6 +1,5 @@
 """Helper functions for the templating module."""
 import os
-import pathlib
 
 TEMPLATE_EXTENSION = ".jinja"
 

--- a/inductiva/templating/manager.py
+++ b/inductiva/templating/manager.py
@@ -37,8 +37,8 @@ class TemplateManager:
             target_dir (str): Path to the target directory.
             overwrite (bool): If True, the destination folder will first
                 be deleted if it already exists.
-                If False (default), a FileExistsError
-                will be raised if any destination file already exists.
+                If False (default), a FileExistsError will be raised if
+                any file already exists in the target directory.
             render_args: Keyword arguments to render the template files.
 
         Raises:

--- a/inductiva/templating/manager.py
+++ b/inductiva/templating/manager.py
@@ -35,8 +35,9 @@ class TemplateManager:
                 containing template files (and potentially static files to be
                 copied without modification).
             target_dir (str): Path to the target directory.
-            overwrite (bool): If True, the destination files will be overwritten
-                if they already exist. If False (default), a FileExistsError
+            overwrite (bool): If True, the destination folder will first
+                be deleted if it already exists.
+                If False (default), a FileExistsError
                 will be raised if any destination file already exists.
             render_args: Keyword arguments to render the template files.
 
@@ -63,12 +64,13 @@ class TemplateManager:
 
         template_dir_struct = helpers.get_dir_structure(source_dir)
 
-        if not overwrite:
-            try:
-                helpers.check_prerender_dir(template_dir_struct, target_dir)
-            except FileExistsError as e:
-                msg = f"{e}; set `overwrite=True` to overwrite existing files."
-                raise FileExistsError(msg) from e
+        if target_dir.exists() and any(target_dir.iterdir()):
+            if overwrite:
+                shutil.rmtree(target_dir)
+            else:
+                msg = (f"Non-empty target directory {target_dir}.\n"
+                       "Use `overwrite=True` to delete previous content.")
+                raise FileExistsError(msg)
 
         for subdir, contents in template_dir_struct.items():
             target_subdir = target_dir / subdir

--- a/inductiva/tests/templating/test_template_engine.py
+++ b/inductiva/tests/templating/test_template_engine.py
@@ -68,15 +68,26 @@ def test_render_dir__target_dir_exists_overwites__renders_correctly(
     # Determine if the directory is rendered when the target
     # exists and the overwrite flag is set.
 
-    # Copy a file to the target directory, in order to cause a conflict.
-    shutil.copyfile(ASSETS_DIR / "non_template.txt",
-                    tmp_target_dir / "non_template.txt")
-    assert os.path.isfile(tmp_target_dir / "non_template.txt")
+    # Create a file in the target directory.
+    new_file_path = tmp_target_dir / "existing_file.txt"
+    with open(new_file_path, "w", encoding="utf-8") as new_file:
+        new_file.write("This is the first line.\n")
+    assert os.path.isfile(tmp_target_dir / "existing_file.txt")
+
     # With overwrite=True, the directory should be rendered.
     TemplateManager.render_dir(ASSETS_DIR,
                                tmp_target_dir,
                                overwrite=True,
                                text="world")
+
+    # The existing_file should no longer exist, because "overwrite"
+    # set to True, the function should delete the existing files.
+    assert not os.path.isfile(new_file_path)
+    # And the new ones should appear there.
+    assert os.path.isfile(tmp_target_dir / "template.txt")
+    assert os.path.isfile(tmp_target_dir / "non_template.txt")
+    assert os.path.isfile(tmp_target_dir / "folder/nested_template.txt")
+    assert os.path.isfile(tmp_target_dir / "folder/nested_non_template.txt")
 
 
 @mark.parametrize(


### PR DESCRIPTION
Change in behaviour:
- any existing "non-colliding" files on the target_dir would be left there (if overwrite=True) and the new ones would appear. This was reported as being confusing and unexpected -- so now we clean up the whole directory if overwrite=True.
