### PR TITLE
Fix creation of image_uri in simulator.run

### DIFF
--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -107,7 +107,7 @@ class Simulator(ABC):
     def _regex_exists_in_file(self, file_path: str, pattern: str) -> bool:
         """
         Check if a given regular expression exists in a file.
-        
+
         :param file_path: Path to the file.
         :param pattern: Regular expression pattern to search for.
         :return: True if the pattern exists, False otherwise.
@@ -215,8 +215,8 @@ class Simulator(ABC):
         suffix = f"{suffix}{dev_suffix}"
         return suffix
 
-    def _get_simulator_image_based_on_resource(
-            self, resource: types.ComputationalResources):
+    def _append_simulator_image_suffix_based_on_resource(
+            self, image_uri: str, resource: types.ComputationalResources):
         """
         Get the simulator image for the simulation, based on the resourced used.
 
@@ -232,7 +232,7 @@ class Simulator(ABC):
         if self._device:
             suffixes = self._get_version_suffixes(resource)
 
-        return f"{self._image_uri}{suffixes}"
+        return f"{image_uri}{suffixes}"
 
     @logs.mute_logging()
     def run(
@@ -292,13 +292,14 @@ class Simulator(ABC):
 
         # Get the user-specified image name. If not specified,
         # use the default image name for the current simulator
-        self._image_uri = kwargs.pop("container_image", self._image_uri)
+        image_uri = kwargs.pop("container_image", self._image_uri)
 
         # CustomImage does not use suffixes. We can the image as is
         if self.__class__.__name__ != "CustomImage":
-            self._image_uri = self._get_simulator_image_based_on_resource(on)
+            image_uri = self._append_simulator_image_suffix_based_on_resource(
+                image_uri, on)
 
-        if on.has_gpu() and "_gpu" not in self._image_uri:
+        if on.has_gpu() and "_gpu" not in image_uri:
             logging.warning("Attention: The machine you selected has a GPU, but"
                             " the simulator you picked will run on the CPU "
                             "only.\n")
@@ -313,7 +314,7 @@ class Simulator(ABC):
             simulator_obj=self,
             storage_dir=storage_dir,
             machine_group=on,
-            container_image=self._image_uri,
+            container_image=image_uri,
             resubmit_on_preemption=resubmit_on_preemption,
             remote_assets=remote_assets,
             simulator_name_alias=self.simulator_name_alias,

--- a/inductiva/tests/simulators/test_simulator_with_resources.py
+++ b/inductiva/tests/simulators/test_simulator_with_resources.py
@@ -50,7 +50,7 @@ def test_simulator__wrong_version__raises_error():
     assert "not available" in str(excinfo.value)
 
 
-def test_get_simulator_image_based_on_resource__dev():
+def test_append_simulator_image_suffix_based_on_resource__dev():
     inductiva.set_api_key("dummy")
     #has both cpu and gpu versions
     gmx = inductiva.simulators.GROMACS(use_dev=True)
@@ -62,14 +62,16 @@ def test_get_simulator_image_based_on_resource__dev():
     mg_no_gpu.has_gpu.return_value = False
 
     # pylint: disable=protected-access
-    sim_image_gpu = gmx._get_simulator_image_based_on_resource(mg_gpu)
-    sim_image_no_gpu = gmx._get_simulator_image_based_on_resource(mg_no_gpu)
+    sim_image_gpu = gmx._append_simulator_image_suffix_based_on_resource(
+        gmx._image_uri, mg_gpu)
+    sim_image_no_gpu = gmx._append_simulator_image_suffix_based_on_resource(
+        gmx._image_uri, mg_no_gpu)
 
     assert sim_image_gpu.endswith("_gpu_dev")
     assert sim_image_no_gpu.endswith("_dev")
 
 
-def test_get_simulator_image_based_on_resource__not_dev():
+def test_append_simulator_image_suffix_based_on_resource__not_dev():
     inductiva.set_api_key("dummy")
     #has both cpu and gpu versions
     gmx = inductiva.simulators.GROMACS(use_dev=False)
@@ -78,7 +80,8 @@ def test_get_simulator_image_based_on_resource__not_dev():
     mg_gpu.has_gpu.return_value = True
 
     # pylint: disable=protected-access
-    sim_image_gpu = gmx._get_simulator_image_based_on_resource(mg_gpu)
+    sim_image_gpu = gmx._append_simulator_image_suffix_based_on_resource(
+        gmx._image_uri, mg_gpu)
 
     assert sim_image_gpu.endswith("_gpu")
 


### PR DESCRIPTION
The image_uri was being updated more than once if several tasks were run with the same simulator object. This fixes that by using a local variable for the final image_uri instead of updating the image_uri property of the object.