### PR TITLE
Make 7z the default compression method

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -335,7 +335,7 @@ def submit_task(simulator,
         remote_assets = []
 
     stream_zip = params.pop("stream_zip", True)
-    compress_with = params.pop("compress_with", CompressionMethod.AUTO)
+    compress_with = params.pop("compress_with", CompressionMethod.SEVEN_Z)
 
     task_request = TaskRequest(simulator=simulator,
                                params=params,


### PR DESCRIPTION
Test in CLI:

```python
import inductiva

input_dir = inductiva.utils.files.download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "gromacs-input-example.zip", True)

commands = [
    "gmx solvate -cs tip4p -box 2.3 -o conf.gro -p topol.top",
    "sleep 10",
    ("gmx grompp -f energy_minimization.mdp -o min.tpr -pp min.top "
     "-po min.mdp -c conf.gro -p topol.top"),
    "gmx mdrun -s min.tpr -o min.trr -c min.gro -e min.edr -g min.log",
    ("gmx grompp -f positions_decorrelation.mdp -o decorr.tpr "
     "-pp decorr.top -po decorr.mdp -c min.gro"),
    "sleep 10",
    ("gmx mdrun -s decorr.tpr -o decorr.trr -x  -c decorr.gro "
     "-e decorr.edr -g decorr.log"),
    ("gmx grompp -f simulation.mdp -o eql.tpr -pp eql.top "
     "-po eql.mdp -c decorr.gro"),
    "sleep 10",
    ("gmx mdrun -s eql.tpr -o eql.trr -x trajectory.xtc -c eql.gro "
     "-e eql.edr -g eql.log")
]
machine = inductiva.resources.MachineGroup("c2-standard-4")

gromacs = inductiva.simulators.GROMACS()

task = gromacs.run(
    input_dir=input_dir,
    commands=commands,
    on=machine,
)

task.wait(
    silent_mode=False,
    download_std_on_completion=True,
)

task.download_outputs(
    filenames=["conf.gro"],
    output_dir="gromacs-outputs",
    uncompress=True,
)

task.download_outputs(
    output_dir="gromacs-outputs-zip",
    uncompress=False,
)

machine.terminate()

info =  task.info.to_dict()
print("stream: ", info["stream_zip"])
print("compress: ", info["compress_with"])
```
