### PR TITLE
Fix openfoam command creation

### DIFF
--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -96,7 +96,11 @@ class OpenFOAM(simulators.Simulator):
             commands = [f"bash {shell_script}"]
 
         for i, command in enumerate(commands):
-            if isinstance(command, str) and "-parallel" in command:
+            # adds mpirun only if string, and mpirun no already present
+            # in the string
+            if isinstance(
+                    command,
+                    str) and "-parallel" in command and "mpirun" not in command:
                 new_command = Command(command, mpi_config=on.get_mpi_config())
                 commands[i] = new_command
 


### PR DESCRIPTION
Last release we added the feature for openfoam to build the mpi commands automatically if `-parallel` is present in the command. But we don't detect if the user already passed `mpirun` in the command.

We now only build the mpi command if the command is a string and mpirun is not present in the command.