### PR TITLE
Add link checker workflow for docs-sources

### DIFF
--- a/.github/workflows/docs-link-checker.yml
+++ b/.github/workflows/docs-link-checker.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Convert linkcheck output to CSV
         run: |
-          echo "Project,File,Line,Status,URL,Message" > linkcheck_summary.csv
-          find build/linkcheck -type f -name output.txt | while read -r file; do
+          echo "Documentation Folder,File,Line,Status,URL,Message" > linkcheck_summary.csv
+          find build/linkcheck -type f -name "*.txt" | while read -r file; do
             project=$(basename "$(dirname "$file")")
             while IFS= read -r line; do
               docfile=$(echo "$line" | awk -F':' '{print $1}')


### PR DESCRIPTION
This PR adds a gitHub action workflow that runs Sphinx's link checker on all subfolders inside `docs-sources/` containing a `conf.py` file.
It only runs manually (via `workflow_dispatch`) and does not trigger on merges or pushes (yet).
The results are saved as a CSV file and uploaded as an artifact.

> [!NOTE]  
> This workflow is intended to be integrated later to run automatically on pull requests.
However, for now, while most issues are still unresolved, running it automatically could become a barrier to merging other changes.
So at this stage, it's set up just for manual testing.