### PR TITLE
Download examples on first auth login

### DIFF
--- a/inductiva/_cli/cmd_auth/login.py
+++ b/inductiva/_cli/cmd_auth/login.py
@@ -57,25 +57,31 @@ def login(args):
         modules.append("openfoam_esi")
         modules.append("openfoam_foundation")
 
-        os.makedirs("simulator_examples", exist_ok=True)
-
+        os.makedirs("Inductiva_examples", exist_ok=True)
+        downloaded = []
         for module in modules:
             url = constants.INDUCTIVA_GIT_EXAMPLES_URL + f"{module}/{module}.py"
 
             response = requests.get(url, timeout=10)
             if response.status_code == 200:
-                with open(f"simulator_examples/{module}.py",
+                downloaded.append(f"{module}.py")
+                with open(f"Inductiva_examples/{module}.py",
                           "w",
                           encoding="utf-8") as f:
                     f.write(response.text)
-        print("")
+        print("\n")
         print(f"Welcome {user_name}!\n"
               "Since this is your first time logging in, we have downloaded "
               "some example scripts for you to get started.\n"
-              "The examples are located in the `simulator_examples` folder.\n"
+              "The examples are located in the `Inductiva_examples` folder.\n"
               "You can run them using the command "
-              "`python simulator_examples/<example.py>`.\n\n"
-              "Example: `python simulator_examples/openfoam_esi.py`\n")
+              "`python Inductiva_examples/<example.py>`.\n\n")
+        print("Available examples:\n")
+        for i in range(0, len(downloaded), 3):
+            line = [word.ljust(25) for word in downloaded[i:i + 4]]
+            print("".join(line))
+        print("\n\nRun your first simulation with "
+              "`python Inductiva_examples/openfoam_esi.py`\n")
 
 
 def register(parser):

--- a/inductiva/_cli/cmd_auth/login.py
+++ b/inductiva/_cli/cmd_auth/login.py
@@ -77,7 +77,7 @@ def login(args):
               "You can run them using the command "
               "`python inductiva_examples/<example.py>`.\n\n")
         print("Available examples:\n")
-        for i in range(0, len(downloaded), 2):
+        for i in range(0, len(downloaded), 3):
             line = [word.ljust(25) for word in downloaded[i:i + 3]]
             print("".join(line))
         print("\n\nRun your first simulation with "

--- a/inductiva/_cli/cmd_auth/login.py
+++ b/inductiva/_cli/cmd_auth/login.py
@@ -1,5 +1,6 @@
 """Register CLI command for login."""
 import argparse
+from typing import List
 import requests
 import getpass
 import pkgutil
@@ -7,6 +8,36 @@ import os
 
 import inductiva
 from inductiva import constants, users, utils
+
+
+def download_example_scripts() -> List[str]:
+    """Downloads example scripts from the Inductiva Github repository.
+
+    The scripts are downloaded to the `inductiva_examples` directory.
+
+    Returns:
+        list: A list of the names of the downloaded example scripts.
+    """
+    modules = [
+        name
+        for _, name, _ in pkgutil.iter_modules(inductiva.simulators.__path__)
+    ]
+    #openfoam as a different naming convention
+    modules.append("openfoam_esi")
+    modules.append("openfoam_foundation")
+
+    os.makedirs("inductiva_examples", exist_ok=True)
+    downloaded = []
+    for module in modules:
+        url = constants.INDUCTIVA_GIT_EXAMPLES_URL + f"{module}/{module}.py"
+
+        response = requests.get(url, timeout=10)
+        if response.status_code == 200:
+            downloaded.append(f"{module}.py")
+            with open(f"inductiva_examples/{module}.py", "w",
+                      encoding="utf-8") as f:
+                f.write(response.text)
+    return downloaded
 
 
 def login(args):
@@ -42,33 +73,16 @@ def login(args):
     # If the API Key is invalid, this will raise an exception
     user_info = users.get_info()
 
-    exists = utils.set_stored_api_key(api_key)
+    first_log_in = utils.set_stored_api_key(api_key)
 
     user_name = user_info["name"] or ""
 
-    if exists:
+    if first_log_in:
         print(f"Welcome back {user_name}!")
     else:
-        modules = [
-            name for _, name, _ in pkgutil.iter_modules(
-                inductiva.simulators.__path__)
-        ]
-        #openfoam as a different naming convention
-        modules.append("openfoam_esi")
-        modules.append("openfoam_foundation")
 
-        os.makedirs("inductiva_examples", exist_ok=True)
-        downloaded = []
-        for module in modules:
-            url = constants.INDUCTIVA_GIT_EXAMPLES_URL + f"{module}/{module}.py"
+        downloaded = download_example_scripts()
 
-            response = requests.get(url, timeout=10)
-            if response.status_code == 200:
-                downloaded.append(f"{module}.py")
-                with open(f"inductiva_examples/{module}.py",
-                          "w",
-                          encoding="utf-8") as f:
-                    f.write(response.text)
         print("\n")
         print(f"Welcome {user_name}!\n"
               "Since this is your first time logging in, we have downloaded "

--- a/inductiva/_cli/cmd_auth/login.py
+++ b/inductiva/_cli/cmd_auth/login.py
@@ -77,8 +77,8 @@ def login(args):
               "You can run them using the command "
               "`python Inductiva_examples/<example.py>`.\n\n")
         print("Available examples:\n")
-        for i in range(0, len(downloaded), 3):
-            line = [word.ljust(25) for word in downloaded[i:i + 4]]
+        for i in range(0, len(downloaded), 2):
+            line = [word.ljust(25) for word in downloaded[i:i + 3]]
             print("".join(line))
         print("\n\nRun your first simulation with "
               "`python Inductiva_examples/openfoam_esi.py`\n")

--- a/inductiva/_cli/cmd_auth/login.py
+++ b/inductiva/_cli/cmd_auth/login.py
@@ -57,7 +57,7 @@ def login(args):
         modules.append("openfoam_esi")
         modules.append("openfoam_foundation")
 
-        os.makedirs("Inductiva_examples", exist_ok=True)
+        os.makedirs("inductiva_examples", exist_ok=True)
         downloaded = []
         for module in modules:
             url = constants.INDUCTIVA_GIT_EXAMPLES_URL + f"{module}/{module}.py"
@@ -65,7 +65,7 @@ def login(args):
             response = requests.get(url, timeout=10)
             if response.status_code == 200:
                 downloaded.append(f"{module}.py")
-                with open(f"Inductiva_examples/{module}.py",
+                with open(f"inductiva_examples/{module}.py",
                           "w",
                           encoding="utf-8") as f:
                     f.write(response.text)
@@ -73,15 +73,15 @@ def login(args):
         print(f"Welcome {user_name}!\n"
               "Since this is your first time logging in, we have downloaded "
               "some example scripts for you to get started.\n"
-              "The examples are located in the `Inductiva_examples` folder.\n"
+              "The examples are located in the `inductiva_examples` folder.\n"
               "You can run them using the command "
-              "`python Inductiva_examples/<example.py>`.\n\n")
+              "`python inductiva_examples/<example.py>`.\n\n")
         print("Available examples:\n")
         for i in range(0, len(downloaded), 2):
             line = [word.ljust(25) for word in downloaded[i:i + 3]]
             print("".join(line))
         print("\n\nRun your first simulation with "
-              "`python Inductiva_examples/openfoam_esi.py`\n")
+              "`python inductiva_examples/openfoam_esi.py`\n")
 
 
 def register(parser):

--- a/inductiva/constants.py
+++ b/inductiva/constants.py
@@ -28,6 +28,10 @@ LOADER_IGNORE_PREFIX = "__"
 
 LOADER_HIDE_PREFIX = "_"
 
+INDUCTIVA_GIT_EXAMPLES_URL = ("https://raw.githubusercontent.com/inductiva"
+                              "/inductiva/refs/heads/main/inductiva/tests/"
+                              "test_simulators/")
+
 # when printing the stack trace, how many lines to show
 EXCEPTIONS_MAX_TRACEBACK_DEPTH = 2
 

--- a/inductiva/simulators/cm1.py
+++ b/inductiva/simulators/cm1.py
@@ -28,7 +28,6 @@ class CM1(simulators.Simulator):
             input_dir: Optional[str],
             *,
             on: types.ComputationalResources,
-            mode: str = "mpi",
             n_vcpus: Optional[int] = None,
             use_hwthread: bool = True,
             sim_config_filename: Optional[str] = None,
@@ -40,7 +39,6 @@ class CM1(simulators.Simulator):
 
         Args:
             input_dir: Path to the directory of the simulation input files.
-            mode (str): The execution mode, either 'mpi' or 'openmp'.
             on: The computational resource to launch the simulation on.
             sim_config_filename: Name of the simulation configuration file.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
@@ -57,19 +55,15 @@ class CM1(simulators.Simulator):
                 the simulation directory.
             other arguments: See the documentation of the base class.
         """
-        mode = mode.lower()
-        executable = "cm1.exe" if mode == "mpi" else "cm1_openmp.exe"
         mpi_config = None
 
-        if mode == "mpi":
-            mpi_kwargs = {"use_hwthread_cpus": use_hwthread}
-            if n_vcpus is not None:
-                mpi_kwargs["np"] = n_vcpus
-            mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
+        mpi_kwargs = {"use_hwthread_cpus": use_hwthread}
+        if n_vcpus is not None:
+            mpi_kwargs["np"] = n_vcpus
+        mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
 
         commands = [
-            Command(f"{executable} {sim_config_filename}",
-                    mpi_config=mpi_config)
+            Command(f"cm1.exe {sim_config_filename}", mpi_config=mpi_config)
         ]
 
         return super().run(input_dir,

--- a/inductiva/simulators/snl_swan.py
+++ b/inductiva/simulators/snl_swan.py
@@ -97,7 +97,8 @@ class SNLSWAN(simulators.Simulator):
 
             commands.append(machinefile_command)
 
-            mpi_flag = f"-mpi {n_vcpus}" if n_vcpus else ""
+            #if the user does not provide n_vcpus use all available by default
+            mpi_flag = f"-mpi {n_vcpus or on.available_vcpus}"
 
             swanrun_command = Command(
                 f"swanrun -input {config_file_only} {mpi_flag}")
@@ -108,6 +109,7 @@ class SNLSWAN(simulators.Simulator):
         elif command == "swan.exe":
 
             mpi_kwargs = {}
+            #If the user does not provide n_vcpus mpi will use all available
             if n_vcpus is not None:
                 mpi_kwargs["np"] = n_vcpus
             mpi_kwargs["use_hwthread_cpus"] = use_hwthread
@@ -116,7 +118,6 @@ class SNLSWAN(simulators.Simulator):
             swan_exe_command = Command(f"swan.exe {sim_config_filename}",
                                        mpi_config=mpi_config)
             commands.append(swan_exe_command)
-
         return super().run(input_dir,
                            on=on,
                            storage_dir=storage_dir,

--- a/inductiva/tests/test_simulators/amr_wind/amr_wind.py
+++ b/inductiva/tests/test_simulators/amr_wind/amr_wind.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 # Set simulation input directory
 input_dir = inductiva.utils.download_from_url(

--- a/inductiva/tests/test_simulators/amr_wind/amr_wind.py
+++ b/inductiva/tests/test_simulators/amr_wind/amr_wind.py
@@ -13,7 +13,8 @@ input_dir = inductiva.utils.download_from_url(
     unzip=True)
 
 # Initialize the Simulator
-amr_wind = inductiva.simulators.AmrWind()
+amr_wind = inductiva.simulators.AmrWind( \
+    version="3.4.1")
 
 # Run simulation with config files in the input directory
 task = amr_wind.run( \

--- a/inductiva/tests/test_simulators/cans/cans.py
+++ b/inductiva/tests/test_simulators/cans/cans.py
@@ -13,7 +13,8 @@ input_dir = inductiva.utils.download_from_url(
     unzip=True)
 
 # Initialize the Simulator
-cans = inductiva.simulators.CaNS()
+cans = inductiva.simulators.CaNS( \
+    version="2.4.0")
 
 # Run simulation with config files in the input directory
 task = cans.run( \

--- a/inductiva/tests/test_simulators/cans/cans.py
+++ b/inductiva/tests/test_simulators/cans/cans.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 # Set simulation input directory
 input_dir = inductiva.utils.download_from_url(

--- a/inductiva/tests/test_simulators/cm1/cm1.py
+++ b/inductiva/tests/test_simulators/cm1/cm1.py
@@ -1,4 +1,4 @@
-"""DualSPHysics example."""
+"""CM1 example"""
 import inductiva
 
 # Instantiate machine group
@@ -6,19 +6,20 @@ cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
     machine_type="c2d-highcpu-4")
 
-# Download the configuration files into a folder
+# Set simulation input directory
 input_dir = inductiva.utils.download_from_url(
     "https://storage.googleapis.com/inductiva-api-demo-files/"
-    "dualsphysics-input-example.zip",
+    "cm1-input-example.zip",
     unzip=True)
 
 # Initialize the Simulator
-dualsphysics = inductiva.simulators.DualSPHysics()
+cm1 = inductiva.simulators.CM1( \
+    version="21.1")
 
 # Run simulation with config files in the input directory
-task = dualsphysics.run( \
+task = cm1.run( \
     input_dir=input_dir,
-    shell_script="run.sh",
+    sim_config_filename="namelist.input",
     on=cloud_machine)
 
 task.wait()

--- a/inductiva/tests/test_simulators/cp2k/cp2k.py
+++ b/inductiva/tests/test_simulators/cp2k/cp2k.py
@@ -4,7 +4,7 @@ import inductiva
 # Allocate cloud machine on Google Cloud Platform
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 # Download input files and store them in a directory
 input_dir = inductiva.utils.download_from_url(

--- a/inductiva/tests/test_simulators/delft3d/delft3d.py
+++ b/inductiva/tests/test_simulators/delft3d/delft3d.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 input_dir = inductiva.utils.download_from_url(
     "https://storage.googleapis.com/inductiva-api-demo-files/"

--- a/inductiva/tests/test_simulators/dualsphysics/dualsphysics.py
+++ b/inductiva/tests/test_simulators/dualsphysics/dualsphysics.py
@@ -13,7 +13,8 @@ input_dir = inductiva.utils.download_from_url(
     unzip=True)
 
 # Initialize the Simulator
-dualsphysics = inductiva.simulators.DualSPHysics()
+dualsphysics = inductiva.simulators.DualSPHysics( \
+    version="5.2.1")
 
 # Run simulation with config files in the input directory
 task = dualsphysics.run( \

--- a/inductiva/tests/test_simulators/fds/fds.py
+++ b/inductiva/tests/test_simulators/fds/fds.py
@@ -11,7 +11,8 @@ input_dir = inductiva.utils.download_from_url(
     "fds-input-example.zip",
     unzip=True)
 
-fds = inductiva.simulators.FDS()
+fds = inductiva.simulators.FDS( \
+    version="6.10.1")
 
 task = fds.run( \
     input_dir=input_dir,

--- a/inductiva/tests/test_simulators/fds/fds.py
+++ b/inductiva/tests/test_simulators/fds/fds.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 input_dir = inductiva.utils.download_from_url(
     "https://storage.googleapis.com/inductiva-api-demo-files/"

--- a/inductiva/tests/test_simulators/fvcom/fvcom.py
+++ b/inductiva/tests/test_simulators/fvcom/fvcom.py
@@ -13,7 +13,8 @@ input_dir = inductiva.utils.download_from_url(
     unzip=True)
 
 # Initialize the Simulator
-fvcom = inductiva.simulators.FVCOM()
+fvcom = inductiva.simulators.FVCOM( \
+    version="5.1.0")
 
 # Run simulation with config files in the input directory
 task = fvcom.run( \

--- a/inductiva/tests/test_simulators/fvcom/fvcom.py
+++ b/inductiva/tests/test_simulators/fvcom/fvcom.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 # Set simulation input directory
 input_dir = inductiva.utils.download_from_url(

--- a/inductiva/tests/test_simulators/gromacs/gromacs.py
+++ b/inductiva/tests/test_simulators/gromacs/gromacs.py
@@ -26,7 +26,8 @@ commands = [
      "-g eql.log"),
 ]
 
-gromacs = inductiva.simulators.GROMACS()
+gromacs = inductiva.simulators.GROMACS( \
+    version="2022.2")
 
 task = gromacs.run( \
     input_dir=input_dir,

--- a/inductiva/tests/test_simulators/gromacs/gromacs.py
+++ b/inductiva/tests/test_simulators/gromacs/gromacs.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 input_dir = inductiva.utils.download_from_url(
     "https://storage.googleapis.com/inductiva-api-demo-files/"

--- a/inductiva/tests/test_simulators/gx/gx.py
+++ b/inductiva/tests/test_simulators/gx/gx.py
@@ -11,7 +11,8 @@ input_dir = inductiva.utils.download_from_url(
     "gx-input-example.zip",
     unzip=True)
 
-gx = inductiva.simulators.GX()
+gx = inductiva.simulators.GX( \
+    version="11-2024")
 
 task = gx.run( \
     input_dir=input_dir,

--- a/inductiva/tests/test_simulators/nwchem/nwchem.py
+++ b/inductiva/tests/test_simulators/nwchem/nwchem.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 input_dir = inductiva.utils.download_from_url(
     "https://storage.googleapis.com/inductiva-api-demo-files/"

--- a/inductiva/tests/test_simulators/nwchem/nwchem.py
+++ b/inductiva/tests/test_simulators/nwchem/nwchem.py
@@ -11,7 +11,8 @@ input_dir = inductiva.utils.download_from_url(
     "nwchem-input-example.zip",
     unzip=True)
 
-nwchem = inductiva.simulators.NWChem()
+nwchem = inductiva.simulators.NWChem( \
+    version="7.2.3")
 
 task = nwchem.run( \
     input_dir=input_dir,

--- a/inductiva/tests/test_simulators/openfast/openfast.py
+++ b/inductiva/tests/test_simulators/openfast/openfast.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 # Set simulation input directory
 input_dir = inductiva.utils.download_from_url(

--- a/inductiva/tests/test_simulators/openfoam_esi/openfoam_esi.py
+++ b/inductiva/tests/test_simulators/openfoam_esi/openfoam_esi.py
@@ -13,7 +13,9 @@ input_dir = inductiva.utils.download_from_url(
     unzip=True)
 
 # Initialize the Simulator
-openfoam = inductiva.simulators.OpenFOAM(distribution="esi")
+openfoam = inductiva.simulators.OpenFOAM( \
+    distribution="esi",
+    version="2406")
 
 # Run simulation with config files in the input directory
 task = openfoam.run( \

--- a/inductiva/tests/test_simulators/openfoam_esi/openfoam_esi.py
+++ b/inductiva/tests/test_simulators/openfoam_esi/openfoam_esi.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 # Set simulation input directory
 input_dir = inductiva.utils.download_from_url(

--- a/inductiva/tests/test_simulators/openfoam_foundation/openfoam_foundation.py
+++ b/inductiva/tests/test_simulators/openfoam_foundation/openfoam_foundation.py
@@ -14,7 +14,8 @@ input_dir = inductiva.utils.download_from_url(
 
 # Initialize the Simulator
 openfoam = inductiva.simulators.OpenFOAM( \
-    distribution="foundation")
+    distribution="foundation",
+    version="8")
 
 # Run simulation with config files in the input directory
 task = openfoam.run( \

--- a/inductiva/tests/test_simulators/opensees/opensees.py
+++ b/inductiva/tests/test_simulators/opensees/opensees.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 # Download input files and store them in a directory
 input_dir = inductiva.utils.download_from_url(

--- a/inductiva/tests/test_simulators/quantum_espresso/quantum_espresso.py
+++ b/inductiva/tests/test_simulators/quantum_espresso/quantum_espresso.py
@@ -26,7 +26,8 @@ commands = [
 ]
 
 # Initialize QuantumEspresso simulator
-qe = inductiva.simulators.QuantumEspresso()
+qe = inductiva.simulators.QuantumEspresso( \
+    version="7.4.1")
 
 # Run simulation
 task = qe.run( \

--- a/inductiva/tests/test_simulators/quantum_espresso/quantum_espresso.py
+++ b/inductiva/tests/test_simulators/quantum_espresso/quantum_espresso.py
@@ -5,7 +5,7 @@ from inductiva.commands import MPIConfig, Command
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 # Set simulation input directory
 input_dir = inductiva.utils.download_from_url(

--- a/inductiva/tests/test_simulators/reef3d/reef3d.py
+++ b/inductiva/tests/test_simulators/reef3d/reef3d.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 input_dir = inductiva.utils.download_from_url(
     "https://storage.googleapis.com/inductiva-api-demo-files/"

--- a/inductiva/tests/test_simulators/reef3d/reef3d.py
+++ b/inductiva/tests/test_simulators/reef3d/reef3d.py
@@ -11,7 +11,8 @@ input_dir = inductiva.utils.download_from_url(
     "reef3d-input-example.zip",
     unzip=True)
 
-reef3d = inductiva.simulators.REEF3D()
+reef3d = inductiva.simulators.REEF3D( \
+    version="24.02")
 
 task = reef3d.run( \
     input_dir=input_dir,

--- a/inductiva/tests/test_simulators/schism/schism.py
+++ b/inductiva/tests/test_simulators/schism/schism.py
@@ -12,7 +12,8 @@ input_dir = inductiva.utils.files.download_from_url(
     "schism-input-example.zip", True)
 
 # Initialize the Simulator
-schism = inductiva.simulators.SCHISM()
+schism = inductiva.simulators.SCHISM( \
+    version="5.11.0")
 
 # Run simulation with config files in the input directory
 task = schism.run( \

--- a/inductiva/tests/test_simulators/schism/schism.py
+++ b/inductiva/tests/test_simulators/schism/schism.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 # Set simulation input directory
 input_dir = inductiva.utils.files.download_from_url(

--- a/inductiva/tests/test_simulators/snl_swan/snl_swan.py
+++ b/inductiva/tests/test_simulators/snl_swan/snl_swan.py
@@ -1,4 +1,4 @@
-"""DualSPHysics example."""
+"""SNLSWAN example."""
 import inductiva
 
 # Instantiate machine group
@@ -6,21 +6,23 @@ cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
     machine_type="c2d-highcpu-4")
 
-# Download the configuration files into a folder
-input_dir = inductiva.utils.download_from_url(
+# Set simulation input directory
+input_dir = inductiva.utils.files.download_from_url(
     "https://storage.googleapis.com/inductiva-api-demo-files/"
-    "dualsphysics-input-example.zip",
-    unzip=True)
+    "snlswan-input-example.zip", True)
 
 # Initialize the Simulator
-dualsphysics = inductiva.simulators.DualSPHysics()
+snlswan = inductiva.simulators.SNLSWAN( \
+    version="2.2")
 
 # Run simulation with config files in the input directory
-task = dualsphysics.run( \
+# Uses swanrun by default
+task = snlswan.run( \
     input_dir=input_dir,
-    shell_script="run.sh",
+    sim_config_filename="input.swn",
     on=cloud_machine)
 
+# Wait for the simulation to finish and download the results
 task.wait()
 cloud_machine.terminate()
 

--- a/inductiva/tests/test_simulators/splishsplash/splishsplash.py
+++ b/inductiva/tests/test_simulators/splishsplash/splishsplash.py
@@ -12,7 +12,8 @@ input_dir = inductiva.utils.download_from_url(
     unzip=True)
 
 # Set simulation input directory
-splishsplash = inductiva.simulators.SplishSplash()
+splishsplash = inductiva.simulators.SplishSplash( \
+    version="2.13.0")
 
 task = splishsplash.run( \
     input_dir=input_dir,

--- a/inductiva/tests/test_simulators/splishsplash/splishsplash.py
+++ b/inductiva/tests/test_simulators/splishsplash/splishsplash.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 input_dir = inductiva.utils.download_from_url(
     "https://storage.googleapis.com/inductiva-api-demo-files/"

--- a/inductiva/tests/test_simulators/swan/swan.py
+++ b/inductiva/tests/test_simulators/swan/swan.py
@@ -12,7 +12,8 @@ input_dir = inductiva.utils.files.download_from_url(
     "swan-input-example.zip", True)
 
 # Initialize the Simulator
-swan = inductiva.simulators.SWAN()
+swan = inductiva.simulators.SWAN( \
+    version="41.45")
 
 # Run simulation with config files in the input directory
 # Uses swanrun by default

--- a/inductiva/tests/test_simulators/swan/swan.py
+++ b/inductiva/tests/test_simulators/swan/swan.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 # Set simulation input directory
 input_dir = inductiva.utils.files.download_from_url(

--- a/inductiva/tests/test_simulators/swash/swash.py
+++ b/inductiva/tests/test_simulators/swash/swash.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 # Set simulation input directory
 input_dir = inductiva.utils.download_from_url(

--- a/inductiva/tests/test_simulators/xbeach/xbeach.py
+++ b/inductiva/tests/test_simulators/xbeach/xbeach.py
@@ -4,7 +4,7 @@ import inductiva
 # Instantiate machine group
 cloud_machine = inductiva.resources.MachineGroup( \
     provider="GCP",
-    machine_type="c2-highcpu-4")
+    machine_type="c2d-highcpu-4")
 
 # Download example configuration files from Inductiva storage
 input_dir = inductiva.utils.download_from_url(

--- a/inductiva/tests/test_simulators/xbeach/xbeach.py
+++ b/inductiva/tests/test_simulators/xbeach/xbeach.py
@@ -13,7 +13,8 @@ input_dir = inductiva.utils.download_from_url(
     unzip=True)
 
 # Initialize the Simulator
-xbeach = inductiva.simulators.XBeach()
+xbeach = inductiva.simulators.XBeach( \
+    version="1.24")
 
 # Run simulation with configuration files in the input directory
 task = xbeach.run( \

--- a/inductiva/utils/authentication.py
+++ b/inductiva/utils/authentication.py
@@ -22,11 +22,17 @@ def get_stored_api_key(path=None):
         return f.read()
 
 
-def set_stored_api_key(api_key, path=None):
-    """Saves the API key to the file system."""
+def set_stored_api_key(api_key, path=None) -> bool:
+    """Saves the API key to the file system.
+    Returns True if the key already existed, False otherwise.
+    """
     key_path = path or constants.API_KEY_FILE_PATH
+
+    exists = key_path.exists()
+
     with open(key_path, "w", encoding="utf-8") as f:
         f.write(api_key)
+    return exists
 
 
 def remove_stored_api_key(path=None):


### PR DESCRIPTION
When the user first logs in with `inductiva auth login` we now download all simulator_examples from our github and place into simulator_examples/<example.py>.

We then present a message encouraging the user to run his first simulation.

On first login:
```
Welcome Paulo Barbosa!
Since this is your first time logging in, we have downloaded some example scripts for you to get started.
The examples are located in the `inductiva_examples` folder.
You can run them using the command `python inductiva_examples/<example.py>`.


Available examples:

amr_wind.py              cans.py                  coawst.py                
cp2k.py                  delft3d.py               dualsphysics.py          
fds.py                   fvcom.py                 gromacs.py               
gx.py                    nwchem.py                openfast.py              
opensees.py              opentelemac.py           quantum_espresso.py      
reef3d.py                schism.py                splishsplash.py          
swan.py                  swash.py                 xbeach.py                
openfoam_esi.py          openfoam_foundation.py   


Run your first simulation with `python inductiva_examples/openfoam_esi.py`
```

PS: also did a small fix on the examples and created some examples that were missing.