### PR TITLE
Adding python docs for simulator classes

### DIFF
--- a/docs-sources/python-client/index.md
+++ b/docs-sources/python-client/index.md
@@ -8,6 +8,7 @@ benchmarks <inductiva.benchmarks>
 projects <inductiva.projects>
 resources <inductiva.resources>
 storage <inductiva.storage>
+simulators <inductiva.simulators>
 tasks <inductiva.tasks>
 templating <inductiva.templating>
 users <inductiva.users>

--- a/docs-sources/python-client/inductiva.benchmarks.rst
+++ b/docs-sources/python-client/inductiva.benchmarks.rst
@@ -1,4 +1,4 @@
-benchmarks sub-package
+benchmarks module
 ============================
 
 .. automodule:: inductiva.benchmarks.benchmark

--- a/docs-sources/python-client/inductiva.projects.rst
+++ b/docs-sources/python-client/inductiva.projects.rst
@@ -1,4 +1,4 @@
-projects sub-package
+projects module
 ==========================
 
 .. automodule:: inductiva.projects.project

--- a/docs-sources/python-client/inductiva.resources.rst
+++ b/docs-sources/python-client/inductiva.resources.rst
@@ -1,4 +1,4 @@
-resources sub-package
+resources module
 ===========================
 
 .. automodule:: inductiva.resources.machine_groups

--- a/docs-sources/python-client/inductiva.storage.rst
+++ b/docs-sources/python-client/inductiva.storage.rst
@@ -1,4 +1,4 @@
-storage sub-package
+storage module
 =========================
 
 .. automodule:: inductiva.storage.storage

--- a/docs-sources/python-client/inductiva.tasks.rst
+++ b/docs-sources/python-client/inductiva.tasks.rst
@@ -1,4 +1,4 @@
-tasks sub-package
+tasks module
 =======================
 
 

--- a/docs-sources/python-client/inductiva.templating.rst
+++ b/docs-sources/python-client/inductiva.templating.rst
@@ -1,4 +1,4 @@
-templating sub-package
+templating module
 ============================
 
 .. automodule:: inductiva.templating.manager

--- a/docs-sources/python-client/inductiva.users.rst
+++ b/docs-sources/python-client/inductiva.users.rst
@@ -1,4 +1,4 @@
-users sub-package
+users module
 =======================
 
 .. automodule:: inductiva.users.methods

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -23,6 +23,10 @@ class AmrWind(simulators.Simulator):
             use_dev (bool): Request use of the development version of
                 the simulator. By default (False), the production version
                 is used.
+            device (str): The device to use for the simulation. If "auto",
+                the device will be selected automatically. If "cpu", the
+                simulation will run on the CPU. If "gpu", the simulation
+                will run on the GPU.
         """
         super().__init__(version=version, use_dev=use_dev, device=device)
         self.simulator = "arbitrary_commands"
@@ -46,16 +50,19 @@ class AmrWind(simulators.Simulator):
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
+
         Args:
             input_dir: Path to the directory of the simulation input files.
+            sim_config_filename: Name of the simulation configuration file.
             on: The computational resource to launch the simulation on.
-            n_vcpus: Number of vCPUs to use in the simulation. If not provided
-            (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
-            number of hardware threads on the node, and use that as the
-            number of slots available.
-            other arguments: See the documentation of the base class.
-            resubmit_on_preemption (bool): Resubmit task for execution when
+                number of hardware threads on the node, and use that as the
+                number of slots available.
+            n_vcpus: Number of vCPUs to use in the simulation. If not provided
+                (default), all vCPUs will be used.
+            storage_dir: Path to the directory where the simulation results
+                will be stored.
+            resubmit_on_preemption: Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
                 using a preemptible resource, i.e., resource instantiated with
                 `spot=True`.
@@ -65,6 +72,7 @@ class AmrWind(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            **kwargs: Keyword arguments to be passed to the base class.
         """
 
         self._input_files_exist(input_dir=input_dir,

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -51,10 +51,10 @@ class CaNS(simulators.Simulator):
             input_dir: Path to the directory of the simulation input files.
             on: The computational resource to launch the simulation on.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
-            (default), all vCPUs will be used.
+                (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
-            number of hardware threads on the node, and use that as the
-            number of slots available.
+                number of hardware threads on the node, and use that as the
+                number of slots available.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
                 using a preemptible resource, i.e., resource instantiated with

--- a/inductiva/simulators/fvcom.py
+++ b/inductiva/simulators/fvcom.py
@@ -59,22 +59,22 @@ class FVCOM(simulators.Simulator):
                 - 'estuary': Uses the fvcom_estuary binary.
                 The modules used to compile each binary can be found in the
                 kutu repository, in the make.inc and make_estuary.inc files
-        (https://github.com/inductiva/kutu/tree/main/simulators/fvcom/v5.1.0).
+                https://github.com/inductiva/kutu/tree/main/simulators/fvcom/
 
             create_namelist: Used to create a namelist file for the simulation.
                 Example: 'create_namelist=hello' will create hello_run.nml in
-                    the working_dir.
+                the working_dir.
 
             working_dir: Path (relative to the input directory) to the directory
                 where the simulation nml file is located. If not provided, the
                 input directory is used.
 
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
-            (default), all vCPUs will be used.
+                (default), all vCPUs will be used.
 
             use_hwthread: If specified Open MPI will attempt to discover the
-            number of hardware threads on the node, and use that as the
-            number of slots available.
+                number of hardware threads on the node, and use that as the
+                number of slots available.
 
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when

--- a/inductiva/simulators/gx.py
+++ b/inductiva/simulators/gx.py
@@ -33,11 +33,11 @@ class GX(simulators.Simulator):
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
+
         Args:
             input_dir: Path to the directory of the simulation input files.
             on: The computational resource to launch the simulation on.
             sim_config_filename: The name of the simulation configuration file.
-            other arguments: See the documentation of the base class.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
                 using a preemptible resource, i.e., resource instantiated with

--- a/inductiva/simulators/mohid.py
+++ b/inductiva/simulators/mohid.py
@@ -52,8 +52,7 @@ class MOHID(simulators.Simulator):
                 simulation ends. This will combine the results of the multiple
                 MPI processes into one.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
-            (default), all vCPUs will be used.
-            other arguments: See the documentation of the base class.
+                (default), all vCPUs will be used.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
                 using a preemptible resource, i.e., resource instantiated with

--- a/inductiva/simulators/nwchem.py
+++ b/inductiva/simulators/nwchem.py
@@ -44,11 +44,10 @@ class NWChem(simulators.Simulator):
             on: The computational resource to launch the simulation on.
             sim_config_filename: Name of the simulation configuration file.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
-            (default), all vCPUs will be used.
+                (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
-            number of hardware threads on the node, and use that as the
-            number of slots available.
-            other arguments: See the documentation of the base class.
+                number of hardware threads on the node, and use that as the
+                number of slots available.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
                 using a preemptible resource, i.e., resource instantiated with

--- a/inductiva/simulators/openfast.py
+++ b/inductiva/simulators/openfast.py
@@ -39,7 +39,6 @@ class OpenFAST(simulators.Simulator):
             input_dir: Path to the directory of the simulation input files.
             commands: List of commands to run using the OpenFAST simulator.
             on: The computational resource to launch the simulation on.
-            other arguments: See the documentation of the base class.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
                 using a preemptible resource, i.e., resource instantiated with

--- a/inductiva/simulators/quantum_espresso.py
+++ b/inductiva/simulators/quantum_espresso.py
@@ -9,7 +9,7 @@ from inductiva import types, tasks, simulators
 class QuantumEspresso(simulators.Simulator):
     """Class to run commands on Quantum Espresso."""
 
-    COMMANDS = [
+    _COMMANDS = [
         "alpha2f", "dvscf_q2r", "head", "matdyn", "plan_avg", "pw", "rism1d",
         "turbo_spectrum", "average", "dynmat", "hp", "molecularnexafs",
         "plotband", "pw2bgw", "scan_ibrav", "upfconv", "band_interpolation",
@@ -57,7 +57,7 @@ class QuantumEspresso(simulators.Simulator):
                      "names (e.g., pw_openmp.x).\n"
                      "For the MPI version, just use the normal command names "
                      " (e.g., pw.x).")
-        return self.COMMANDS
+        return self._COMMANDS
 
     def run(self,
             input_dir: Optional[str],
@@ -76,7 +76,7 @@ class QuantumEspresso(simulators.Simulator):
             commands: List of commands to run.
             on: The computatißonal resource to launch the simulation on.
             storage_dir: Parent directory for storing simulation
-                               results.
+                results.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
                 using a preemptible resource, i.e., resource instantiated with

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -42,10 +42,10 @@ class REEF3D(simulators.Simulator):
             input_dir: Path to the directory of the simulation input files.
             on: The computational resource to launch the simulation on.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
-            (default), all vCPUs will be used.
+                (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
-            number of hardware threads on the node, and use that as the
-            number of slots available.
+                number of hardware threads on the node, and use that as the
+                number of slots available.
             sim_config_filename: Name of the simulation configuration file.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when

--- a/inductiva/simulators/schism.py
+++ b/inductiva/simulators/schism.py
@@ -37,6 +37,7 @@ class SCHISM(simulators.Simulator):
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
+        
         Args:
             input_dir: Path to the directory of the simulation input files.
             on: The computational resource to launch the simulation on.
@@ -44,8 +45,8 @@ class SCHISM(simulators.Simulator):
             https://schism-dev.github.io/schism/master/getting-started/running-model.html
             storage_dir: Directory for storing simulation results.
             use_hwthread: If specified Open MPI will attempt to discover the
-            number of hardware threads on the node, and use that as the
-            number of slots available.
+                number of hardware threads on the node, and use that as the
+                number of slots available.
             n_vcpus: Number of virtual cpus
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -72,11 +72,6 @@ class Simulator(ABC):
         return self._version
 
     @property
-    def use_dev(self):
-        """Get whether the development version of the simulator is used."""
-        return self._use_dev
-
-    @property
     def name(self):
         """Get the name of the simulator."""
         return self.__class__.__name__
@@ -221,7 +216,7 @@ class Simulator(ABC):
         suffix = f"{suffix}{dev_suffix}"
         return suffix
 
-    def get_simulator_image_based_on_resource(
+    def _get_simulator_image_based_on_resource(
             self, resource: types.ComputationalResources):
         """
         Get the simulator image for the simulation, based on the resourced used.
@@ -286,7 +281,7 @@ class Simulator(ABC):
                 "run-parallel_simulations.html "
                 "to learn how to create your own computational resource.")
 
-        self.validate_computational_resources(on)
+        self._validate_computational_resources(on)
 
         if "commands" in kwargs:
             cmds = commands.Command.commands_to_dicts(kwargs["commands"])
@@ -298,7 +293,7 @@ class Simulator(ABC):
 
         # CustomImage does not use suffixes. We can the image as is
         if self.__class__.__name__ != "CustomImage":
-            self._image_uri = self.get_simulator_image_based_on_resource(on)
+            self._image_uri = self._get_simulator_image_based_on_resource(on)
 
         if on.has_gpu() and "_gpu" not in self._image_uri:
             logging.warning("Attention: The machine you selected has a GPU, but"
@@ -323,7 +318,7 @@ class Simulator(ABC):
             **kwargs,
         )
 
-    def validate_computational_resources(self, resource):
+    def _validate_computational_resources(self, resource):
         """Validate the computational resources passed to the run method.
 
         Args:

--- a/inductiva/simulators/snl_swan.py
+++ b/inductiva/simulators/snl_swan.py
@@ -52,10 +52,10 @@ class SNLSWAN(simulators.Simulator):
             sim_config_filename: Name of the simulation configuration file.
                 Mandatory when using 'swanrun' command.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
-            (default), all vCPUs will be used.
+                (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
-            number of hardware threads on the node, and use that as the
-            number of slots available.
+                number of hardware threads on the node, and use that as the
+                number of slots available.
             on: The computational resource to launch the simulation on.
             storage_dir: Directory for storing simulation results.
             resubmit_on_preemption (bool): Resubmit task for execution when

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -47,10 +47,10 @@ class SWAN(simulators.Simulator):
             sim_config_filename: Name of the simulation configuration file.
                 Mandatory when using 'swanrun' command.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
-            (default), all vCPUs will be used.
+                (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
-            number of hardware threads on the node, and use that as the
-            number of slots available.
+                number of hardware threads on the node, and use that as the
+                number of slots available.
             on: The computational resource to launch the simulation on.
             storage_dir: Directory for storing simulation results.
             resubmit_on_preemption (bool): Resubmit task for execution when

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -45,10 +45,10 @@ class SWASH(simulators.Simulator):
             sim_config_filename: Name of the simulation configuration file.
             on: The computational resource to launch the simulation on.
             n_vcpus: Number of vCPUs to use in the simulation. If not provided
-            (default), all vCPUs will be used.
+                (default), all vCPUs will be used.
             use_hwthread: If specified Open MPI will attempt to discover the
-            number of hardware threads on the node, and use that as the
-            number of slots available.
+                number of hardware threads on the node, and use that as the
+                number of slots available.
             resubmit_on_preemption (bool): Resubmit task for execution when
                 previous execution attempts were preempted. Only applicable when
                 using a preemptible resource, i.e., resource instantiated with

--- a/inductiva/tests/simulators/test_simulator_with_resources.py
+++ b/inductiva/tests/simulators/test_simulator_with_resources.py
@@ -60,8 +60,9 @@ def test_get_simulator_image_based_on_resource__dev():
     mg_no_gpu = mock.Mock()
     mg_no_gpu.has_gpu.return_value = False
 
-    sim_image_gpu = gmx.get_simulator_image_based_on_resource(mg_gpu)
-    sim_image_no_gpu = gmx.get_simulator_image_based_on_resource(mg_no_gpu)
+    # pylint: disable=protected-access
+    sim_image_gpu = gmx._get_simulator_image_based_on_resource(mg_gpu)
+    sim_image_no_gpu = gmx._get_simulator_image_based_on_resource(mg_no_gpu)
 
     assert sim_image_gpu.endswith("_gpu_dev")
     assert sim_image_no_gpu.endswith("_dev")
@@ -75,7 +76,8 @@ def test_get_simulator_image_based_on_resource__not_dev():
     mg_gpu = mock.Mock()
     mg_gpu.has_gpu.return_value = True
 
-    sim_image_gpu = gmx.get_simulator_image_based_on_resource(mg_gpu)
+    # pylint: disable=protected-access
+    sim_image_gpu = gmx._get_simulator_image_based_on_resource(mg_gpu)
 
     assert sim_image_gpu.endswith("_gpu")
 
@@ -93,7 +95,8 @@ def test_validate_computational_resources__unsupported_resource__raise_error(
     simulator = TesterSimulator()
 
     with pytest.raises(ValueError) as excinfo:
-        simulator.validate_computational_resources(mock_instance)
+        # pylint: disable=protected-access
+        simulator._validate_computational_resources(mock_instance)
 
     assert "The computational resource is invalid" in str(excinfo.value)
 
@@ -108,7 +111,8 @@ def test_mpi_enabled__dummy_simulator():
 
     mpi_enabled_sim = simulators.simulator.mpi_enabled(TesterSimulator)
 
-    assert resources.MPICluster in mpi_enabled_sim.get_supported_resources()
+    # pylint: disable=protected-access
+    assert resources.MPICluster in mpi_enabled_sim._get_supported_resources()
 
 
 @mark.parametrize("simulator", [
@@ -133,7 +137,8 @@ def test_validate_computational_resources__none_resource__no_wrapper(
 
     with pytest.raises(ValueError) as excinfo:
         simulator = TesterSimulator()
-        simulator.validate_computational_resources(None)
+        # pylint: disable=protected-access
+        simulator._validate_computational_resources(None)
 
     assert "The computational resource is invalid" in str(excinfo.value)
 
@@ -145,7 +150,8 @@ def test_validate_computational_resources__none_resource_mpi_wrapped(
 
     with pytest.raises(ValueError) as excinfo:
         simulator = simulators.simulator.mpi_enabled(TesterSimulator)()
-        simulator.validate_computational_resources(None)
+        # pylint: disable=protected-access
+        simulator._validate_computational_resources(None)
 
     assert "The computational resource is invalid" in str(excinfo.value)
 
@@ -165,14 +171,16 @@ def test_validate_computational_resources__valid_machine_group__no_error(
         machine = inductiva.resources.MachineGroup("c2-standard-16")
 
         try:
-            TesterSimulator().validate_computational_resources(machine)
+            # pylint: disable=protected-access
+            TesterSimulator()._validate_computational_resources(machine)
         except ValueError:
             assert False, error_message
 
         simulator = simulators.simulator.mpi_enabled(TesterSimulator)
 
         try:
-            simulator().validate_computational_resources(machine)
+            # pylint: disable=protected-access
+            simulator()._validate_computational_resources(machine)
         except ValueError:
             assert False, error_message
 
@@ -193,7 +201,8 @@ def test_validate_computational_resources__valid_mpi_cluster__no_error(
         simulator = simulators.simulator.mpi_enabled(TesterSimulator)
 
         try:
-            simulator().validate_computational_resources(machine)
+            # pylint: disable=protected-access
+            simulator()._validate_computational_resources(machine)
         except ValueError:
             assert False, error_message
 


### PR DESCRIPTION
Note: I had to change little pieces of code to make methods protected rather than public, so that they are not shown in the documentation (as they were not intended for direct usage, but only for internal behaviour).