### PR TITLE
Add example to CLI Help via `parser.epilog`

### DIFF
--- a/docs-sources/api-functions/sphinx_argparse_cli_ext.py
+++ b/docs-sources/api-functions/sphinx_argparse_cli_ext.py
@@ -111,7 +111,7 @@ class SphinxArgParseCliExt(SphinxArgparseCli):
 
     @staticmethod
     def create_section(parser: argparse.ArgumentParser) -> nodes.Node:
-        text = parser.epilog
+        text = parser.epilog.strip()
         if text.startswith("examples:"):
             text = text.removeprefix("examples:")
         text = textwrap.dedent(text)

--- a/inductiva/_cli/cmd_projects/list.py
+++ b/inductiva/_cli/cmd_projects/list.py
@@ -1,5 +1,6 @@
 """List the user projects information via CLI."""
 from collections import defaultdict
+import textwrap
 from typing import TextIO
 import argparse
 import sys
@@ -45,5 +46,17 @@ def register(parser):
                              "It lists all your available projects.")
 
     _cli.utils.add_watch_argument(subparser)
+
+    subparser.epilog = textwrap.dedent("""
+        examples:
+            $ inductiva projects list
+
+            NAME                                   NR_TASKS
+            openfoam-dambreak-2d-standard            5
+            openfoam-dambreak-3d-highres            22
+            xbeach-storm-surge-portugal-coast       10
+            openfast-wind-turbine                    4
+            xbeach-sediment-transport-validation     8
+    """)
 
     subparser.set_defaults(func=get_projects)


### PR DESCRIPTION
This PR demonstrates how to add examples so they display correctly both in the local CLI and on the website after the documentation is automatically generated.

To do this, simply add the example to the `subparser.epilog` field directly in the source code, as shown in this PR (check [Files changed](https://github.com/inductiva/inductiva/pull/2519/files)).

The example should the command usage (e.g., `inductiva storage upload file.txt`) and an expected output (e.g., `Success!`)

---

The modules listed below, which were not selected, have some CLI commands with incomplete or missing examples.

- [X] auth
- [ ] containers
- [ ] logs
- [X] projects
- [ ] resources
- [X] simulators
- [ ] storage
- [ ] task-runner
- [ ] tasks
- [ ] user