### PR TITLE
Add user login/logout methods

### DIFF
--- a/docs-sources/how-it-works/basics/install-guide.md
+++ b/docs-sources/how-it-works/basics/install-guide.md
@@ -20,6 +20,10 @@ pip install inductiva
 
 ## Step 2: Authenticate With Your API Key
 
+You have multiple ways to authenticate with the Inductiva Python package:
+
+### Option 1: Using the Command Line
+
 In your Command Prompt, run the following authentication command:
 
 ```python
@@ -35,3 +39,26 @@ inductiva user info
 ```
 
 This will display your account information, confirming that the API key has been stored successfully.
+
+
+### Option 2: Using the Python API
+
+Alternatively, you can authenticate directly within your Python scripts in a couple of ways:
+
+1. Providing the API Key as an Argument:
+
+```python
+import inductiva
+
+inductiva.users.login(api_key="<your_api_key>")
+```
+
+<br>
+
+2. Enter the API Key in the Terminal (when prompted by the Python script):
+```python
+import inductiva
+
+inductiva.users.login()
+```
+When prompted, paste your unique API key, which you can retrieve from [Inductiva's web Console](https://console.inductiva.ai/account/details).

--- a/docs-sources/how-it-works/basics/install-guide.md
+++ b/docs-sources/how-it-works/basics/install-guide.md
@@ -43,19 +43,8 @@ This will display your account information, confirming that the API key has been
 
 ### Option 2: Using the Python API
 
-Alternatively, you can authenticate directly within your Python scripts in a couple of ways:
+Alternatively, you can authenticate directly within your Python script:
 
-1. Providing the API Key as an Argument:
-
-```python
-import inductiva
-
-inductiva.users.login(api_key="<your_api_key>")
-```
-
-<br>
-
-2. Enter the API Key in the Terminal (when prompted by the Python script):
 ```python
 import inductiva
 

--- a/inductiva/__init__.py
+++ b/inductiva/__init__.py
@@ -85,7 +85,9 @@ def _set_key_and_check_version():
     is_auth_cli = len(sys.argv) > 1 and sys.argv[1] == "auth"
     if not utils.format_utils.getenv_bool("GITHUB_ACTIONS", False) \
             and not is_auth_cli:
-        set_api_key(get_api_key())
+        key = get_api_key()
+        if key:
+            set_api_key(key)
 
     # Perform version check only on first invocation
     if not hasattr(_set_key_and_check_version, "version_checked"):
@@ -184,6 +186,14 @@ def set_api_key(api_key, login_message=True):
 def get_api_key():
     """Returns the value of inductiva._api_key or the stored API key."""
     api_key = _api_key.get() or utils.authentication.get_stored_api_key()
+    return api_key
+
+
+def get_validated_api_key():
+    """Returns the value of inductiva._api_key or the stored API key.
+    Raises ValueError if the API key is invalid.
+    """
+    api_key = get_api_key()
     _validate_api_key(api_key)
     return api_key
 
@@ -231,4 +241,8 @@ ansi_enabled = _supports_ansi()
 
 _set_key_and_check_version()
 
-_check_user_info()
+try:
+    get_validated_api_key()
+    _check_user_info()
+except ValueError:
+    pass

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -27,7 +27,7 @@ from inductiva.utils import format_utils, files
 
 def get_api_config() -> Configuration:
     """Returns an API configuration object."""
-    api_key = inductiva.get_api_key()
+    api_key = inductiva.get_validated_api_key()
 
     api_config = Configuration(host=inductiva.api_url)
     api_config.api_key["APIKeyHeader"] = api_key

--- a/inductiva/users/__init__.py
+++ b/inductiva/users/__init__.py
@@ -1,2 +1,2 @@
 #pylint: disable=missing-module-docstring
-from inductiva.users.methods import get_quotas, get_info, get_costs
+from inductiva.users.methods import get_quotas, get_info, get_costs, login, logout

--- a/inductiva/users/methods.py
+++ b/inductiva/users/methods.py
@@ -1,8 +1,13 @@
 """Methods to interact with the user info on the API."""
+import argparse
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
+import inductiva
 from inductiva import api
+from inductiva._cli.cmd_auth.login import login as login_cmd
+from inductiva._cli.cmd_auth.logout import logout as logout_cmd
+
 from inductiva.client.apis.tags.users_api import UsersApi
 
 
@@ -78,3 +83,30 @@ def get_costs(start_year: int,
 
         request = api_instance.get_user_costs(query_params=query_params)
     return request.body["costs"]
+
+
+def login(api_key: Optional[str] = None, private: bool = False) -> None:
+    """Logs the user in to the Inductiva platform.
+
+    This function handles user login, either by using a provided API key
+    or by prompting the user to log in via the command line.
+
+    Args:
+        api_key: The API key to use for authentication. If provided,
+            the user will be logged in using this key. If not provided,
+            the user will be prompted to log in via the command line.
+        private:  If True, no api_key will be printed to the console.
+    """
+
+    if not api_key:
+        args = argparse.Namespace(private=private)
+        login_cmd(args)
+    else:
+        inductiva.set_api_key(api_key)
+        get_info()
+        print("Login successful.")
+
+
+def logout():
+    """Logs the user out by removing the stored API key."""
+    logout_cmd(None)

--- a/inductiva/users/methods.py
+++ b/inductiva/users/methods.py
@@ -85,26 +85,18 @@ def get_costs(start_year: int,
     return request.body["costs"]
 
 
-def login(api_key: Optional[str] = None, private: bool = False) -> None:
+def login(private: bool = False) -> None:
     """Logs the user in to the Inductiva platform.
 
-    This function handles user login, either by using a provided API key
-    or by prompting the user to log in via the command line.
+    This function handles user login by prompting the user to log in via the
+      command line.
 
     Args:
-        api_key: The API key to use for authentication. If provided,
-            the user will be logged in using this key. If not provided,
-            the user will be prompted to log in via the command line.
         private:  If True, no api_key will be printed to the console.
     """
 
-    if not api_key:
-        args = argparse.Namespace(private=private)
-        login_cmd(args)
-    else:
-        inductiva.set_api_key(api_key)
-        get_info()
-        print("Login successful.")
+    args = argparse.Namespace(private=private)
+    login_cmd(args)
 
 
 def logout():

--- a/inductiva/users/methods.py
+++ b/inductiva/users/methods.py
@@ -1,9 +1,8 @@
 """Methods to interact with the user info on the API."""
 import argparse
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
-import inductiva
 from inductiva import api
 from inductiva._cli.cmd_auth.login import login as login_cmd
 from inductiva._cli.cmd_auth.logout import logout as logout_cmd


### PR DESCRIPTION
related to https://github.com/inductiva/tasks/issues/1099
closes https://github.com/inductiva/tasks/issues/1035

Add support for `login` and `logout` directly from the Python client, without requiring the CLI.

This PR allows `import inductiva` without authentication. If the user calls a method that requires authentication, an “Invalid API key” error will be raised.

The version compatibility check still runs during `import inductiva`, as the corresponding endpoint does not require authentication.

```python
import inductiva

# login using terminal api_key 
>>> inductiva.users.login()
     ___  _   _  ____   _   _   ____  _____  ___ __     __ _    
    |_ _|| \ | ||  _ \ | | | | / ___||_   _||_ _|\ \   / // \   
     | | |  \| || | | || | | || |      | |   | |  \ \ / // _ \  
     | | | |\  || |_| || |_| || |___   | |   | |   \ V // ___ \ 
    |___||_| \_||____/  \___/  \____|  |_|  |___|   \_//_/   \_\
    
    To log in, you need an API Key. You can obtain it from your account at https://console.inductiva.ai/account.
Please paste your API Key here: <key>

# logout
>>> inductiva.users.logout()
Logout successful.

# logout when not logged in
>>> inductiva.users.logout()
Error: You are not logged in.
