### PR TITLE
Fix `start_time` variable in `task._get_duration` method

### DIFF
--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -1414,7 +1414,8 @@ class Task:
             return None
 
         # The task is still running
-        start_time = getattr(info, start_attribute)
+        start_time_string = getattr(info, start_attribute)
+        start_time = datetime.datetime.fromisoformat(start_time_string)
 
         # start time may be None if the task was killed before it started
         if start_time is None:


### PR DESCRIPTION

```bash
(inductiva-prod-env) ➜  troubleshooting inductiva tasks list --id c6p95erpxbwgtfyjcfiu2odar

Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniforge/base/envs/inductiva-prod-env/bin/inductiva", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/henriquepreto/Desktop/inductiva/inductiva/_cli/main.py", line 81, in main
    exit_code = args.func(args)
                ^^^^^^^^^^^^^^^
  File "/Users/henriquepreto/Desktop/inductiva/inductiva/_cli/cmd_tasks/list.py", line 12, in list_tasks
    _list_tasks(**vars(args), fout=fout)
  File "/Users/henriquepreto/Desktop/inductiva/inductiva/_cli/cmd_tasks/list.py", line 45, in _list_tasks
    table_dict = tasks.to_dict(task_list)
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/henriquepreto/Desktop/inductiva/inductiva/tasks/methods.py", line 31, in to_dict
    execution_time = task.get_computation_time(cached=True)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/henriquepreto/Desktop/inductiva/inductiva/tasks/task.py", line 1434, in get_computation_time
    return self._get_duration(
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/henriquepreto/Desktop/inductiva/inductiva/tasks/task.py", line 1425, in _get_duration
    return (end_time - start_time).total_seconds()
            ~~~~~~~~~^~~~~~~~~~~~
TypeError: unsupported operand type(s) for -: 'datetime.datetime' and 'str'
```