### PR TITLE
Prevent Commands from having special characters

### DIFF
--- a/inductiva/commands/commands.py
+++ b/inductiva/commands/commands.py
@@ -6,7 +6,6 @@ from .mpiconfig import MPIConfig
 
 class Command:
     """Abstraction class for commands."""
-
     SPECIAL_CHARACTERS = r"[|><&;*?~$]"
     SPECIAL_CHARACTERS_PRETTY_PRINT = r"| > < & ; * ? ~ $"
 

--- a/inductiva/commands/commands.py
+++ b/inductiva/commands/commands.py
@@ -1,10 +1,14 @@
 """Wrapper class for simulator commands."""
+import re
 from inductiva import types
 from .mpiconfig import MPIConfig
 
 
 class Command:
     """Abstraction class for commands."""
+
+    SPECIAL_CHARACTERS = r"[|><&;*?~$()\[\]]"
+    SPECIAL_CHARACTERS_PRETTY_PRINT = r"| > < & ; * ? ~ $ ( ) [ ]"
 
     def __init__(self, cmd: str, *prompts: str, mpi_config: MPIConfig = None):
         """
@@ -23,10 +27,24 @@ class Command:
 
         if mpi_config and not isinstance(mpi_config, MPIConfig):
             raise TypeError("'mpi_config' must be an instance of MPIConfig.")
-
+        if self._has_special_chars(cmd):
+            raise ValueError(
+                "Command contains unsupported characters.\n"
+                "Please avoid using any of the following characters:\n"
+                f"{self.SPECIAL_CHARACTERS_PRETTY_PRINT}\n")
         self.cmd = cmd
         self.prompts = list(prompts)
         self.mpi_config = mpi_config
+
+    def _has_special_chars(self, command):
+        """Checks if the command contains special characters.
+        Args:
+            command: The command to check.
+        Returns:
+            True if the command contains special characters, False otherwise.
+            """
+
+        return bool(re.search(self.SPECIAL_CHARACTERS, command))
 
     def to_dict(self):
         """

--- a/inductiva/commands/commands.py
+++ b/inductiva/commands/commands.py
@@ -7,8 +7,8 @@ from .mpiconfig import MPIConfig
 class Command:
     """Abstraction class for commands."""
 
-    SPECIAL_CHARACTERS = r"[|><&;*?~$()\[\]]"
-    SPECIAL_CHARACTERS_PRETTY_PRINT = r"| > < & ; * ? ~ $ ( ) [ ]"
+    SPECIAL_CHARACTERS = r"[|><&;*?~$]"
+    SPECIAL_CHARACTERS_PRETTY_PRINT = r"| > < & ; * ? ~ $"
 
     def __init__(self, cmd: str, *prompts: str, mpi_config: MPIConfig = None):
         """

--- a/inductiva/tests/simulators/test_simulator_with_resources.py
+++ b/inductiva/tests/simulators/test_simulator_with_resources.py
@@ -254,6 +254,7 @@ def test_resubmit_on_preemption__is_correctly_handled(resubmit_on_preemption):
     mock_mg = mock.Mock()
     mock_mg.id = uuid.uuid4()
     mock_mg.has_gpu.return_value = True
+    mock_mg.available_vcpus = 16
 
     for sim_name, simcls in sim_classes:
 


### PR DESCRIPTION
Since we are running commands with:

subprocess.run with `shell=False` our commands can't have special characters. We now check for them in the python client to avoid having strange things happen to the machines.