### PR TITLE
Add cleanup_commands to coawst.

### DIFF
--- a/inductiva/simulators/coawst.py
+++ b/inductiva/simulators/coawst.py
@@ -61,6 +61,7 @@ class COAWST(simulators.Simulator):
             on: types.ComputationalResources,
             coawst_bin: str = "coawstM",
             init_commands: Optional[List[str]] = None,
+            cleanup_commands: Optional[List[str]] = None,
             use_hwthread: bool = True,
             n_vcpus: Optional[int] = None,
             storage_dir: Optional[str] = "",
@@ -81,6 +82,10 @@ class COAWST(simulators.Simulator):
                 `/workdir/output/artifacts/__COAWST`. It can also be used
                 to run any helper function present within COAWST, like
                 `scrip_coawst`.
+            cleanup_commands: List of helper commands to clean up things
+                after your simulation finishes. Used to copy files from
+                `/workdir/output/artifacts/__COAWST` to your input_dir. Or
+                to delete unwanted files generated during the simulation.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
             (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
@@ -130,6 +135,11 @@ class COAWST(simulators.Simulator):
         # Add init commands after building and before running the simulation
         if init_commands is not None:
             commands = commands[:1] + init_commands + commands[1:]
+
+        # Add cleanup commands after running the simulation
+        if cleanup_commands is not None:
+            # add comands to the penultimate position
+            commands = commands[:-2] + cleanup_commands + commands[-2:]
 
         return super().run(input_dir,
                            on=on,

--- a/inductiva/simulators/coawst.py
+++ b/inductiva/simulators/coawst.py
@@ -57,7 +57,7 @@ class COAWST(simulators.Simulator):
             input_dir: Optional[str],
             sim_config_filename: str,
             *,
-            build_coawst_script: str = None,
+            build_coawst_script: Optional[str] = None,
             on: types.ComputationalResources,
             coawst_bin: str = "coawstM",
             init_commands: Optional[List[str]] = None,

--- a/inductiva/simulators/coawst.py
+++ b/inductiva/simulators/coawst.py
@@ -113,7 +113,7 @@ class COAWST(simulators.Simulator):
                                     build_coawst_script=build_coawst_script)
 
             build_script = os.path.join(input_dir, build_coawst_script)
-            
+
             # only validates the build script if we are going to compile
             if simulation_binary is None:
                 self._validate_build_script(build_script=str(build_script))

--- a/inductiva/simulators/coawst.py
+++ b/inductiva/simulators/coawst.py
@@ -86,17 +86,19 @@ class COAWST(simulators.Simulator):
                 `/workdir/output/artifacts/__COAWST`. It can also be used
                 to run any helper function present within COAWST, like
                 `scrip_coawst`.
+                Will run before the compilation of the simulator.
             cleanup_commands: List of helper commands to clean up things
                 after your simulation finishes. Used to copy files from
                 `/workdir/output/artifacts/__COAWST` to your input_dir. Or
                 to delete unwanted files generated during the simulation.
+                Will run after the simulation ends.
             compile_simulator :
                 If True, the simulator will be compiled using the provided
                 `build_coawst_script`, and the simulation will run using the
                 specified `coawst_bin`.  
                 If False, the simulation will be run directly using the
                 precompiled `coawst_bin` binary, which should already exist in
-                the `input_dir`.
+                the `input_dir` with the same name as `coawst_bin`.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
                 (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the

--- a/inductiva/tests/simulators/test_simulator_with_resources.py
+++ b/inductiva/tests/simulators/test_simulator_with_resources.py
@@ -290,6 +290,8 @@ def test_resubmit_on_preemption__is_correctly_handled(resubmit_on_preemption):
             # that check if the input files are present
             if sim_name == "COAWST":
                 run_kwargs["remote_assets"] = ["temp"]
+                run_kwargs["build_coawst_script"] = "hello_world.sh"
+
 
             if sim_name in ("SWAN", "SWASH", "SNLSWAN"):
                 args = ("test_folder",)

--- a/inductiva/tests/simulators/test_simulator_with_resources.py
+++ b/inductiva/tests/simulators/test_simulator_with_resources.py
@@ -292,7 +292,6 @@ def test_resubmit_on_preemption__is_correctly_handled(resubmit_on_preemption):
                 run_kwargs["remote_assets"] = ["temp"]
                 run_kwargs["build_coawst_script"] = "hello_world.sh"
 
-
             if sim_name in ("SWAN", "SWASH", "SNLSWAN"):
                 args = ("test_folder",)
 


### PR DESCRIPTION
This list of commands will run after the simulation finishes and will allow the user to delete unwanted files, OR (this is why i added it) will allow the user to copy the compiled binary to the simulation files for later use in other simulations.


Because we want to allow the user to copy back the binary and re-use it in other simulations we need some extra arguments like -> simulation_binary that, if used will skip the compilation.