### PR TITLE
Add `pytimeparse` for `time_to_live` parsing

### DIFF
--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -350,10 +350,10 @@ def submit_task(simulator,
                 assigned. If None, the task will be assigned to
                 the default project.
         time_to_live: Maximum allowed runtime for the task, specified as a
-            string duration. Supports all formats accepted by the
-            `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-            "90s". The task will be automatically terminated if it exceeds
-            this duration after starting.
+            string duration. Supports common time duration formats such as
+            "10m", "2 hours", "1h30m", or "90s". The task will be
+            automatically terminated if it exceeds this duration after
+            starting.
     Return:
         Returns the task id.
     """

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -349,11 +349,11 @@ def submit_task(simulator,
         project: Name of the project to which the task will be
                 assigned. If None, the task will be assigned to
                 the default project.
-        time_to_live: Maximum duration the task is allowed to run, 
-            specified as a string with a time unit suffix. Supported formats
-            include minutes ("10m") or hours ("2h"). The task will be 
-            automatically terminated once this duration has elapsed since
-            its start.
+        time_to_live: Maximum allowed runtime for the task, specified as a
+            string duration. Supports all formats accepted by the
+            `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+            "90s". The task will be automatically terminated if it exceeds
+            this duration after starting.
     Return:
         Returns the task id.
     """

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -14,6 +14,7 @@ import decimal
 import ssl
 from contextlib import contextmanager
 from typing import List, Optional
+from pytimeparse.timeparse import timeparse
 
 import logging
 
@@ -363,14 +364,19 @@ def submit_task(simulator,
     stream_zip = params.pop("stream_zip", True)
     compress_with = params.pop("compress_with", CompressionMethod.SEVEN_Z)
 
-    ttls = format_utils.str_to_seconds(time_to_live) if time_to_live else None
+    if time_to_live:
+        time_to_live_seconds = timeparse(time_to_live)
+        if time_to_live_seconds is None:
+            raise ValueError("Time could not be parsed from the given string.")
+    else:
+        time_to_live_seconds = None
 
     task_request = TaskRequest(simulator=simulator,
                                extra_params=params,
                                project=project_name,
                                resource_pool=machine_group.id,
                                container_image=container_image,
-                               time_to_live_seconds=ttls,
+                               time_to_live_seconds=time_to_live_seconds,
                                storage_path_prefix=storage_path_prefix,
                                simulator_name_alias=simulator_name_alias,
                                resubmit_on_preemption=resubmit_on_preemption,

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -14,7 +14,7 @@ import decimal
 import ssl
 from contextlib import contextmanager
 from typing import List, Optional
-from pytimeparse.timeparse import timeparse
+from pytimeparse2 import parse
 
 import logging
 
@@ -351,7 +351,7 @@ def submit_task(simulator,
                 the default project.
         time_to_live: Maximum allowed runtime for the task, specified as a
             string duration. Supports all formats accepted by the
-            `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+            `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
             "90s". The task will be automatically terminated if it exceeds
             this duration after starting.
     Return:
@@ -364,19 +364,14 @@ def submit_task(simulator,
     stream_zip = params.pop("stream_zip", True)
     compress_with = params.pop("compress_with", CompressionMethod.SEVEN_Z)
 
-    if time_to_live:
-        time_to_live_seconds = timeparse(time_to_live)
-        if time_to_live_seconds is None:
-            raise ValueError("Time could not be parsed from the given string.")
-    else:
-        time_to_live_seconds = None
+    ttls = parse(time_to_live, raise_exception=True) if time_to_live else None
 
     task_request = TaskRequest(simulator=simulator,
                                extra_params=params,
                                project=project_name,
                                resource_pool=machine_group.id,
                                container_image=container_image,
-                               time_to_live_seconds=time_to_live_seconds,
+                               time_to_live_seconds=ttls,
                                storage_path_prefix=storage_path_prefix,
                                simulator_name_alias=simulator_name_alias,
                                resubmit_on_preemption=resubmit_on_preemption,

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -364,14 +364,14 @@ def submit_task(simulator,
     stream_zip = params.pop("stream_zip", True)
     compress_with = params.pop("compress_with", CompressionMethod.SEVEN_Z)
 
-    ttls = parse(time_to_live, raise_exception=True) if time_to_live else None
+    time_to_live_seconds = parse(time_to_live, raise_exception=True)
 
     task_request = TaskRequest(simulator=simulator,
                                extra_params=params,
                                project=project_name,
                                resource_pool=machine_group.id,
                                container_image=container_image,
-                               time_to_live_seconds=ttls,
+                               time_to_live_seconds=time_to_live_seconds,
                                storage_path_prefix=storage_path_prefix,
                                simulator_name_alias=simulator_name_alias,
                                resubmit_on_preemption=resubmit_on_preemption,

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -14,7 +14,7 @@ import decimal
 import ssl
 from contextlib import contextmanager
 from typing import List, Optional
-from pytimeparse2 import parse
+import pytimeparse2
 
 import logging
 
@@ -364,7 +364,11 @@ def submit_task(simulator,
     stream_zip = params.pop("stream_zip", True)
     compress_with = params.pop("compress_with", CompressionMethod.SEVEN_Z)
 
-    time_to_live_seconds = parse(time_to_live, raise_exception=True)
+    time_to_live_seconds = (
+        pytimeparse2.parse(time_to_live, raise_exception=True)
+        if time_to_live
+        else None
+    )
 
     task_request = TaskRequest(simulator=simulator,
                                extra_params=params,

--- a/inductiva/api/methods.py
+++ b/inductiva/api/methods.py
@@ -364,11 +364,8 @@ def submit_task(simulator,
     stream_zip = params.pop("stream_zip", True)
     compress_with = params.pop("compress_with", CompressionMethod.SEVEN_Z)
 
-    time_to_live_seconds = (
-        pytimeparse2.parse(time_to_live, raise_exception=True)
-        if time_to_live
-        else None
-    )
+    time_to_live_seconds = pytimeparse2.parse(
+        time_to_live, raise_exception=True) if time_to_live else None
 
     task_request = TaskRequest(simulator=simulator,
                                extra_params=params,

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -75,7 +75,7 @@ class AmrWind(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
             **kwargs: Keyword arguments to be passed to the base class.

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -74,10 +74,10 @@ class AmrWind(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
             **kwargs: Keyword arguments to be passed to the base class.
         """
 

--- a/inductiva/simulators/amr_wind.py
+++ b/inductiva/simulators/amr_wind.py
@@ -73,11 +73,11 @@ class AmrWind(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
             **kwargs: Keyword arguments to be passed to the base class.
         """
 

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -67,10 +67,10 @@ class CaNS(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
             other arguments: See the documentation of the base class.
         """
 

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -66,11 +66,11 @@ class CaNS(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
             other arguments: See the documentation of the base class.
         """
 

--- a/inductiva/simulators/cans.py
+++ b/inductiva/simulators/cans.py
@@ -68,7 +68,7 @@ class CaNS(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
             other arguments: See the documentation of the base class.

--- a/inductiva/simulators/cm1.py
+++ b/inductiva/simulators/cm1.py
@@ -59,11 +59,11 @@ class CM1(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-           time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
             other arguments: See the documentation of the base class.
         """
         if sim_config_filename is None:

--- a/inductiva/simulators/cm1.py
+++ b/inductiva/simulators/cm1.py
@@ -60,10 +60,10 @@ class CM1(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
             other arguments: See the documentation of the base class.
         """
         if sim_config_filename is None:

--- a/inductiva/simulators/cm1.py
+++ b/inductiva/simulators/cm1.py
@@ -61,7 +61,7 @@ class CM1(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
             other arguments: See the documentation of the base class.

--- a/inductiva/simulators/coawst.py
+++ b/inductiva/simulators/coawst.py
@@ -119,7 +119,7 @@ class COAWST(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/coawst.py
+++ b/inductiva/simulators/coawst.py
@@ -117,11 +117,11 @@ class COAWST(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
 
         if build_coawst_script is None and compile_simulator:

--- a/inductiva/simulators/coawst.py
+++ b/inductiva/simulators/coawst.py
@@ -118,10 +118,10 @@ class COAWST(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
 
         if build_coawst_script is None and compile_simulator:

--- a/inductiva/simulators/cp2k.py
+++ b/inductiva/simulators/cp2k.py
@@ -67,10 +67,10 @@ class CP2K(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
             other arguments: See the documentation of the base class.
         """
 

--- a/inductiva/simulators/cp2k.py
+++ b/inductiva/simulators/cp2k.py
@@ -68,7 +68,7 @@ class CP2K(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
             other arguments: See the documentation of the base class.

--- a/inductiva/simulators/cp2k.py
+++ b/inductiva/simulators/cp2k.py
@@ -66,11 +66,11 @@ class CP2K(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
             other arguments: See the documentation of the base class.
         """
 

--- a/inductiva/simulators/custom_image.py
+++ b/inductiva/simulators/custom_image.py
@@ -51,11 +51,11 @@ class CustomImage(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
         return super().run(input_dir,
                            on=on,

--- a/inductiva/simulators/custom_image.py
+++ b/inductiva/simulators/custom_image.py
@@ -52,10 +52,10 @@ class CustomImage(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
         return super().run(input_dir,
                            on=on,

--- a/inductiva/simulators/custom_image.py
+++ b/inductiva/simulators/custom_image.py
@@ -53,7 +53,7 @@ class CustomImage(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -68,10 +68,10 @@ class DualSPHysics(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
             vtk_to_obj: Whether to convert the output VTK files to OBJ meshes
                 using marching cubes.
             vtk_to_obj_vtk_dir: Directory containing VTK files to be converted.

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -67,11 +67,11 @@ class DualSPHysics(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
             vtk_to_obj: Whether to convert the output VTK files to OBJ meshes
                 using marching cubes.
             vtk_to_obj_vtk_dir: Directory containing VTK files to be converted.

--- a/inductiva/simulators/dualsphysics.py
+++ b/inductiva/simulators/dualsphysics.py
@@ -69,7 +69,7 @@ class DualSPHysics(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
             vtk_to_obj: Whether to convert the output VTK files to OBJ meshes

--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -60,10 +60,10 @@ class FDS(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
 
         self._input_files_exist(input_dir=input_dir,

--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -61,7 +61,7 @@ class FDS(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/fds.py
+++ b/inductiva/simulators/fds.py
@@ -59,11 +59,11 @@ class FDS(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
 
         self._input_files_exist(input_dir=input_dir,

--- a/inductiva/simulators/fvcom.py
+++ b/inductiva/simulators/fvcom.py
@@ -90,11 +90,11 @@ class FVCOM(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
 
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
 
             other arguments: See the documentation of the base class.
         """

--- a/inductiva/simulators/fvcom.py
+++ b/inductiva/simulators/fvcom.py
@@ -92,7 +92,7 @@ class FVCOM(simulators.Simulator):
 
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
 

--- a/inductiva/simulators/fvcom.py
+++ b/inductiva/simulators/fvcom.py
@@ -91,10 +91,10 @@ class FVCOM(simulators.Simulator):
                 created.
 
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
 
             other arguments: See the documentation of the base class.
         """

--- a/inductiva/simulators/gromacs.py
+++ b/inductiva/simulators/gromacs.py
@@ -62,7 +62,7 @@ class GROMACS(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/gromacs.py
+++ b/inductiva/simulators/gromacs.py
@@ -61,10 +61,10 @@ class GROMACS(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
 
         return super().run(input_dir,

--- a/inductiva/simulators/gromacs.py
+++ b/inductiva/simulators/gromacs.py
@@ -60,11 +60,11 @@ class GROMACS(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
 
         return super().run(input_dir,

--- a/inductiva/simulators/gx.py
+++ b/inductiva/simulators/gx.py
@@ -51,7 +51,7 @@ class GX(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/gx.py
+++ b/inductiva/simulators/gx.py
@@ -50,10 +50,10 @@ class GX(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
 
         self._input_files_exist(input_dir=input_dir,

--- a/inductiva/simulators/gx.py
+++ b/inductiva/simulators/gx.py
@@ -49,11 +49,11 @@ class GX(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
 
         self._input_files_exist(input_dir=input_dir,

--- a/inductiva/simulators/mohid.py
+++ b/inductiva/simulators/mohid.py
@@ -66,7 +66,7 @@ class MOHID(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/mohid.py
+++ b/inductiva/simulators/mohid.py
@@ -65,10 +65,10 @@ class MOHID(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
 
         self._check_vcpus(n_vcpus, on)

--- a/inductiva/simulators/mohid.py
+++ b/inductiva/simulators/mohid.py
@@ -64,11 +64,11 @@ class MOHID(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
 
         self._check_vcpus(n_vcpus, on)

--- a/inductiva/simulators/nwchem.py
+++ b/inductiva/simulators/nwchem.py
@@ -59,11 +59,11 @@ class NWChem(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
 
         self._input_files_exist(input_dir=input_dir,

--- a/inductiva/simulators/nwchem.py
+++ b/inductiva/simulators/nwchem.py
@@ -60,10 +60,10 @@ class NWChem(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
 
         self._input_files_exist(input_dir=input_dir,

--- a/inductiva/simulators/nwchem.py
+++ b/inductiva/simulators/nwchem.py
@@ -61,7 +61,7 @@ class NWChem(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/openfast.py
+++ b/inductiva/simulators/openfast.py
@@ -51,10 +51,10 @@ class OpenFAST(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
         return super().run(input_dir,
                            on=on,

--- a/inductiva/simulators/openfast.py
+++ b/inductiva/simulators/openfast.py
@@ -50,11 +50,11 @@ class OpenFAST(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
         return super().run(input_dir,
                            on=on,

--- a/inductiva/simulators/openfast.py
+++ b/inductiva/simulators/openfast.py
@@ -52,7 +52,7 @@ class OpenFAST(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -82,7 +82,7 @@ class OpenFOAM(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
             other arguments: See the documentation of the base class.

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -80,11 +80,11 @@ class OpenFOAM(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
             other arguments: See the documentation of the base class.
         """
         if not commands and not shell_script:

--- a/inductiva/simulators/openfoam.py
+++ b/inductiva/simulators/openfoam.py
@@ -81,10 +81,10 @@ class OpenFOAM(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
             other arguments: See the documentation of the base class.
         """
         if not commands and not shell_script:

--- a/inductiva/simulators/opensees.py
+++ b/inductiva/simulators/opensees.py
@@ -110,10 +110,10 @@ class OpenSees(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
             other arguments: See the documentation of the base class.
         """
 

--- a/inductiva/simulators/opensees.py
+++ b/inductiva/simulators/opensees.py
@@ -109,11 +109,11 @@ class OpenSees(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
             other arguments: See the documentation of the base class.
         """
 

--- a/inductiva/simulators/opensees.py
+++ b/inductiva/simulators/opensees.py
@@ -111,7 +111,7 @@ class OpenSees(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
             other arguments: See the documentation of the base class.

--- a/inductiva/simulators/quantum_espresso.py
+++ b/inductiva/simulators/quantum_espresso.py
@@ -90,7 +90,7 @@ class QuantumEspresso(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/quantum_espresso.py
+++ b/inductiva/simulators/quantum_espresso.py
@@ -89,10 +89,10 @@ class QuantumEspresso(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
         return super().run(input_dir,
                            on=on,

--- a/inductiva/simulators/quantum_espresso.py
+++ b/inductiva/simulators/quantum_espresso.py
@@ -88,11 +88,11 @@ class QuantumEspresso(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
         return super().run(input_dir,
                            on=on,

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -60,7 +60,7 @@ class REEF3D(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
             other arguments: See the documentation of the base class.

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -59,10 +59,10 @@ class REEF3D(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
             other arguments: See the documentation of the base class.
         """
         mpi_kwargs = {}

--- a/inductiva/simulators/reef3d.py
+++ b/inductiva/simulators/reef3d.py
@@ -58,11 +58,11 @@ class REEF3D(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
             other arguments: See the documentation of the base class.
         """
         mpi_kwargs = {}

--- a/inductiva/simulators/schism.py
+++ b/inductiva/simulators/schism.py
@@ -59,11 +59,11 @@ class SCHISM(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
         mpi_kwargs = {}
         mpi_kwargs["use_hwthread_cpus"] = use_hwthread

--- a/inductiva/simulators/schism.py
+++ b/inductiva/simulators/schism.py
@@ -60,10 +60,10 @@ class SCHISM(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
         mpi_kwargs = {}
         mpi_kwargs["use_hwthread_cpus"] = use_hwthread

--- a/inductiva/simulators/schism.py
+++ b/inductiva/simulators/schism.py
@@ -61,7 +61,7 @@ class SCHISM(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/sfincs.py
+++ b/inductiva/simulators/sfincs.py
@@ -49,10 +49,10 @@ class SFINCS(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
             other arguments: See the documentation of the base class.
         """
 

--- a/inductiva/simulators/sfincs.py
+++ b/inductiva/simulators/sfincs.py
@@ -50,7 +50,7 @@ class SFINCS(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
             other arguments: See the documentation of the base class.

--- a/inductiva/simulators/sfincs.py
+++ b/inductiva/simulators/sfincs.py
@@ -48,11 +48,11 @@ class SFINCS(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-           time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
             other arguments: See the documentation of the base class.
         """
 

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -269,7 +269,7 @@ class Simulator(ABC):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
             **kwargs: Additional keyword arguments to be passed to the

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -268,10 +268,10 @@ class Simulator(ABC):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
             **kwargs: Additional keyword arguments to be passed to the
                 simulation API method.
         """

--- a/inductiva/simulators/simulator.py
+++ b/inductiva/simulators/simulator.py
@@ -267,11 +267,11 @@ class Simulator(ABC):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
             **kwargs: Additional keyword arguments to be passed to the
                 simulation API method.
         """

--- a/inductiva/simulators/snl_swan.py
+++ b/inductiva/simulators/snl_swan.py
@@ -72,10 +72,10 @@ class SNLSWAN(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
 
         if command not in ("swanrun", "swan.exe"):

--- a/inductiva/simulators/snl_swan.py
+++ b/inductiva/simulators/snl_swan.py
@@ -71,11 +71,11 @@ class SNLSWAN(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
 
         if command not in ("swanrun", "swan.exe"):

--- a/inductiva/simulators/snl_swan.py
+++ b/inductiva/simulators/snl_swan.py
@@ -73,7 +73,7 @@ class SNLSWAN(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/splishsplash.py
+++ b/inductiva/simulators/splishsplash.py
@@ -60,11 +60,11 @@ class SplishSplash(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
             vtk_to_obj: Whether to convert the output VTK files to OBJ meshes
                 using marching cubes.
             vtk_to_obj_vtk_dir: Directory containing VTK files to be converted.

--- a/inductiva/simulators/splishsplash.py
+++ b/inductiva/simulators/splishsplash.py
@@ -61,10 +61,10 @@ class SplishSplash(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
             vtk_to_obj: Whether to convert the output VTK files to OBJ meshes
                 using marching cubes.
             vtk_to_obj_vtk_dir: Directory containing VTK files to be converted.

--- a/inductiva/simulators/splishsplash.py
+++ b/inductiva/simulators/splishsplash.py
@@ -62,7 +62,7 @@ class SplishSplash(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
             vtk_to_obj: Whether to convert the output VTK files to OBJ meshes

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -66,11 +66,11 @@ class SWAN(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
 
         if command not in ("swanrun", "swan.exe"):

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -67,10 +67,10 @@ class SWAN(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
 
         if command not in ("swanrun", "swan.exe"):

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -68,7 +68,7 @@ class SWAN(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -65,7 +65,7 @@ class SWASH(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -63,11 +63,11 @@ class SWASH(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
 
         if command not in ("swashrun", "swash.exe"):

--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -64,10 +64,10 @@ class SWASH(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
 
         if command not in ("swashrun", "swash.exe"):

--- a/inductiva/simulators/wrf.py
+++ b/inductiva/simulators/wrf.py
@@ -107,11 +107,11 @@ class WRF(simulators.Simulator):
             gen_gif_fps (int): Frames per second for the GIF. Default is 3.
             gen_gif_variable (str): Variable to be used for generating the GIF.
                 Default is "RAINNC".
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
         """
 
         if case_name not in self.VALID_CASE_NAMES:

--- a/inductiva/simulators/wrf.py
+++ b/inductiva/simulators/wrf.py
@@ -108,10 +108,10 @@ class WRF(simulators.Simulator):
             gen_gif_variable (str): Variable to be used for generating the GIF.
                 Default is "RAINNC".
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
         """
 
         if case_name not in self.VALID_CASE_NAMES:

--- a/inductiva/simulators/wrf.py
+++ b/inductiva/simulators/wrf.py
@@ -109,7 +109,7 @@ class WRF(simulators.Simulator):
                 Default is "RAINNC".
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
         """

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -64,7 +64,7 @@ class XBeach(simulators.Simulator):
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
                 string duration. Supports all formats accepted by the
-                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
                 "90s". The task will be automatically terminated if it exceeds
                 this duration after starting.
             other arguments: See the documentation of the base class.

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -62,11 +62,11 @@ class XBeach(simulators.Simulator):
                 assigned. If None, the task will be assigned to
                 the default project. If the project does not exist, it will be
                 created.
-            time_to_live: Maximum duration the task is allowed to run, 
-                specified as a string with a time unit suffix. Supported formats
-                include minutes ("10m") or hours ("2h"). The task will be 
-                automatically terminated once this duration has elapsed since
-                its start.
+            time_to_live: Maximum allowed runtime for the task, specified as a
+                string duration. Supports all formats accepted by the
+                `pytimeparse` library, such as "10m", "2 hours", "1h30m", or
+                "90s". The task will be automatically terminated if it exceeds
+                this duration after starting.
             other arguments: See the documentation of the base class.
         """
 

--- a/inductiva/simulators/xbeach.py
+++ b/inductiva/simulators/xbeach.py
@@ -63,10 +63,10 @@ class XBeach(simulators.Simulator):
                 the default project. If the project does not exist, it will be
                 created.
             time_to_live: Maximum allowed runtime for the task, specified as a
-                string duration. Supports all formats accepted by the
-                `pytimeparse2` library, such as "10m", "2 hours", "1h30m", or
-                "90s". The task will be automatically terminated if it exceeds
-                this duration after starting.
+                string duration. Supports common time duration formats such as
+                "10m", "2 hours", "1h30m", or "90s". The task will be
+                automatically terminated if it exceeds this duration after
+                starting.
             other arguments: See the documentation of the base class.
         """
 

--- a/inductiva/utils/format_utils.py
+++ b/inductiva/utils/format_utils.py
@@ -310,17 +310,3 @@ def currency_formatter(amount: float) -> str:
         return f"{amount:.{decimal_places}f} {CURRENCY_SYMBOL}"
 
     return f"{amount:.2f} {CURRENCY_SYMBOL}"
-
-
-def str_to_seconds(duration: str) -> int:
-    """
-    Convert a duration string to seconds.
-    Supports only minutes (m) or hours (h).
-    """
-    unit = duration[-1].lower()
-    units = {"h": 3600, "m": 60}
-    if unit not in units:
-        err_msg = "Invalid unit: only minutes (m) or hours (h) are supported."
-        raise ValueError(err_msg)
-    value = int(duration[:-1])
-    return value * units[unit]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
   python-dateutil >= 2.8.2
   pydantic >= 2
   typing-extensions >= 4.7.1
-  pytimeparse
+  pytimeparse2
 
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
   python-dateutil >= 2.8.2
   pydantic >= 2
   typing-extensions >= 4.7.1
+  pytimeparse
 
 
 [options.extras_require]


### PR DESCRIPTION
This PR adds `pytimeparse` as a dependency to convert the `time_to_live` parameter from a string to seconds. It also updates the simulator's docstrings.