### PR TITLE
Update simulators remote_assets parameter to accept Union[str, list[str]]

### DIFF
--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -1,8 +1,8 @@
 """AmrWind module of the API for numerical simulations of fluid flows."""
 from typing import List, Literal, Optional, Union
 
-from inductiva import types, tasks, simulators
-from inductiva.commands import MPIConfig, Command
+from inductiva import simulators, tasks, types
+from inductiva.commands import Command, MPIConfig
 
 
 @simulators.simulator.mpi_enabled

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -1,5 +1,5 @@
 """AmrWind module of the API for numerical simulations of fluid flows."""
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from inductiva import types, tasks, simulators
 from inductiva.commands import MPIConfig, Command
@@ -46,7 +46,7 @@ class AmrWind(simulators.Simulator):
             n_vcpus: Optional[int] = None,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -1,5 +1,5 @@
 """AmrWind module of the API for numerical simulations of fluid flows."""
-from typing import List, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands import Command, MPIConfig

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -1,5 +1,5 @@
 """CaNS module of the API for numerical simulations of fluid flows."""
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from inductiva import types, tasks, simulators
 from inductiva.commands.commands import Command
@@ -42,7 +42,7 @@ class CaNS(simulators.Simulator):
             n_vcpus: Optional[int] = None,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -1,5 +1,5 @@
 """CaNS module of the API for numerical simulations of fluid flows."""
-from typing import List, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -1,7 +1,7 @@
 """CaNS module of the API for numerical simulations of fluid flows."""
 from typing import List, Literal, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/cm1.py
+++ b/inductiva/simulators/cm1.py
@@ -1,7 +1,7 @@
 """CM1 module of the API."""
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/cm1.py
+++ b/inductiva/simulators/cm1.py
@@ -1,5 +1,5 @@
 """CM1 module of the API."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 from inductiva.commands.commands import Command
@@ -33,7 +33,7 @@ class CM1(simulators.Simulator):
             sim_config_filename: Optional[str] = None,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/cm1.py
+++ b/inductiva/simulators/cm1.py
@@ -1,5 +1,5 @@
 """CM1 module of the API."""
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command

--- a/inductiva/simulators/coawst.py
+++ b/inductiva/simulators/coawst.py
@@ -1,7 +1,7 @@
 """COAWST simulator module of the API."""
 
 import os
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 from inductiva.commands.commands import Command
@@ -67,7 +67,7 @@ class COAWST(simulators.Simulator):
             n_vcpus: Optional[int] = None,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/coawst.py
+++ b/inductiva/simulators/coawst.py
@@ -3,7 +3,7 @@
 import os
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/cp2k.py
+++ b/inductiva/simulators/cp2k.py
@@ -1,7 +1,7 @@
 """CP2K module of the API."""
 from typing import List, Literal, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/cp2k.py
+++ b/inductiva/simulators/cp2k.py
@@ -1,5 +1,5 @@
 """CP2K module of the API."""
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from inductiva import types, tasks, simulators
 from inductiva.commands.commands import Command
@@ -40,7 +40,7 @@ class CP2K(simulators.Simulator):
             use_hwthread: bool = True,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/cp2k.py
+++ b/inductiva/simulators/cp2k.py
@@ -1,5 +1,5 @@
 """CP2K module of the API."""
-from typing import List, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command

--- a/inductiva/simulators/custom_image.py
+++ b/inductiva/simulators/custom_image.py
@@ -1,5 +1,5 @@
 """Class to run commands on an custom image."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 
@@ -30,7 +30,7 @@ class CustomImage(simulators.Simulator):
             on: types.ComputationalResources,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/custom_image.py
+++ b/inductiva/simulators/custom_image.py
@@ -1,7 +1,7 @@
 """Class to run commands on an custom image."""
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 
 
 @simulators.simulator.mpi_enabled

--- a/inductiva/simulators/delft3d.py
+++ b/inductiva/simulators/delft3d.py
@@ -1,6 +1,7 @@
 """Delft3D module of the API."""
 from typing import Optional, Union
-from inductiva import types, simulators
+
+from inductiva import simulators, types
 
 
 class Delft3D(simulators.Simulator):

--- a/inductiva/simulators/delft3d.py
+++ b/inductiva/simulators/delft3d.py
@@ -1,5 +1,5 @@
 """Delft3D module of the API."""
-from typing import Optional
+from typing import Optional, Union
 from inductiva import types, simulators
 
 
@@ -26,7 +26,7 @@ class Delft3D(simulators.Simulator):
             on: types.ComputationalResources,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[list[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs):
 

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -1,6 +1,6 @@
 """DualSPHysics simulator module of the API."""
 
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from inductiva import types, tasks, simulators
 
@@ -37,7 +37,7 @@ class DualSPHysics(simulators.Simulator):
         on: types.ComputationalResources,
         storage_dir: Optional[str] = "",
         resubmit_on_preemption: bool = False,
-        remote_assets: Optional[List[str]] = None,
+        remote_assets: Optional[Union[str, list[str]]] = None,
         project: Optional[str] = None,
         vtk_to_obj: Optional[bool] = False,
         vtk_to_obj_vtk_dir: Optional[str] = None,

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -2,7 +2,7 @@
 
 from typing import List, Literal, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 
 
 class DualSPHysics(simulators.Simulator):

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -1,6 +1,6 @@
 """DualSPHysics simulator module of the API."""
 
-from typing import List, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 from inductiva import simulators, tasks, types
 

--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -2,7 +2,7 @@
 
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -1,6 +1,6 @@
 """FDS simulator module of the API."""
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 from inductiva.commands.commands import Command
@@ -33,7 +33,7 @@ class FDS(simulators.Simulator):
             use_hwthread: bool = True,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -1,6 +1,6 @@
 """FDS simulator module of the API."""
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command

--- a/inductiva/simulators/fvcom.py
+++ b/inductiva/simulators/fvcom.py
@@ -1,7 +1,7 @@
 """FVCOM simulator module of the API."""
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/fvcom.py
+++ b/inductiva/simulators/fvcom.py
@@ -1,5 +1,5 @@
 """FVCOM simulator module of the API."""
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command

--- a/inductiva/simulators/fvcom.py
+++ b/inductiva/simulators/fvcom.py
@@ -1,5 +1,5 @@
 """FVCOM simulator module of the API."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 from inductiva.commands.commands import Command
@@ -39,7 +39,7 @@ class FVCOM(simulators.Simulator):
             working_dir: Optional[str] = "",
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/gromacs.py
+++ b/inductiva/simulators/gromacs.py
@@ -2,7 +2,7 @@
 
 from typing import List, Literal, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 
 
 class GROMACS(simulators.Simulator):

--- a/inductiva/simulators/gromacs.py
+++ b/inductiva/simulators/gromacs.py
@@ -1,6 +1,6 @@
 """GROMACS module of the API"""
 
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from inductiva import types, tasks, simulators
 
@@ -37,7 +37,7 @@ class GROMACS(simulators.Simulator):
         on: types.ComputationalResources,
         storage_dir: Optional[str] = "",
         resubmit_on_preemption: bool = False,
-        remote_assets: Optional[List[str]] = None,
+        remote_assets: Optional[Union[str, list[str]]] = None,
         project: Optional[str] = None,
         **kwargs,
     ) -> tasks.Task:

--- a/inductiva/simulators/gromacs.py
+++ b/inductiva/simulators/gromacs.py
@@ -1,6 +1,6 @@
 """GROMACS module of the API"""
 
-from typing import List, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 from inductiva import simulators, tasks, types
 

--- a/inductiva/simulators/gx.py
+++ b/inductiva/simulators/gx.py
@@ -1,5 +1,5 @@
 """GX module of the API for numerical simulations."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 
@@ -29,7 +29,7 @@ class GX(simulators.Simulator):
             on: types.ComputationalResources,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/gx.py
+++ b/inductiva/simulators/gx.py
@@ -1,7 +1,7 @@
 """GX module of the API for numerical simulations."""
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 
 
 class GX(simulators.Simulator):

--- a/inductiva/simulators/gx.py
+++ b/inductiva/simulators/gx.py
@@ -1,5 +1,5 @@
 """GX module of the API for numerical simulations."""
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 

--- a/inductiva/simulators/methods.py
+++ b/inductiva/simulators/methods.py
@@ -1,7 +1,8 @@
 """Methods to interact with the available simulators."""
-from typing import Dict, List
-import inductiva
 import json
+from typing import Dict, List
+
+import inductiva
 from inductiva.client.apis.tags.simulators_api import SimulatorsApi
 
 

--- a/inductiva/simulators/mohid.py
+++ b/inductiva/simulators/mohid.py
@@ -1,7 +1,7 @@
 """MOHID simulator module of the API."""
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 
 ALLOWD_MOHID_COMMANDS = ["MohidWater.exe", "MohidLand.exe"]
 

--- a/inductiva/simulators/mohid.py
+++ b/inductiva/simulators/mohid.py
@@ -1,5 +1,5 @@
 """MOHID simulator module of the API."""
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 

--- a/inductiva/simulators/mohid.py
+++ b/inductiva/simulators/mohid.py
@@ -1,5 +1,5 @@
 """MOHID simulator module of the API."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 
@@ -34,7 +34,7 @@ class MOHID(simulators.Simulator):
             n_vcpus: Optional[int] = None,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/nwchem.py
+++ b/inductiva/simulators/nwchem.py
@@ -2,7 +2,7 @@
 
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/nwchem.py
+++ b/inductiva/simulators/nwchem.py
@@ -1,6 +1,6 @@
 """NWChem simulator module of the API."""
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command

--- a/inductiva/simulators/nwchem.py
+++ b/inductiva/simulators/nwchem.py
@@ -1,6 +1,6 @@
 """NWChem simulator module of the API."""
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 from inductiva.commands.commands import Command
@@ -34,7 +34,7 @@ class NWChem(simulators.Simulator):
             use_hwthread: bool = True,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/openfast.py
+++ b/inductiva/simulators/openfast.py
@@ -1,5 +1,5 @@
 """OpenFAST module of the API for wind turbine simulations."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 
@@ -30,7 +30,7 @@ class OpenFAST(simulators.Simulator):
             on: types.ComputationalResources,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/openfast.py
+++ b/inductiva/simulators/openfast.py
@@ -1,5 +1,5 @@
 """OpenFAST module of the API for wind turbine simulations."""
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 

--- a/inductiva/simulators/openfast.py
+++ b/inductiva/simulators/openfast.py
@@ -1,7 +1,7 @@
 """OpenFAST module of the API for wind turbine simulations."""
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 
 
 class OpenFAST(simulators.Simulator):

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -1,7 +1,7 @@
 """OpenFOAM module of the API for fluid dynamics."""
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 
 AVAILABLE_OPENFOAM_DISTRIBUTIONS = ["foundation", "esi"]
 

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -1,5 +1,5 @@
 """OpenFOAM module of the API for fluid dynamics."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 
@@ -57,7 +57,7 @@ class OpenFOAM(simulators.Simulator):
             on: types.ComputationalResources,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/opensees.py
+++ b/inductiva/simulators/opensees.py
@@ -1,8 +1,8 @@
 """OpenSees module of the API."""
-from typing import List, Literal, Optional, Union
 import logging
+from typing import List, Literal, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/opensees.py
+++ b/inductiva/simulators/opensees.py
@@ -1,5 +1,5 @@
 """OpenSees module of the API."""
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 import logging
 
 from inductiva import types, tasks, simulators
@@ -83,7 +83,7 @@ class OpenSees(simulators.Simulator):
             use_hwthread: bool = True,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/opensees.py
+++ b/inductiva/simulators/opensees.py
@@ -1,6 +1,6 @@
 """OpenSees module of the API."""
 import logging
-from typing import List, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command

--- a/inductiva/simulators/opentelemac.py
+++ b/inductiva/simulators/opentelemac.py
@@ -1,6 +1,7 @@
 """OpenTelemac module of the API."""
 from typing import Optional, Union
-from inductiva import types, simulators
+
+from inductiva import simulators, types
 
 
 class OpenTelemac(simulators.Simulator):

--- a/inductiva/simulators/opentelemac.py
+++ b/inductiva/simulators/opentelemac.py
@@ -1,5 +1,5 @@
 """OpenTelemac module of the API."""
-from typing import Optional
+from typing import Optional, Union
 from inductiva import types, simulators
 
 
@@ -25,7 +25,7 @@ class OpenTelemac(simulators.Simulator):
             on: types.ComputationalResources,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[list[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs):
 

--- a/inductiva/simulators/quantum_espresso.py
+++ b/inductiva/simulators/quantum_espresso.py
@@ -1,5 +1,5 @@
 """Class to run commands on Quantum Espresso."""
-from typing import List, Optional
+from typing import List, Optional, Union
 import logging
 
 from inductiva import types, tasks, simulators
@@ -67,7 +67,7 @@ class QuantumEspresso(simulators.Simulator):
             on: types.ComputationalResources,
             extra_metadata: Optional[dict] = None,
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/quantum_espresso.py
+++ b/inductiva/simulators/quantum_espresso.py
@@ -1,8 +1,8 @@
 """Class to run commands on Quantum Espresso."""
-from typing import List, Optional, Union
 import logging
+from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 
 
 @simulators.simulator.mpi_enabled

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -1,6 +1,6 @@
 """Reef3D simulator module of the API."""
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -1,6 +1,6 @@
 """Reef3D simulator module of the API."""
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import simulators, types, tasks
 from inductiva.commands.commands import Command
@@ -33,7 +33,7 @@ class REEF3D(simulators.Simulator):
             use_hwthread: bool = True,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -2,7 +2,7 @@
 
 from typing import List, Optional, Union
 
-from inductiva import simulators, types, tasks
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/schism.py
+++ b/inductiva/simulators/schism.py
@@ -1,5 +1,5 @@
 """SCHISM module of the API."""
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command

--- a/inductiva/simulators/schism.py
+++ b/inductiva/simulators/schism.py
@@ -1,7 +1,7 @@
 """SCHISM module of the API."""
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/schism.py
+++ b/inductiva/simulators/schism.py
@@ -1,5 +1,5 @@
 """SCHISM module of the API."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 from inductiva.commands.commands import Command
@@ -33,7 +33,7 @@ class SCHISM(simulators.Simulator):
             use_hwthread: bool = True,
             n_vcpus: Optional[int] = None,
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/sfincs.py
+++ b/inductiva/simulators/sfincs.py
@@ -1,7 +1,7 @@
 """SFINCS module of the API."""
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 
 
 class SFINCS(simulators.Simulator):

--- a/inductiva/simulators/sfincs.py
+++ b/inductiva/simulators/sfincs.py
@@ -1,5 +1,5 @@
 """SFINCS module of the API."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 
@@ -27,7 +27,7 @@ class SFINCS(simulators.Simulator):
             on: types.ComputationalResources,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/sfincs.py
+++ b/inductiva/simulators/sfincs.py
@@ -1,5 +1,5 @@
 """SFINCS module of the API."""
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -4,7 +4,7 @@ import os
 import pathlib
 import re
 from abc import ABC
-from typing import List, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 from inductiva import commands, logs, projects, resources, tasks, types
 

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -1,5 +1,5 @@
 """Base class for low-level simulators."""
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 from abc import ABC
 import logging
 import os
@@ -243,7 +243,7 @@ class Simulator(ABC):
         on: types.ComputationalResources,
         storage_dir: Optional[str] = "",
         resubmit_on_preemption: bool = False,
-        remote_assets: Optional[List[str]] = None,
+        remote_assets: Optional[Union[str, list[str]]] = None,
         project: Optional[str] = None,
         **kwargs,
     ) -> tasks.Task:
@@ -270,6 +270,9 @@ class Simulator(ABC):
             **kwargs: Additional keyword arguments to be passed to the
                 simulation API method.
         """
+        if isinstance(remote_assets, str):
+            remote_assets = [remote_assets]
+
         self._validate_input_files(input_dir, remote_assets)
 
         input_dir_path = self._setup_input_dir(input_dir) if input_dir else None

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -1,15 +1,14 @@
 """Base class for low-level simulators."""
-from typing import List, Literal, Optional, Union
-from abc import ABC
 import logging
 import os
-import re
-
 import pathlib
+import re
+from abc import ABC
+from typing import List, Literal, Optional, Union
 
-from inductiva import projects, types, tasks, resources, logs
+from inductiva import commands, logs, projects, resources, tasks, types
+
 from .methods import list_available_images
-from inductiva import commands
 
 
 def mpi_enabled(cls):

--- a/inductiva/simulators/snl_swan.py
+++ b/inductiva/simulators/snl_swan.py
@@ -1,8 +1,8 @@
 """ SNL SWAN module of the API."""
-from typing import List, Optional, Union
 from pathlib import Path
+from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/snl_swan.py
+++ b/inductiva/simulators/snl_swan.py
@@ -1,5 +1,5 @@
 """ SNL SWAN module of the API."""
-from typing import List, Optional
+from typing import List, Optional, Union
 from pathlib import Path
 
 from inductiva import types, tasks, simulators
@@ -35,7 +35,7 @@ class SNLSWAN(simulators.Simulator):
         input_dir: Optional[str],
         *,
         sim_config_filename: Optional[str],
-        remote_assets: Optional[List[str]] = None,
+        remote_assets: Optional[Union[str, list[str]]] = None,
         project: Optional[str] = None,
         resubmit_on_preemption: bool = False,
         on: types.ComputationalResources,

--- a/inductiva/simulators/snl_swan.py
+++ b/inductiva/simulators/snl_swan.py
@@ -1,6 +1,6 @@
 """ SNL SWAN module of the API."""
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command

--- a/inductiva/simulators/splishsplash.py
+++ b/inductiva/simulators/splishsplash.py
@@ -1,5 +1,5 @@
 """SplisHSPlasH simulator module of the API."""
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 

--- a/inductiva/simulators/splishsplash.py
+++ b/inductiva/simulators/splishsplash.py
@@ -1,7 +1,7 @@
 """SplisHSPlasH simulator module of the API."""
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 
 
 class SplishSplash(simulators.Simulator):

--- a/inductiva/simulators/splishsplash.py
+++ b/inductiva/simulators/splishsplash.py
@@ -1,5 +1,5 @@
 """SplisHSPlasH simulator module of the API."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 
@@ -29,7 +29,7 @@ class SplishSplash(simulators.Simulator):
         on: types.ComputationalResources,
         storage_dir: Optional[str] = "",
         resubmit_on_preemption: bool = False,
-        remote_assets: Optional[List[str]] = None,
+        remote_assets: Optional[Union[str, list[str]]] = None,
         project: Optional[str] = None,
         vtk_to_obj: Optional[bool] = False,
         vtk_to_obj_vtk_dir: Optional[str] = None,

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -1,6 +1,6 @@
 """SWAN module of the API."""
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -1,8 +1,8 @@
 """SWAN module of the API."""
-from typing import List, Optional, Union
 from pathlib import Path
+from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -1,5 +1,5 @@
 """SWAN module of the API."""
-from typing import List, Optional
+from typing import List, Optional, Union
 from pathlib import Path
 
 from inductiva import types, tasks, simulators
@@ -30,7 +30,7 @@ class SWAN(simulators.Simulator):
         input_dir: Optional[str],
         *,
         sim_config_filename: Optional[str],
-        remote_assets: Optional[List[str]] = None,
+        remote_assets: Optional[Union[str, list[str]]] = None,
         project: Optional[str] = None,
         resubmit_on_preemption: bool = False,
         on: types.ComputationalResources,

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -1,6 +1,6 @@
 """SWASH module of the API."""
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 from inductiva.commands.commands import Command
@@ -35,7 +35,7 @@ class SWASH(simulators.Simulator):
             storage_dir: Optional[str] = "",
             on: types.ComputationalResources,
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -1,6 +1,6 @@
 """SWASH module of the API."""
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command

--- a/inductiva/simulators/wrf.py
+++ b/inductiva/simulators/wrf.py
@@ -2,7 +2,7 @@
 
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/wrf.py
+++ b/inductiva/simulators/wrf.py
@@ -1,6 +1,6 @@
 """WRF simulator module of the API."""
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 from inductiva.commands.commands import Command
@@ -61,7 +61,7 @@ class WRF(simulators.Simulator):
             n_vcpus: Optional[int] = None,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             init_commands: Optional[List[str]] = None,
             gen_gif: bool = False,
             gen_gif_files: Optional[List[str]] = None,

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -1,7 +1,7 @@
 """XBeach module of the API."""
 from typing import List, Optional, Union
 
-from inductiva import types, tasks, simulators
+from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
 from inductiva.commands.mpiconfig import MPIConfig
 

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -1,5 +1,5 @@
 """XBeach module of the API."""
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -1,5 +1,5 @@
 """XBeach module of the API."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from inductiva import types, tasks, simulators
 from inductiva.commands.commands import Command
@@ -34,7 +34,7 @@ class XBeach(simulators.Simulator):
             export_vtk: bool = False,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
-            remote_assets: Optional[List[str]] = None,
+            remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.


### PR DESCRIPTION
This PR adds the ability to do:
```python
sim.run(
    ...
    remote_assets="my_folder",
)
```

whereas previously only this worked:
```python
sim.run(
    ...
    remote_assets=["my_folder"],
)
```