### PR TITLE
Improve openfoam list of commands

### DIFF
--- a/inductiva/resources/machine_groups.py
+++ b/inductiva/resources/machine_groups.py
@@ -160,7 +160,7 @@ class BaseMachineGroup(ABC):
 
     def set_mpi_config(self,
                        mpi_version: str = "4.1.6",
-                       np: int = None,
+                       np: Optional[int] = None,
                        use_hwthread_cpus: bool = True):
         """Set the MPI configuration for the cluster.
         Args:
@@ -170,10 +170,7 @@ class BaseMachineGroup(ABC):
         """
         self.mpi_version = mpi_version
         self.use_hwthread_cpus = use_hwthread_cpus
-        if np is not None:
-            self.np = self.available_vcpus
-        else:
-            self.np = np
+        self.np = np or self.available_vcpus
 
     def get_mpi_config(self):
         """Get the MPI configuration for the cluster."""
@@ -656,8 +653,7 @@ class MachineGroup(BaseMachineGroup):
         self._register_machine_group(num_vms=self.num_machines,
                                      spot=self.spot,
                                      is_elastic=self._is_elastic)
-        if self.np is None:
-            self.np = self.available_vcpus
+        self.np = self.np or self.available_vcpus
 
     def _validate_inputs(self):
         super()._validate_inputs()
@@ -757,8 +753,7 @@ class ElasticMachineGroup(BaseMachineGroup):
                                      is_elastic=self._is_elastic,
                                      num_vms=self._active_machines,
                                      spot=self.spot)
-        if self.np is None:
-            self.np = self.available_vcpus
+        self.np = self.np or self.available_vcpus
 
     def _validate_inputs(self):
         super()._validate_inputs()
@@ -851,8 +846,7 @@ class MPICluster(BaseMachineGroup):
                                      is_elastic=self._is_elastic,
                                      spot=self.spot,
                                      type=self._type)
-        if self.np is None:
-            self.np = self.available_vcpus
+        self.np = self.np or self.available_vcpus
 
     def _validate_inputs(self):
         super()._validate_inputs()

--- a/inductiva/resources/machine_groups.py
+++ b/inductiva/resources/machine_groups.py
@@ -826,6 +826,9 @@ class MPICluster(BaseMachineGroup):
             automatically terminated.
         num_machines: The number of virtual machines to launch.
     """
+    # Constructor arguments
+    num_machines: int = 2
+
     # Internal attributes
     auto_resize_disk_max_gb = None
     _type = ResourceType.MPI.value

--- a/inductiva/resources/machine_groups.py
+++ b/inductiva/resources/machine_groups.py
@@ -826,12 +826,6 @@ class MPICluster(BaseMachineGroup):
             automatically terminated.
         num_machines: The number of virtual machines to launch.
     """
-    # Constructor arguments
-    num_machines: int = 2
-    mpi_version: str = "4.1.6"
-    np: int = None
-    use_hwthread_cpus: bool = True
-
     # Internal attributes
     auto_resize_disk_max_gb = None
     _type = ResourceType.MPI.value

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -100,7 +100,7 @@ class OpenFOAM(simulators.Simulator):
             if isinstance(command, str) and "-parallel" in command:
                 new_command = Command(command, mpi_config=on.get_mpi_config())
                 commands[i] = new_command
-        asd
+
         return super().run(input_dir,
                            on=on,
                            commands=commands,

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -2,6 +2,9 @@
 from typing import List, Optional, Union
 
 from inductiva import simulators, tasks, types
+from inductiva.commands.commands import Command
+from inductiva.commands.mpiconfig import MPIConfig
+from inductiva.resources.machine_groups import MPICluster
 
 AVAILABLE_OPENFOAM_DISTRIBUTIONS = ["foundation", "esi"]
 
@@ -93,6 +96,15 @@ class OpenFOAM(simulators.Simulator):
                                     remote_assets=remote_assets,
                                     shell_script=shell_script)
             commands = [f"bash {shell_script}"]
+
+        # If running on MPICluster convert parallel commands
+        # into mpi commands
+        if isinstance(on, MPICluster):
+            for i, command in enumerate(commands):
+                if "-parallel" in command:
+                    new_command = Command(command,
+                                          mpi_config=on.get_mpi_config())
+                    commands[i] = new_command
 
         return super().run(input_dir,
                            on=on,

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -96,15 +96,11 @@ class OpenFOAM(simulators.Simulator):
                                     shell_script=shell_script)
             commands = [f"bash {shell_script}"]
 
-        # If running on MPICluster convert parallel commands
-        # into mpi commands
-        if isinstance(on, MPICluster):
-            for i, command in enumerate(commands):
-                if isinstance(command, str) and "-parallel" in command:
-                    new_command = Command(command,
-                                          mpi_config=on.get_mpi_config())
-                    commands[i] = new_command
-
+        for i, command in enumerate(commands):
+            if isinstance(command, str) and "-parallel" in command:
+                new_command = Command(command, mpi_config=on.get_mpi_config())
+                commands[i] = new_command
+        asd
         return super().run(input_dir,
                            on=on,
                            commands=commands,

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
-from inductiva.resources.machine_groups import MPICluster
 
 AVAILABLE_OPENFOAM_DISTRIBUTIONS = ["foundation", "esi"]
 

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Union
 
 from inductiva import simulators, tasks, types
 from inductiva.commands.commands import Command
-from inductiva.commands.mpiconfig import MPIConfig
 from inductiva.resources.machine_groups import MPICluster
 
 AVAILABLE_OPENFOAM_DISTRIBUTIONS = ["foundation", "esi"]

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -101,7 +101,7 @@ class OpenFOAM(simulators.Simulator):
         # into mpi commands
         if isinstance(on, MPICluster):
             for i, command in enumerate(commands):
-                if "-parallel" in command:
+                if isinstance(command, str) and "-parallel" in command:
                     new_command = Command(command,
                                           mpi_config=on.get_mpi_config())
                     commands[i] = new_command


### PR DESCRIPTION
This PR introduces two main changes:

1. **Custom MPI Configuration for `MPICluster`**
   Users can now specify a custom MPI configuration when creating an `MPICluster` machine.

   * If no configuration is provided, a default will be used: `mpi_version=4.1.6`, `use_hwthread_cpus=True`, and `np` set to the number of available cores on the cluster.
Example:
```python
cloud_machine = inductiva.resources.MPICluster(
    provider="GCP",
    machine_type="c3d-standard-90",
    num_machines=9,
    data_disk_gb=200,
    spot=True
)
mpi_config-> version="4.1.6", use_hwthread_cpus=True, np=810
```

```python
cloud_machine = inductiva.resources.MPICluster(
    provider="GCP",
    machine_type="c3d-standard-90",
    num_machines=9,
    mpi_version="1.2.3",
    np=5,
    data_disk_gb=200,
    spot=True
)
mpi_config-> version="1.2.3", use_hwthread_cpus=True, np=5
```

2. **Improved OpenFOAM Command Handling**
   Users can once again pass a list of commands to OpenFOAM, now as plain strings (as before).

   * We automatically check each command for the presence of the `-parallel` flag.
   * If detected, the command is converted into a `Command` object, using the MPI configuration defined for the machine.

This will simplify the process of creating the list of commands from (old way):
```python
# MPI configuration
mpiconfig = MPIConfig("4.1.6", np=n_procs, use_hwthread_cpus=True)

# Preprocessing and solver commands
commands = [
    "cp system/controlDict.noWrite system/controlDict",
    "cp system/fvSolution.fixedIter system/fvSolution",
    f"decomposePar -constant {file_handler}",
    "restore0Dir -processor",
    Command(f"renumberMesh -constant -overwrite -parallel {file_handler}", mpi_config=mpiconfig),
    Command(f"potentialFoam -initialiseUBCs -parallel {file_handler}", mpi_config=mpiconfig),
    Command(f"applyBoundaryLayer -ybl '0.0450244' -parallel {file_handler}", mpi_config=mpiconfig),
    Command(f"{solver_rans} -parallel {file_handler}", mpi_config=mpiconfig),
]
```

to
```python
# Preprocessing and solver commands
commands = [
    "cp system/controlDict.noWrite system/controlDict",
    "cp system/fvSolution.fixedIter system/fvSolution",
    f"decomposePar -constant {file_handler}",
    "restore0Dir -processor",
    f"renumberMesh -constant -overwrite -parallel {file_handler}",
    f"potentialFoam -initialiseUBCs -parallel {file_handler}",
    f"applyBoundaryLayer -ybl '0.0450244' -parallel {file_handler}",
    f"{solver_rans} -parallel {file_handler}",
]
```
We will convert the last 3 commands into commands with mpi configs automatically.

> Note: The old way should work exactly the same. We only convert commands that are strings. If you pass a command object in the list we will not touch it.