### PR TITLE
Add installation troubleshooting guide to website

### DIFF
--- a/docs-sources/documentation/cli/auth.md
+++ b/docs-sources/documentation/cli/auth.md
@@ -1,7 +1,7 @@
 # auth
 
 The `inductiva auth` command allows you to manage your
-authentication on Inductiva API. 
+authentication on Inductiva API.
 
 This is a fundamental aspect of your experience: you will only be
 able to start machines and launch simulations after you are authenticated.
@@ -27,25 +27,25 @@ Authenticate using your Inductiva API key.
 inductiva auth login
 ```
 
-You will be prompted to enter your API key. 
+You will be prompted to enter your API key.
 
 ```sh
-     ___  _   _  ____   _   _   ____  _____  ___ __     __ _    
-    |_ _|| \ | ||  _ \ | | | | / ___||_   _||_ _|\ \   / // \   
-     | | |  \| || | | || | | || |      | |   | |  \ \ / // _ \  
-     | | | |\  || |_| || |_| || |___   | |   | |   \ V // ___ \ 
+     ___  _   _  ____   _   _   ____  _____  ___ __     __ _
+    |_ _|| \ | ||  _ \ | | | | / ___||_   _||_ _|\ \   / // \
+     | | |  \| || | | || | | || |      | |   | |  \ \ / // _ \
+     | | | |\  || |_| || |_| || |___   | |   | |   \ V // ___ \
     |___||_| \_||____/  \___/  \____|  |_|  |___|   \_//_/   \_\
-    
-    You are already logged in. Run `inductiva auth logout` if you want to log out. 
+
+    You are already logged in. Run `inductiva auth logout` if you want to log out.
     Setting a new API Key will erase the existing one.
     To log in, you need an API Key. You can obtain it from your account at https://console.inductiva.ai/account.
 Please paste your API Key here:
 ```
 
 At this stage, please copy paste your personal API key that is available
-from your [User Account] (https://console.inductiva.ai/account/details)
+from your [User Account] (https://console.inductiva.ai/account/profile)
 page in the Web Console.  Once authenticated, your credentials will be
-stored locally for future sessions using that machine. 
+stored locally for future sessions using that machine.
 
 ### `logout`
 Remove stored authentication credentials and log out.

--- a/docs-sources/documentation/cli/overview.md
+++ b/docs-sources/documentation/cli/overview.md
@@ -40,7 +40,7 @@ inductiva auth login
 ```
 
 When prompted, copy paste your personal API key that is availalbe
-from your [User Account] (<https://console.inductiva.ai/account/details>)
+from your [User Account] (<https://console.inductiva.ai/account/profile>)
 page in the Web Console.
 
 ## Need Help?

--- a/docs-sources/how-it-works/basics/install-guide.md
+++ b/docs-sources/how-it-works/basics/install-guide.md
@@ -18,6 +18,8 @@ Open your Terminal (Linux/MacOS) or Command Prompt/PowerShell (Windows) and ente
 pip install inductiva
 ```
 
+If you encounter any issues during installation, please refer to our <a href="/guides/how-it-works/basics/troubleshooting">troubleshooting guide</a> for assistance.
+
 ## Step 2: Authenticate Using Inductiva's CLI (Command Line Interface)
 
 Now that the Inductiva package is installed, run the authentication command:
@@ -32,13 +34,13 @@ You should see the INDUCTIVA text art:
 </div>
 <br>
 
-> ⚠️ **Warning**  
-> Windows users might experience an error when trying to authenticate this way, meaning that Inductiva's CLI (Command Line Interface) was not successfuly installed.  
+> ⚠️ **Warning**
+> Windows users might experience an error when trying to authenticate this way, meaning that Inductiva's CLI (Command Line Interface) was not successfuly installed.
 > If this is the case, follow the instructions to Authenticate Using the Python API. Otherwise, move to Step 3.
 
 #### If you got an error and did not get the INDUCTIVA text art
 
-If you weren't able to authenticate using Inductiva's CLI (Command Line Interface), you can do it directly within a Python script.  
+If you weren't able to authenticate using Inductiva's CLI (Command Line Interface), you can do it directly within a Python script.
 
 On your Command Prompt/PowerShell start your Python interpreter:
 
@@ -46,7 +48,7 @@ On your Command Prompt/PowerShell start your Python interpreter:
 python
 ```
 
-You should get a message with the Python version.  
+You should get a message with the Python version.
 Then type:
 
 ```python
@@ -67,4 +69,4 @@ To confirm your authentication, type:
 inductiva user info
 ```
 
-This will display your account information, confirming that the API key has been stored successfully.  
+This will display your account information, confirming that the API key has been stored successfully.

--- a/docs-sources/how-it-works/basics/quick-start-guide.md
+++ b/docs-sources/how-it-works/basics/quick-start-guide.md
@@ -16,7 +16,7 @@ Before starting, ensure the following:
 
 - **Python installed**: Make sure Python (>=3.9) is installed on your system. Check our <a href="/guides/systemrequirements">System Prep guide</a> for more information.
 - **Inductiva API Setup**: Ensure Inductiva library is installed. If you haven’t already, go through the installation steps.
-For a quick check, see that your API Key is set in [Inductiva's web Console](https://console.inductiva.ai/account/details).
+For a quick check, see that your API Key is set in [Inductiva's web Console](https://console.inductiva.ai/account/profile).
 
 ## Create the Python file
 

--- a/docs-sources/how-it-works/basics/troubleshooting.md
+++ b/docs-sources/how-it-works/basics/troubleshooting.md
@@ -1,14 +1,12 @@
-# Troubleshooting Guide
+# Troubleshoot installation
+
 In this troubleshooting section, we aim to guide you through resolving issues
 related to incorrect or incomplete installation of the Inductiva package
-or its dependencies. This guide assumes you’ve gone through all steps we've shared
-in the [user console](https://console.inductiva.ai/), and have faced
-some issues.
+or its dependencies.
 
 If you find bugs, need help, or want to talk to the developers, reach out to us on
-support@inductiva.ai
+[support@inductiva.ai](mailto:support@inductiva.ai).
 
-If you find any security issues, please report to security@inductiva.ai
 
 ---
 
@@ -20,6 +18,7 @@ steps you can take:
 ```
 pip install --upgrade pip
 ```
+
 ### Use virtualenv or venv to isolate dependencies
 
 If installing the package fails, you can retry it on a new Python virtual environment.
@@ -111,7 +110,7 @@ installation:
 2. **Edit Environment Variables**:
    - Go to the **Advanced** tab and click **Environment Variables**.
    - Under **System variables**, find the `PATH` variable and click **Edit**.
-   - Click **New** and add the path to the `Scripts` folder in your Python installation directory.  
+   - Click **New** and add the path to the `Scripts` folder in your Python installation directory.
      Example: `C:\path\to\python\Scripts`
 
 #### On macOS:

--- a/docs-sources/how-it-works/index.md
+++ b/docs-sources/how-it-works/index.md
@@ -22,6 +22,7 @@ hidden: true
 💥 How many cores can be used? <basics/how-many-cores>
 📌 Pick a cloud machine for your simulation <basics/pick-cloud-machine>
 ✈️ Start your first cloud machine with Inductiva <basics/start-first-machine>
+🛠️ Troubleshoot installation <basics/troubleshooting>
 
 ```
 


### PR DESCRIPTION
Move the troubleshooting guide to the website, and link it in the "install the inductiva python package page".