### PR TITLE
List all storage files

### DIFF
--- a/inductiva/_cli/cmd_storage/list.py
+++ b/inductiva/_cli/cmd_storage/list.py
@@ -7,7 +7,8 @@ from inductiva import storage
 
 def listdir(args):
     """List the user's remote storage contents."""
-    storage.listdir(args.path, args.max_results, args.order_by, args.sort_order)
+    max_results = None if args.all else args.max_results
+    storage.listdir(args.path, max_results, args.order_by, args.sort_order)
 
 
 def register(parser):
@@ -38,5 +39,9 @@ def register(parser):
                            type=str,
                            choices=["desc", "asc"],
                            help="Sorting order (desc or asc).")
-
+    subparser.add_argument(
+        "--all",
+        action="store_true",
+        help="List all results, ignoring --max-results."
+    )
     subparser.set_defaults(func=listdir)

--- a/inductiva/_cli/cmd_storage/list.py
+++ b/inductiva/_cli/cmd_storage/list.py
@@ -39,9 +39,7 @@ def register(parser):
                            type=str,
                            choices=["desc", "asc"],
                            help="Sorting order (desc or asc).")
-    subparser.add_argument(
-        "--all",
-        action="store_true",
-        help="List all results, ignoring --max-results."
-    )
+    subparser.add_argument("--all",
+                           action="store_true",
+                           help="List all results, ignoring --max-results.")
     subparser.set_defaults(func=listdir)

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -112,7 +112,6 @@ def listdir(
     if max_results is not None:
         query_params["max_results"] = max_results
 
-
     contents = api.list_storage_contents(query_params).body
     all_contents = []
     for content_name, info in contents.items():

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -67,7 +67,7 @@ def get_space_used():
 
 def listdir(
     path="/",
-    max_results: int = 10,
+    max_results: Optional[int] = 10,
     order_by: Literal["size", "creation_time"] = "creation_time",
     sort_order: Literal["asc", "desc"] = "desc",
     print_results: bool = True,
@@ -75,7 +75,8 @@ def listdir(
     """List and display the contents of the user's storage.
     Args:
         path (str): Storage directory to list. Default is root.
-        max_results (int): The maximum number of results to return.
+        max_results (int): The maximum number of results to return. If not set,
+            all entries are returned.
         order_by (str): The field to sort the contents by.
         sort_order (str): Whether to sort the contents in ascending or
         descending order.
@@ -102,12 +103,17 @@ def listdir(
     if len(path.split("/")) < 2:
         path += "/"
 
-    contents = api.list_storage_contents({
+    query_params = {
         "path": path,
-        "max_results": max_results,
         "sort_by": order_by,
-        "order": sort_order
-    }).body
+        "order": sort_order,
+    }
+
+    if max_results is not None:
+        query_params["max_results"] = max_results
+
+
+    contents = api.list_storage_contents(query_params).body
     all_contents = []
     for content_name, info in contents.items():
         size = info["size_bytes"]


### PR DESCRIPTION
Closes https://github.com/inductiva/tasks/issues/1105

Test:

```bash
...
(inductiva-local-env) ➜  test-list-all inductiva storage upload folder-11 folder-11
(inductiva-local-env) ➜  test-list-all inductiva storage ls

 NAME        SIZE     CREATION TIME
 folder-11   3 B      15/05, 11:38:41
 folder-10   3 B      15/05, 11:38:36
 folder-9    3 B      15/05, 11:38:31
 folder-8    3 B      15/05, 11:38:27
 folder-7    3 B      15/05, 11:38:23
 folder-6    3 B      15/05, 11:38:20
 folder-5    3 B      15/05, 11:38:16
 folder-4    3 B      15/05, 11:38:13
 folder-3    3 B      15/05, 11:29:30
 folder-2    2 B      15/05, 11:29:26

Total storage size used:
	Volume: 30 B
	Cost: 0.00000000056 US$/month

Listed 10 folder(s). Ordered by creation_time.
Use --max-results/-m to control the number of results displayed.
(inductiva-local-env) ➜  test-list-all inductiva storage ls --all

 NAME        SIZE     CREATION TIME
 folder-11   3 B      15/05, 11:38:41
 folder-10   3 B      15/05, 11:38:36
 folder-9    3 B      15/05, 11:38:31
 folder-8    3 B      15/05, 11:38:27
 folder-7    3 B      15/05, 11:38:23
 folder-6    3 B      15/05, 11:38:20
 folder-5    3 B      15/05, 11:38:16
 folder-4    3 B      15/05, 11:38:13
 folder-3    3 B      15/05, 11:29:30
 folder-2    2 B      15/05, 11:29:26
 folder-1    1 B      15/05, 11:29:23

Total storage size used:
	Volume: 30 B
	Cost: 0.00000000056 US$/month

Listed 11 folder(s). Ordered by creation_time.
Use --max-results/-m to control the number of results displayed.
(inductiva-local-env) ➜  test-list-all inductiva storage list --max 1              

 NAME        SIZE     CREATION TIME
 folder-11   3 B      15/05, 11:38:41

Total storage size used:
	Volume: 30 B
	Cost: 0.00000000056 US$/month

Listed 1 folder(s). Ordered by creation_time.
Use --max-results/-m to control the number of results displayed.
```