### PR TITLE
Don't setup sigint handler if not supported

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -231,9 +231,13 @@ def block_until_status_is(api_instance: TasksApi,
 
 
 def _configure_sigint_handler(handler):
+    if not handler:
+        return None
+
     try:
         return signal.signal(signal.SIGINT, handler)
-    except ValueError:
+    except ValueError as e:
+        logging.warning("Custom SIGINT handler not configured: %s", e)
         # If the signal is not supported, ignore it
         pass
 


### PR DESCRIPTION
Signal handlers can't be set if not on the main thread of the process. Suppress the error thrown, so that the package can be used in multi threading environments.