### PR TITLE
Fix permission issue when converting local Docker images

### DIFF
--- a/inductiva/_cli/cmd_containers/convert.py
+++ b/inductiva/_cli/cmd_containers/convert.py
@@ -95,6 +95,7 @@ def convert_image(args, fout: TextIO = sys.stdout):
                                          delete=False,
                                          dir=constants.TMP_DIR) as tmp:
             tmp_tar_path = tmp.name
+            os.chmod(tmp_tar_path, 0o644)
             with open(tmp_tar_path, "wb") as f:
                 for chunk in image_obj.save(named=True):
                     f.write(chunk)


### PR DESCRIPTION
This PR ensures that the temporary tarball created during image conversion is world-readable by explicitly setting its permissions to 0644. This is necessary because the conversion process runs inside a Docker container, which may not have permission to read the file if it's only accessible to the host user.