### PR TITLE
Fix exception logging

### DIFF
--- a/inductiva/logs/log.py
+++ b/inductiva/logs/log.py
@@ -76,8 +76,8 @@ def _get_traceback_first_and_last_lines(exc_traceback, n_lines: int,
 def _handle_api_exception(exc_type, exc_value, exc_traceback,
                           is_notebook: bool):
     if issubclass(exc_type, exceptions.ApiException) and \
-        400 <= exc_value.status  < 500:
-        detail = json.loads(exc_value.data)["detail"]
+        400 <= exc_value.status < 500:
+        detail = json.loads(exc_value.body)["detail"]
 
         # Gets the last N lines of the traceback
         formatted_tb = _get_traceback_first_and_last_lines(


### PR DESCRIPTION
With the upgrade to pydantic V2, `data` is not equivalent to `body` in the HTTP response object.