### PR TITLE
Update personal docker quality of life

### DIFF
--- a/inductiva/_cli/cmd_containers/convert.py
+++ b/inductiva/_cli/cmd_containers/convert.py
@@ -10,13 +10,11 @@ import tempfile
 from typing import TextIO
 import uuid
 
-import docker.errors
-
 from inductiva import constants
 
 try:
     import docker
-    from docker.errors import DockerException, ImageNotFound
+    from docker.errors import DockerException, ImageNotFound, NotFound
 except ImportError:
     docker = None
 
@@ -167,7 +165,7 @@ def convert_image(args, fout: TextIO = sys.stdout):
         try:
             if container:
                 container.remove(force=True)
-        except docker.errors.NotFound:
+        except NotFound:
             pass
 
     # Clean up the temporary tar file if one was created.

--- a/inductiva/_cli/cmd_containers/convert.py
+++ b/inductiva/_cli/cmd_containers/convert.py
@@ -8,6 +8,9 @@ import sys
 import os
 import tempfile
 from typing import TextIO
+import uuid
+
+import docker.errors
 
 from inductiva import constants
 
@@ -90,7 +93,9 @@ def convert_image(args, fout: TextIO = sys.stdout):
             return False
 
         # Save the image to a temporary tar file.
-        with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(suffix=".tar",
+                                         delete=False,
+                                         dir=constants.TMP_DIR) as tmp:
             tmp_tar_path = tmp.name
             with open(tmp_tar_path, "wb") as f:
                 for chunk in image_obj.save(named=True):
@@ -126,7 +131,7 @@ def convert_image(args, fout: TextIO = sys.stdout):
     try:
         container = client.containers.run(
             image=constants.TASK_RUNNER_IMAGE,
-            name="apptainer-converter",
+            name=f"apptainer-converter-{uuid.uuid4().hex[:8]}",
             entrypoint="/usr/bin/apptainer",
             command=command,
             mounts=mounts,
@@ -156,6 +161,14 @@ def convert_image(args, fout: TextIO = sys.stdout):
     except Exception as e:  # pylint: disable=broad-exception-caught
         print(f"Error during conversion: {e}", file=fout)
         return False
+
+    finally:
+        # Clean up the container if it was created.
+        try:
+            if container:
+                container.remove(force=True)
+        except docker.errors.NotFound:
+            pass
 
     # Clean up the temporary tar file if one was created.
     if tmp_tar_path and os.path.exists(tmp_tar_path):

--- a/inductiva/_cli/cmd_containers/upload.py
+++ b/inductiva/_cli/cmd_containers/upload.py
@@ -8,6 +8,7 @@ import pathlib
 import sys
 import tempfile
 from inductiva import storage, constants
+from inductiva.client.exceptions import ApiException
 from inductiva.utils.input_functions import user_confirmation_prompt
 from .convert import convert_image
 
@@ -57,7 +58,7 @@ def upload_container(args):
     # ---------- pre-flight: does it already exist? ---------------------------
     try:
         contents = storage.listdir(folder_name, print_results=False)
-    except Exception as e:  # pylint: disable=broad-except
+    except ApiException as e:
         print(f"Error accessing remote folder '{folder_name}': {e}",
               file=sys.stderr)
         return
@@ -65,11 +66,11 @@ def upload_container(args):
     already_there = any(c["content_name"] == filename for c in contents)
     if already_there:
         if args.overwrite:
-            print(f"⚠️  '{output_path}' exists - will overwrite it "
+            print(f"'{output_path}' exists - will overwrite it "
                   "(because --overwrite).")
             try:
                 storage.remove_workspace(f"{folder_name}/{filename}")
-            except Exception as e:  # pylint: disable=broad-except
+            except ApiException as e:
                 print(f"Failed to delete old file: {e}", file=sys.stderr)
                 return
         else:

--- a/inductiva/_cli/cmd_containers/upload.py
+++ b/inductiva/_cli/cmd_containers/upload.py
@@ -54,7 +54,7 @@ def upload_container(args):
     folder_name = output_path.split(os.sep)[0]
     filename = os.path.basename(output_path)
 
-    # ---------- pre-flight: does it already exist? ------------------------------
+    # ---------- pre-flight: does it already exist? ---------------------------
     try:
         contents = storage.listdir(folder_name, print_results=False)
     except Exception as e:  # pylint: disable=broad-except

--- a/inductiva/constants.py
+++ b/inductiva/constants.py
@@ -49,6 +49,8 @@ else:
 
 LOGS_FILE_PATH = HOME_DIR / "inductiva.log"
 API_KEY_FILE_PATH = HOME_DIR / "api_key"
+TMP_DIR = HOME_DIR / "tmp"
+TMP_DIR.mkdir(parents=True, exist_ok=True)
 
 TASK_OUTPUT_ZIP = "output.zip"
 TASK_INPUT_ZIP = "input.zip"


### PR DESCRIPTION
There were a few bugs that were harming the quality of life for the personal docker usage.

### 1 Containers hanging

The apptainer-converter container wouldn't be removed after the conversion was finished. Users needed to do `docker ps -a` and `docker rm apptainer-converter-id`

To solve this, i've added a finally clause to remove the apptainer-converter container used in this session.

---

### 2 Multiple conversions

Users couldn't convert/upload multiple containers at the same time. The `apptainer-converter` container was named after itself, meaning that only one could exist at any given time.

To solve this, i've added a mini unique id to the end of the `apptainer-converter` name, so now it should allow more multiple conversions to happen at the same time. 

---

### 3 Overwrite flag

Users couldn't update existing containers on their remote storage. They had to use `inductiva containers rm` and then upload the new container.

Now, the upload command checks if the container already exists. If it does, then it will prompt the user if it wants to overwrite it.

```bash
➜  inductiva containers upload docker://nginx:alpine   
Overwrite the existing file?
  - nginx.sif
Are you sure you want to proceed (y/[N])? 
```

Or if the users use the `--overwrite / -f` flag this confirmation is skipped.

```bash
➜  inductiva containers upload docker://nginx:alpine --overwrite
⚠️  'my-containers/nginx.sif' exists - will overwrite it (because --overwrite).
Removing workspace file(s)...
Workspace file(s) removed successfully.
Converting docker://nginx:alpine -> /Users/franreno/.inductiva/tmp/tmp3aet9uld/my-containers/nginx.sif...
Conversion started with container ID: 02f1387ff7ea
```


---

### 4 Tmp permission error

The upload command tried to use the /tmp directory (in linux). But if the user didn't had permissions to write at that location the command would fail.

To solve this, I've updated the command to have a tmp dir inside of the HOME_DIR of the User. Meaning that the conversion and upload will create a temporary file at `/home/user/.inductiva/tmp` instead of `/tmp/`, which should bypass this permission error. 