### PR TITLE
Add `time_to_live` parameter

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -325,7 +325,8 @@ def submit_task(simulator,
                 simulator_name_alias: Optional[str] = None,
                 simulator_obj=None,
                 remote_assets: Optional[List[str]] = None,
-                project_name: Optional[str] = None):
+                project_name: Optional[str] = None,
+                time_to_live: Optional[str] = None):
     """Submit a task and send input files to the API.
 
     Args:
@@ -347,6 +348,11 @@ def submit_task(simulator,
         project: Name of the project to which the task will be
                 assigned. If None, the task will be assigned to
                 the default project.
+        time_to_live: Maximum duration the task is allowed to run, 
+            specified as a string with a time unit suffix. Supported formats
+            include minutes ("10m") or hours ("2h"). The task will be 
+            automatically terminated once this duration has elapsed since
+            its start.
     Return:
         Returns the task id.
     """
@@ -357,11 +363,14 @@ def submit_task(simulator,
     stream_zip = params.pop("stream_zip", True)
     compress_with = params.pop("compress_with", CompressionMethod.SEVEN_Z)
 
+    ttls = format_utils.str_to_seconds(time_to_live) if time_to_live else None
+
     task_request = TaskRequest(simulator=simulator,
                                extra_params=params,
                                project=project_name,
                                resource_pool=machine_group.id,
                                container_image=container_image,
+                               time_to_live_seconds=ttls,
                                storage_path_prefix=storage_path_prefix,
                                simulator_name_alias=simulator_name_alias,
                                resubmit_on_preemption=resubmit_on_preemption,

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -48,6 +48,7 @@ class AmrWind(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -72,6 +73,11 @@ class AmrWind(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
             **kwargs: Keyword arguments to be passed to the base class.
         """
 
@@ -96,4 +102,5 @@ class AmrWind(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -44,6 +44,7 @@ class CaNS(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -65,6 +66,11 @@ class CaNS(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
             other arguments: See the documentation of the base class.
         """
 
@@ -94,4 +100,5 @@ class CaNS(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/cm1.py
+++ b/inductiva/simulators/cm1.py
@@ -35,6 +35,7 @@ class CM1(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -58,6 +59,11 @@ class CM1(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+           time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
             other arguments: See the documentation of the base class.
         """
         if sim_config_filename is None:
@@ -89,4 +95,5 @@ class CM1(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/coawst.py
+++ b/inductiva/simulators/coawst.py
@@ -69,6 +69,7 @@ class COAWST(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -116,6 +117,11 @@ class COAWST(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
 
         if build_coawst_script is None and compile_simulator:
@@ -188,4 +194,5 @@ class COAWST(simulators.Simulator):
                            remote_assets=remote_assets,
                            resubmit_on_preemption=resubmit_on_preemption,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/cp2k.py
+++ b/inductiva/simulators/cp2k.py
@@ -42,6 +42,7 @@ class CP2K(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -65,6 +66,11 @@ class CP2K(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
             other arguments: See the documentation of the base class.
         """
 
@@ -89,4 +95,5 @@ class CP2K(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/custom_image.py
+++ b/inductiva/simulators/custom_image.py
@@ -32,6 +32,7 @@ class CustomImage(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
         Args:
@@ -50,6 +51,11 @@ class CustomImage(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
         return super().run(input_dir,
                            on=on,
@@ -59,4 +65,5 @@ class CustomImage(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/delft3d.py
+++ b/inductiva/simulators/delft3d.py
@@ -29,6 +29,7 @@ class Delft3D(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs):
 
         if commands is None and shell_script is None:
@@ -53,4 +54,5 @@ class Delft3D(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -39,6 +39,7 @@ class DualSPHysics(simulators.Simulator):
         resubmit_on_preemption: bool = False,
         remote_assets: Optional[Union[str, list[str]]] = None,
         project: Optional[str] = None,
+        time_to_live: Optional[str] = None,
         vtk_to_obj: Optional[bool] = False,
         vtk_to_obj_vtk_dir: Optional[str] = None,
         vtk_to_obj_vtk_prefix: Optional[str] = "PartFluid_",
@@ -66,6 +67,11 @@ class DualSPHysics(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
             vtk_to_obj: Whether to convert the output VTK files to OBJ meshes
                 using marching cubes.
             vtk_to_obj_vtk_dir: Directory containing VTK files to be converted.
@@ -131,4 +137,5 @@ class DualSPHysics(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -35,6 +35,7 @@ class FDS(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -58,6 +59,11 @@ class FDS(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
 
         self._input_files_exist(input_dir=input_dir,
@@ -84,4 +90,5 @@ class FDS(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/fvcom.py
+++ b/inductiva/simulators/fvcom.py
@@ -41,6 +41,7 @@ class FVCOM(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -89,6 +90,12 @@ class FVCOM(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
 
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
+
             other arguments: See the documentation of the base class.
         """
         if model != "" and model.lower() != "estuary":
@@ -121,4 +128,5 @@ class FVCOM(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/gromacs.py
+++ b/inductiva/simulators/gromacs.py
@@ -39,6 +39,7 @@ class GROMACS(simulators.Simulator):
         resubmit_on_preemption: bool = False,
         remote_assets: Optional[Union[str, list[str]]] = None,
         project: Optional[str] = None,
+        time_to_live: Optional[str] = None,
         **kwargs,
     ) -> tasks.Task:
         """Run a list of GROMACS commands.
@@ -59,6 +60,11 @@ class GROMACS(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
 
         return super().run(input_dir,
@@ -68,4 +74,5 @@ class GROMACS(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/gx.py
+++ b/inductiva/simulators/gx.py
@@ -31,6 +31,7 @@ class GX(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -48,6 +49,11 @@ class GX(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
 
         self._input_files_exist(input_dir=input_dir,
@@ -63,4 +69,5 @@ class GX(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/mohid.py
+++ b/inductiva/simulators/mohid.py
@@ -36,6 +36,7 @@ class MOHID(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -63,6 +64,11 @@ class MOHID(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
 
         self._check_vcpus(n_vcpus, on)
@@ -92,4 +98,5 @@ class MOHID(simulators.Simulator):
                            run_subprocess_dir=working_dir,
                            resubmit_on_preemption=resubmit_on_preemption,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/nwchem.py
+++ b/inductiva/simulators/nwchem.py
@@ -36,6 +36,7 @@ class NWChem(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -58,6 +59,11 @@ class NWChem(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
 
         self._input_files_exist(input_dir=input_dir,
@@ -81,4 +87,5 @@ class NWChem(simulators.Simulator):
                            remote_assets=remote_assets,
                            resubmit_on_preemption=resubmit_on_preemption,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/openfast.py
+++ b/inductiva/simulators/openfast.py
@@ -32,6 +32,7 @@ class OpenFAST(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -49,6 +50,11 @@ class OpenFAST(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
         return super().run(input_dir,
                            on=on,
@@ -57,4 +63,5 @@ class OpenFAST(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -60,6 +60,7 @@ class OpenFOAM(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -79,6 +80,11 @@ class OpenFOAM(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
             other arguments: See the documentation of the base class.
         """
         if not commands and not shell_script:
@@ -109,4 +115,5 @@ class OpenFOAM(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/opensees.py
+++ b/inductiva/simulators/opensees.py
@@ -85,6 +85,7 @@ class OpenSees(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -108,6 +109,11 @@ class OpenSees(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
             other arguments: See the documentation of the base class.
         """
 
@@ -150,4 +156,5 @@ class OpenSees(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/opentelemac.py
+++ b/inductiva/simulators/opentelemac.py
@@ -28,6 +28,7 @@ class OpenTelemac(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs):
 
         return super().run(input_dir,
@@ -37,4 +38,5 @@ class OpenTelemac(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/quantum_espresso.py
+++ b/inductiva/simulators/quantum_espresso.py
@@ -69,6 +69,7 @@ class QuantumEspresso(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
         Args:
@@ -87,6 +88,11 @@ class QuantumEspresso(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
         return super().run(input_dir,
                            on=on,
@@ -97,4 +103,5 @@ class QuantumEspresso(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -35,6 +35,7 @@ class REEF3D(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -57,6 +58,11 @@ class REEF3D(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
             other arguments: See the documentation of the base class.
         """
         mpi_kwargs = {}
@@ -77,4 +83,5 @@ class REEF3D(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/schism.py
+++ b/inductiva/simulators/schism.py
@@ -35,6 +35,7 @@ class SCHISM(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
         
@@ -58,6 +59,11 @@ class SCHISM(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
         mpi_kwargs = {}
         mpi_kwargs["use_hwthread_cpus"] = use_hwthread
@@ -79,4 +85,5 @@ class SCHISM(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/sfincs.py
+++ b/inductiva/simulators/sfincs.py
@@ -29,6 +29,7 @@ class SFINCS(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -47,6 +48,11 @@ class SFINCS(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+           time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
             other arguments: See the documentation of the base class.
         """
 
@@ -63,4 +69,5 @@ class SFINCS(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -244,6 +244,7 @@ class Simulator(ABC):
         resubmit_on_preemption: bool = False,
         remote_assets: Optional[Union[str, list[str]]] = None,
         project: Optional[str] = None,
+        time_to_live: Optional[str] = None,
         **kwargs,
     ) -> tasks.Task:
         """Run the simulation.
@@ -266,6 +267,11 @@ class Simulator(ABC):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
             **kwargs: Additional keyword arguments to be passed to the
                 simulation API method.
         """
@@ -319,6 +325,7 @@ class Simulator(ABC):
             remote_assets=remote_assets,
             simulator_name_alias=self.simulator_name_alias,
             project_name=project,
+            time_to_live=time_to_live,
             **kwargs,
         )
 

--- a/inductiva/simulators/snl_swan.py
+++ b/inductiva/simulators/snl_swan.py
@@ -43,6 +43,7 @@ class SNLSWAN(simulators.Simulator):
         n_vcpus: Optional[int] = None,
         use_hwthread: bool = True,
         command: str = "swanrun",
+        time_to_live: Optional[str] = None,
         **kwargs,
     ) -> tasks.Task:
         """Run the simulation.
@@ -70,6 +71,11 @@ class SNLSWAN(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
 
         if command not in ("swanrun", "swan.exe"):
@@ -135,4 +141,5 @@ class SNLSWAN(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/splishsplash.py
+++ b/inductiva/simulators/splishsplash.py
@@ -31,6 +31,7 @@ class SplishSplash(simulators.Simulator):
         resubmit_on_preemption: bool = False,
         remote_assets: Optional[Union[str, list[str]]] = None,
         project: Optional[str] = None,
+        time_to_live: Optional[str] = None,
         vtk_to_obj: Optional[bool] = False,
         vtk_to_obj_vtk_dir: Optional[str] = None,
         vtk_to_obj_vtk_prefix: Optional[str] = "PartFluid_",
@@ -59,6 +60,11 @@ class SplishSplash(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
             vtk_to_obj: Whether to convert the output VTK files to OBJ meshes
                 using marching cubes.
             vtk_to_obj_vtk_dir: Directory containing VTK files to be converted.
@@ -130,5 +136,6 @@ class SplishSplash(simulators.Simulator):
             resubmit_on_preemption=resubmit_on_preemption,
             remote_assets=remote_assets,
             project=project,
+            time_to_live=time_to_live,
             **kwargs,
         )

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -32,6 +32,7 @@ class SWAN(simulators.Simulator):
         sim_config_filename: Optional[str],
         remote_assets: Optional[Union[str, list[str]]] = None,
         project: Optional[str] = None,
+        time_to_live: Optional[str] = None,
         resubmit_on_preemption: bool = False,
         on: types.ComputationalResources,
         storage_dir: Optional[str] = "",
@@ -65,6 +66,11 @@ class SWAN(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
 
         if command not in ("swanrun", "swan.exe"):
@@ -130,4 +136,5 @@ class SWAN(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -37,6 +37,7 @@ class SWASH(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -62,6 +63,11 @@ class SWASH(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
 
         if command not in ("swashrun", "swash.exe"):
@@ -128,4 +134,5 @@ class SWASH(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/wrf.py
+++ b/inductiva/simulators/wrf.py
@@ -69,6 +69,7 @@ class WRF(simulators.Simulator):
             gen_gif_fps: int = 3,
             gen_gif_variable: Optional[List[str]] = "RAINNC",
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -106,7 +107,11 @@ class WRF(simulators.Simulator):
             gen_gif_fps (int): Frames per second for the GIF. Default is 3.
             gen_gif_variable (str): Variable to be used for generating the GIF.
                 Default is "RAINNC".
-            
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
         """
 
         if case_name not in self.VALID_CASE_NAMES:
@@ -161,4 +166,5 @@ class WRF(simulators.Simulator):
                            remote_assets=remote_assets,
                            resubmit_on_preemption=resubmit_on_preemption,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -36,6 +36,7 @@ class XBeach(simulators.Simulator):
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
             project: Optional[str] = None,
+            time_to_live: Optional[str] = None,
             **kwargs) -> tasks.Task:
         """Run the simulation.
 
@@ -61,6 +62,11 @@ class XBeach(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
+            time_to_live: Maximum duration the task is allowed to run, 
+                specified as a string with a time unit suffix. Supported formats
+                include minutes ("10m") or hours ("2h"). The task will be 
+                automatically terminated once this duration has elapsed since
+                its start.
             other arguments: See the documentation of the base class.
         """
 
@@ -91,4 +97,5 @@ class XBeach(simulators.Simulator):
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
                            project=project,
+                           time_to_live=time_to_live,
                            **kwargs)

--- a/inductiva/tasks/run_simulation.py
+++ b/inductiva/tasks/run_simulation.py
@@ -19,6 +19,7 @@ def run_simulation(
     remote_assets: Optional[List[str]] = None,
     simulator_name_alias: Optional[str] = None,
     project_name: Optional[str] = None,
+    time_to_live: Optional[str] = None,
     verbose: bool = True,
     **kwargs: Any,
 ) -> tasks.Task:
@@ -50,6 +51,7 @@ def run_simulation(
                                   simulator_obj=simulator_obj,
                                   remote_assets=remote_assets,
                                   project_name=project_name,
+                                  time_to_live=time_to_live,
                                   verbose=verbose)
 
     if not isinstance(task_id, str):

--- a/inductiva/utils/format_utils.py
+++ b/inductiva/utils/format_utils.py
@@ -310,3 +310,17 @@ def currency_formatter(amount: float) -> str:
         return f"{amount:.{decimal_places}f} {CURRENCY_SYMBOL}"
 
     return f"{amount:.2f} {CURRENCY_SYMBOL}"
+
+
+def str_to_seconds(duration: str) -> int:
+    """
+    Convert a duration string to seconds.
+    Supports only minutes (m) or hours (h).
+    """
+    unit = duration[-1].lower()
+    units = {"h": 3600, "m": 60}
+    if unit not in units:
+        err_msg = "Invalid unit: only minutes (m) or hours (h) are supported."
+        raise ValueError(err_msg)
+    value = int(duration[:-1])
+    return value * units[unit]


### PR DESCRIPTION
Related to [#953](https://github.com/inductiva/tasks/issues/953)

Examples:
- `time_to_live="1m"` -- sets the time to live to 1 minute.
- `time_to_live="2h"` -- sets the time to live to 2 hours.

I tested the new `time_to_live` parameter using the following script:

```python
import inductiva

input_dir = inductiva.utils.files.download_from_url(
    "https://storage.googleapis.com/inductiva-api-demo-files/"
    "gromacs-input-example.zip", True)

commands = ["sleep 120"]
machine = inductiva.resources.MachineGroup("c2-standard-4")
gromacs = inductiva.simulators.GROMACS()

task = gromacs.run(
    input_dir=input_dir,
    commands=commands,
    on=machine,
    time_to_live="1m",
)

task.wait()
machine.terminate()
```

This produced the following output in the CLI:

```bash
...
│# COMMAND: ['sleep', '120']
│# Working directory: /workdir/output/artifacts
│
│
│ -------
│
│ -------
■ Your task exceeded its configured time-to-live (TTL) and was automatically stopped.
Downloading stdout and stderr files to inductiva_output/hc0vv9dxm04e2yivzu09awwxx/outputs...
Partial download completed to inductiva_output/hc0vv9dxm04e2yivzu09awwxx/outputs.
Successfully requested termination of MachineGroup(name="api-dqq8q7psjxdbd16f3imcwdnd9").
Termination of the machine group freed the following quotas:
...
```

And the following output in the Console:

![Screenshot 2025-06-24 at 13 56 40](https://github.com/user-attachments/assets/5954499e-3bf1-46d2-866f-46ee44352af6)