### PR TITLE
Improved Download tests

### DIFF
--- a/inductiva/tests/utils/test_download_examples.py
+++ b/inductiva/tests/utils/test_download_examples.py
@@ -1,25 +1,51 @@
 """Test examples download."""
 import os
 import ssl
+import shutil
 import zipfile
 import inductiva
 
+_URL = "https://storage.googleapis.com/inductiva-api-demo-files/" \
+          "openfoam-input-example.zip"
 
-def test_download_from_url():
+
+def test_download_from_url_unzip_false():
+
+    expected_download_path = os.path.join(os.curdir,
+                                          "openfoam-input-example.zip")
+    # Check that the file does not exist yet.
+    assert not os.path.exists(expected_download_path)
+    # Download file from url.
+    download_path = inductiva.utils.files.download_from_url(_URL)
+    # Check if the file exists.
+    assert os.path.exists(download_path)
+    # Check if the file was downloaded to the expected location.
+    assert os.path.samefile(download_path, expected_download_path)
+    # Check if the file is a zip file.
+    assert zipfile.is_zipfile(download_path)
+    # Delete the zip file that was downloaded.
+    os.remove(download_path)
+
+
+def test_download_from_url_unzip_true():
     # Disable SSL verification.
     # Had to do this for tests to pass on windows.
     #pylint: disable=protected-access
     ssl._create_default_https_context = ssl._create_unverified_context
 
-    url = "https://storage.googleapis.com/inductiva-api-demo-files/" \
-          "openfoam-input-example.zip"
+    # Check that the expected folder to unzip to, does not exist yet.
+    expected_unzipped_folder_path = os.path.join(os.curdir,
+                                                 "openfoam-input-example")
+    assert not os.path.exists(expected_unzipped_folder_path)
 
-    # Check if the unzip argument works.
-    download_path = inductiva.utils.files.download_from_url(url, unzip=True)
-    assert os.path.exists(download_path)
-    assert not zipfile.is_zipfile(download_path)
+    # Download and decompress file from url.
+    download_path = inductiva.utils.files.download_from_url(_URL, unzip=True)
 
-    # Check if the default is a zip file.
-    download_path = inductiva.utils.files.download_from_url(url)
-    assert os.path.exists(download_path)
-    assert zipfile.is_zipfile(download_path)
+    # Check if the unzipped folder has now been created.
+    assert os.path.isdir(download_path)
+
+    # Check folder was decompressed to the expected location.
+    assert os.path.samefile(download_path, expected_unzipped_folder_path)
+
+    # Delete the unzipped folder.
+    shutil.rmtree(download_path)


### PR DESCRIPTION
The main goal was to avoid leaving files on the local filesystem when one run the tests -- now the tests deletes the zip and the decompressed folder.
In the process I also took the opportunity to make more assertions about what was expected and not.