### PR TITLE
Stop upload notifications to storage

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -114,21 +114,6 @@ def upload_file(api_instance: ApiClient, input_path: str, method: str, url: str,
             raise ApiException(status=resp.status, reason=resp.reason)
 
 
-def notify_upload_complete(api_endpoint,
-                           query_params: Dict[str, str] = None,
-                           path_params: Dict[str, str] = None):
-    """
-    Notifies the API that the file upload is complete.
-    """
-    params = {}
-    if query_params is not None:
-        params["query_params"] = query_params
-    if path_params is not None:
-        params["path_params"] = path_params
-
-    api_endpoint(**params)
-
-
 def upload_input(api_instance: TasksApi, input_dir, params, task_id,
                  storage_path_prefix):
     """Uploads the inputs of a given task to the API.
@@ -157,11 +142,7 @@ def upload_input(api_instance: TasksApi, input_dir, params, task_id,
                        unit_scale=True,
                        unit_divisor=1000) as progress_bar:
             upload_file(api_instance, input_zip_path, "PUT", url, progress_bar)
-            notify_upload_complete(
-                api_instance.notify_input_uploaded,
-                path_params={"task_id": task_id},
-            )
-
+            api_instance.notify_input_uploaded(path_params={"task_id": task_id})
         logging.info("Local input directory successfully uploaded.")
         logging.info("")
 

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -344,13 +344,6 @@ def upload(
             try:
                 methods.upload_file(api_instance, local_file_path, "PUT", url,
                                     progress_bar)
-
-                methods.notify_upload_complete(
-                    api_instance.notify_upload_file,
-                    query_params={
-                        "path": remote_file_path,
-                    },
-                )
             except exceptions.ApiException as e:
                 raise e
 


### PR DESCRIPTION
Storage no longer needs to be notified when a file is uploaded. Notification is now only required to start a simulation.