### PR TITLE
Improve Benchmark logging

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -295,7 +295,7 @@ def task_info_str(
 
     info_str += (f"\t· Local input directory: {local_input_dir}\n"
                  "\t· Submitting to the following computational resources:\n")
-    info_str += f" \t\t· {resource_pool}\n"
+    info_str += f" \t\t· {resource_pool}"
 
     if task_submitted_info is not None:
         ttl_seconds = task_submitted_info.get("time_to_live_seconds")
@@ -381,6 +381,8 @@ def submit_task(simulator,
             simulator_obj,
             task_submitted_info,
         ))
+    logging.info("■ Task %s submitted to the queue of the %s.\n", task_id,
+                 machine_group)
 
     # If the status returned by the previous HTTP request is "pending-input",
     #  ZIP inputs and send them via "POST task/{task_id}/input".

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -160,7 +160,7 @@ class Benchmark(projects.Project):
         self.runs.clear()
         logging.info(
             "Benchmark \033[1m%s\033[0m has started...\n"
-            "Go to https://console.inductiva.ai/projects/%s?project=%s "
+            "Go to https://console.inductiva.ai/projects/%s "
             "for more details.\n", self.name, self.name, self.name)
         return self
 

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -155,7 +155,7 @@ class Benchmark(projects.Project):
                 simulator.run(input_dir=input_dir,
                               on=machine_group,
                               project=self.name,
-                              silent_mode=True,
+                              verbose=False,
                               **kwargs)
         self.runs.clear()
         logging.info(

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -161,7 +161,7 @@ class Benchmark(projects.Project):
         logging.info(
             "Benchmark \033[1m%s\033[0m has started...\n"
             "Go to https://console.inductiva.ai/projects/%s "
-            "for more details.\n", self.name, self.name, self.name)
+            "for more details.\n", self.name, self.name)
         return self
 
     def wait(self) -> Self:

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -179,7 +179,7 @@ class Benchmark(projects.Project):
         with tqdm.tqdm(total=len(running_tasks),
                        desc="Processing tasks",
                        bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt}") as pbar:
-            with ThreadPoolExecutor(max_workers=len(running_tasks)) as executor:
+            with ThreadPoolExecutor() as executor:
                 future_to_task = {
                     executor.submit(
                         lambda t: t.wait(download_std_on_completion=False,

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -204,7 +204,7 @@ class Benchmark(projects.Project):
                         # Update progress bar for each completed task
                         pbar.update(1)
 
-        print("\n")
+        logging.info("\n")
         return self
 
     def export(

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -197,12 +197,14 @@ class Benchmark(projects.Project):
                         if status != TaskStatusCode.SUCCESS:
                             logging.info(
                                 "   · To understand why the task did not "
-                                "complete successfully go to https://console.inductiva.ai/tasks/%s",
+                                "complete successfully go to "
+                                "https://console.inductiva.ai/tasks/%s",
                                 task.id)
 
                         # Update progress bar for each completed task
                         pbar.update(1)
 
+        print("\n")
         return self
 
     def export(

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -178,7 +178,7 @@ class Benchmark(projects.Project):
 
         with tqdm.tqdm(total=len(running_tasks),
                        desc="Processing tasks",
-                       bar_format='{l_bar}{bar}| {n_fmt}/{total_fmt}') as pbar:
+                       bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt}") as pbar:
             with ThreadPoolExecutor(max_workers=len(running_tasks)) as executor:
                 future_to_task = {
                     executor.submit(
@@ -196,8 +196,8 @@ class Benchmark(projects.Project):
 
                         if status != TaskStatusCode.SUCCESS:
                             logging.info(
-                                "   · To understand why the task did not complete "
-                                "successfully go to https://console.inductiva.ai/tasks/%s",
+                                "   · To understand why the task did not "
+                                "complete successfully go to https://console.inductiva.ai/tasks/%s",
                                 task.id)
 
                         # Update progress bar for each completed task

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -1,5 +1,4 @@
 """API for Benchmarking"""
-from datetime import time
 import enum
 import json
 import csv
@@ -160,8 +159,8 @@ class Benchmark(projects.Project):
         self.runs.clear()
         logging.info(
             "Benchmark \033[1m%s\033[0m has started...\n"
-            "Go to https://console.inductiva.ai/projects/%s?project=%s for more details.\n",
-            self.name, self.name, self.name)
+            "Go to https://console.inductiva.ai/projects/%s?project=%s "
+            "for more details.\n", self.name, self.name, self.name)
         return self
 
     def wait(self) -> Self:
@@ -189,12 +188,13 @@ class Benchmark(projects.Project):
                 for future in as_completed(future_to_task):
                     task = future_to_task[future]
                     status = future.result()
-                    logging.info(
-                        f"Task {task.id} completed with status: {status}")
+                    logging.info("Task %s completed with status: %s", task.id,
+                                 status)
 
                     if status != TaskStatusCode.SUCCESS:
                         logging.error(
-                            "   · To understand why the task did not complete successfully go to https://console.inductiva.ai/tasks/%s",
+                            "   · To understand why the task did not complete successfully "
+                            "go to https://console.inductiva.ai/tasks/%s",
                             task.id)
 
                     # Update progress bar for each completed task

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -158,6 +158,10 @@ class Benchmark(projects.Project):
                               silent_mode=True,
                               **kwargs)
         self.runs.clear()
+        logging.info(
+            "Benchmark \033[1m%s\033[0m has started...\n"
+            "Go to https://console.inductiva.ai/projects/%s?project=%s for more details.\n",
+            self.name, self.name, self.name)
         return self
 
     def wait(self) -> Self:
@@ -169,10 +173,8 @@ class Benchmark(projects.Project):
         """
         running_tasks = self.get_tasks()
 
-        logging.info(
-            "Waiting for Benchmark \033[1m%s\033[0m to complete...\n"
-            "Go to https://console.inductiva.ai/projects/%s?project=%s for more details.\n",
-            self.name, self.name, self.name)
+        logging.info("Waiting for Benchmark \033[1m%s\033[0m to complete...\n",
+                     self.name)
 
         with tqdm.tqdm(total=len(running_tasks),
                        desc="Processing tasks") as pbar:

--- a/inductiva/benchmarks/benchmark.py
+++ b/inductiva/benchmarks/benchmark.py
@@ -171,12 +171,12 @@ class Benchmark(projects.Project):
         Returns:
             Self: The current instance for method chaining.
         """
-        running_tasks = self.get_tasks()
+        tasks = self.get_tasks()
 
         logging.info("Waiting for Benchmark \033[1m%s\033[0m to complete...\n",
                      self.name)
 
-        with tqdm.tqdm(total=len(running_tasks),
+        with tqdm.tqdm(total=len(tasks),
                        desc="Processing tasks",
                        bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt}") as pbar:
             with ThreadPoolExecutor() as executor:
@@ -184,7 +184,7 @@ class Benchmark(projects.Project):
                     executor.submit(
                         lambda t: t.wait(download_std_on_completion=False,
                                          silent_mode=True), task):
-                        task for task in running_tasks
+                        task for task in tasks
                 }
 
                 for future in as_completed(future_to_task):

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -19,7 +19,7 @@ def run_simulation(
     remote_assets: Optional[List[str]] = None,
     simulator_name_alias: Optional[str] = None,
     project_name: Optional[str] = None,
-    silent_mode: bool = False,
+    verbose: bool = True,
     **kwargs: Any,
 ) -> tasks.Task:
     """Run a simulation via Inductiva Web API."""
@@ -62,7 +62,7 @@ def run_simulation(
     else:
         pos_info = f"Task {task_id} does not have queue information."
 
-    if not silent_mode:
+    if verbose:
         logging.info(
             "%s\n"
             "· Consider tracking the status of the task via CLI:"

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -19,6 +19,7 @@ def run_simulation(
     remote_assets: Optional[List[str]] = None,
     simulator_name_alias: Optional[str] = None,
     project_name: Optional[str] = None,
+    silent_mode: bool = False,
     **kwargs: Any,
 ) -> tasks.Task:
     """Run a simulation via Inductiva Web API."""
@@ -50,9 +51,6 @@ def run_simulation(
                                   remote_assets=remote_assets,
                                   project_name=project_name)
 
-    logging.info("■ Task %s submitted to the queue of the %s.", task_id,
-                 machine_group)
-
     if not isinstance(task_id, str):
         raise RuntimeError(
             f"Expected result to be a string with task_id, got {type(task_id)}")
@@ -64,17 +62,18 @@ def run_simulation(
     else:
         pos_info = f"Task {task_id} does not have queue information."
 
-    logging.info(
-        "%s\n"
-        "· Consider tracking the status of the task via CLI:"
-        "\n\tinductiva tasks list --id %s\n"
-        "· Or, tracking the logs of the task via CLI:"
-        "\n\tinductiva logs %s\n"
-        "· Or, track the task files in real time with:"
-        "\n\tinductiva tasks list-files %s\n"
-        "· You can also get more information "
-        "about the task via the CLI command:"
-        "\n\tinductiva tasks info %s\n\n", pos_info, task_id, task_id, task_id,
-        task_id)
+    if not silent_mode:
+        logging.info(
+            "%s\n"
+            "· Consider tracking the status of the task via CLI:"
+            "\n\tinductiva tasks list --id %s\n"
+            "· Or, tracking the logs of the task via CLI:"
+            "\n\tinductiva logs %s\n"
+            "· Or, track the task files in real time with:"
+            "\n\tinductiva tasks list-files %s\n"
+            "· You can also get more information "
+            "about the task via the CLI command:"
+            "\n\tinductiva tasks info %s\n\n", pos_info, task_id, task_id,
+            task_id, task_id)
 
     return task

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -692,10 +692,11 @@ class Task:
         prev_status = None
         is_tty = sys.stdout.isatty()
 
-        logging.info(
-            "Waiting for task %s to complete...\n"
-            "Go to https://console.inductiva.ai/tasks/%s for more details.",
-            self.id, self.id)
+        if not silent_mode:
+            logging.info(
+                "Waiting for task %s to complete...\n"
+                "Go to https://console.inductiva.ai/tasks/%s for more details.",
+                self.id, self.id)
 
         requires_newline = False
         previous_duration_l = 0
@@ -719,7 +720,8 @@ class Task:
                 if requires_newline:
                     requires_newline = False
                     sys.stdout.write("\n")
-                self._handle_status_change(status, description)
+                if not silent_mode:
+                    self._handle_status_change(status, description)
 
                 if (status == models.TaskStatusCode.COMPUTATIONSTARTED) and (
                         not silent_mode):
@@ -735,13 +737,14 @@ class Task:
             elif (status != models.TaskStatusCode.SUBMITTED and
                   not task_info.is_terminal):
 
-                #clear previous line
-                print(" " * previous_duration_l, end="\r")
+                if not silent_mode:
+                    #clear previous line
+                    print(" " * previous_duration_l, end="\r")
 
-                duration = f"Duration: {duration}"
-                print(duration, end="\r")
+                    duration = f"Duration: {duration}"
+                    print(duration, end="\r")
 
-                previous_duration_l = len(duration)
+                    previous_duration_l = len(duration)
 
             prev_status = status
 

--- a/inductiva/tests/benchmarks/test_benchmark.py
+++ b/inductiva/tests/benchmarks/test_benchmark.py
@@ -156,19 +156,19 @@ def test_benchmark_run(benchmark, num_repeats, wait_for_quotas):
                   a=1,
                   b=1,
                   project="test_benchmark",
-                  silent_mode=True),
+                  verbose=False),
         mock.call(input_dir="dir",
                   on=m4,
                   a=1,
                   b=4,
                   project="test_benchmark",
-                  silent_mode=True),
+                  verbose=False),
         mock.call(input_dir="dir",
                   on=m8,
                   a=1,
                   b=8,
                   project="test_benchmark",
-                  silent_mode=True),
+                  verbose=False),
     ] * num_repeats
     simulator.run.assert_has_calls(calls=simulator_run_calls, any_order=True)
     assert len(simulator.run.call_args_list) == num_repeats * num_runs

--- a/inductiva/tests/benchmarks/test_benchmark.py
+++ b/inductiva/tests/benchmarks/test_benchmark.py
@@ -151,9 +151,24 @@ def test_benchmark_run(benchmark, num_repeats, wait_for_quotas):
     m8.start.assert_called_once_with(wait_for_quotas=wait_for_quotas)
 
     simulator_run_calls = [
-        mock.call(input_dir="dir", on=m4, a=1, b=1, project="test_benchmark"),
-        mock.call(input_dir="dir", on=m4, a=1, b=4, project="test_benchmark"),
-        mock.call(input_dir="dir", on=m8, a=1, b=8, project="test_benchmark"),
+        mock.call(input_dir="dir",
+                  on=m4,
+                  a=1,
+                  b=1,
+                  project="test_benchmark",
+                  silent_mode=True),
+        mock.call(input_dir="dir",
+                  on=m4,
+                  a=1,
+                  b=4,
+                  project="test_benchmark",
+                  silent_mode=True),
+        mock.call(input_dir="dir",
+                  on=m8,
+                  a=1,
+                  b=8,
+                  project="test_benchmark",
+                  silent_mode=True),
     ] * num_repeats
     simulator.run.assert_has_calls(calls=simulator_run_calls, any_order=True)
     assert len(simulator.run.call_args_list) == num_repeats * num_runs


### PR DESCRIPTION
closes [#1091](https://github.com/inductiva/tasks/issues/1091)

I need some feedback. I am running the following example (with very little runs -- only 3 Machine Groups):

```
from inductiva import benchmarks, simulators, resources

benchmark = benchmarks.Benchmark(name="benchmark-improve-logging") \
    .set_default(simulator=simulators.SWASH(),
                 input_dir="model_input/",
                 sim_config_filename="S1.sws") \
    .add_run(on=resources.MachineGroup("n2d-highcpu-32")) \
    .add_run(on=resources.MachineGroup("c3-highcpu-22")) \
    .add_run(on=resources.MachineGroup("n2-highcpu-32")) \

benchmark.run(num_repeats=2)

benchmark.wait()
```

and this is the current logging situation, with some big improvements already (I killed all the tasks for the benchmark to complete faster):


https://github.com/user-attachments/assets/9dd9ec84-0e41-4964-b908-2d9edb8e7674


I believe the logging could still be improved:

- should I remove even further the initial logging of the MGs / tasks / download input... ?
  - for example, to only have more generic logging: Setting up resources, Preparing Tasks, etc... and then the Benchmark progress bar?
- There is also the scenario where the user gets stuck "waiting for quotas" to start MGs. In that case the final Benchmark logging is delayed and a lot of tasks have already finished when it is displayed

