### PR TITLE
Add events module import in __init__.py

### DIFF
--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -24,6 +24,7 @@ from . import tasks
 from . import users
 from . import logs
 from . import api
+from . import events
 from .templating import TemplateManager
 
 logs.setup(getattr(logging, os.environ.get("INDUCTIVA_LOG_LEVEL", "INFO")))


### PR DESCRIPTION
Before this wouldn't work:

```python
import inductiva

inductiva.events.register(
    inductiva.events.triggers.TaskOutputUploaded(task_id=task.id),
    inductiva.events.actions.EmailNotification(
        inductiva.users.get_info()["email"]))
```

It would only work like this:

```python
import inductiva
from inductiva import events

events.register(
   events.triggers.TaskOutputUploaded(task_id=task.id),
    events.actions.EmailNotification(
        inductiva.users.get_info()["email"]))
```