### PR TITLE
Sanitize file paths for download

### DIFF
--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -16,6 +16,7 @@ from typing import List, Literal, Optional, Tuple
 
 import concurrent.futures
 import tqdm
+import re
 
 import inductiva
 from inductiva import constants
@@ -399,7 +400,7 @@ def _resolve_local_path(
     append_path=None,
     strip_zip=False,
 ):
-    remote_url_path = urllib.parse.urlparse(url).path
+    remote_url_path = urllib.parse.unquote(urllib.parse.urlparse(url).path)
     index = remote_url_path.find(remote_base_path)
     relative_path = remote_url_path[index:]
 
@@ -409,6 +410,7 @@ def _resolve_local_path(
     local_path = os.path.join(local_base_dir, relative_path)
     if append_path:
         local_path = os.path.join(local_path, append_path)
+    local_path = re.sub(r'[<>:"|?*]', '_', local_path)
 
     os.makedirs(os.path.dirname(local_path), exist_ok=True)
 

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -410,7 +410,7 @@ def _resolve_local_path(
     local_path = os.path.join(local_base_dir, relative_path)
     if append_path:
         local_path = os.path.join(local_path, append_path)
-    local_path = re.sub(r'[<>:"|?*]', '_', local_path)
+    local_path = re.sub(r"[<>:\"|?*]", "_", local_path)
 
     os.makedirs(os.path.dirname(local_path), exist_ok=True)
 

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -16,7 +16,6 @@ from typing import List, Literal, Optional, Tuple
 
 import concurrent.futures
 import tqdm
-import re
 
 import inductiva
 from inductiva import constants

--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -400,7 +400,7 @@ def _resolve_local_path(
     append_path=None,
     strip_zip=False,
 ):
-    remote_url_path = urllib.parse.unquote(urllib.parse.urlparse(url).path)
+    remote_url_path = utils.data.unquote_url_path(url)
     index = remote_url_path.find(remote_base_path)
     relative_path = remote_url_path[index:]
 
@@ -410,7 +410,7 @@ def _resolve_local_path(
     local_path = os.path.join(local_base_dir, relative_path)
     if append_path:
         local_path = os.path.join(local_path, append_path)
-    local_path = re.sub(r"[<>:\"|?*]", "_", local_path)
+    local_path = utils.data.sanitize_path(local_path)
 
     os.makedirs(os.path.dirname(local_path), exist_ok=True)
 

--- a/inductiva/tests/storage/test_storage.py
+++ b/inductiva/tests/storage/test_storage.py
@@ -2,6 +2,7 @@
 
 import pytest
 from unittest import mock
+from inductiva import utils
 from inductiva.storage.storage import _construct_remote_paths
 
 
@@ -105,3 +106,19 @@ def test__construct_remote_paths(
     )
 
     assert remote_file_paths == expected_remote_paths
+
+
+@pytest.mark.parametrize("url,expected", [
+    ("http://example.com/my%20file.txt", "/my file.txt"),
+    ("https://server/folder/path%3Cname%3E.zip", "/folder/path<name>.zip"),
+])
+def test_unquote_url_path(url, expected):
+    assert utils.data.unquote_url_path(url) == expected
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("un:safe<name>|file?.txt", "un_safe_name__file_.txt"),
+    ("already_safe.txt", "already_safe.txt"),
+])
+def test_sanitize_path(raw, expected):
+    assert utils.data.sanitize_path(raw) == expected

--- a/inductiva/tests/storage/test_storage.py
+++ b/inductiva/tests/storage/test_storage.py
@@ -108,17 +108,17 @@ def test__construct_remote_paths(
     assert remote_file_paths == expected_remote_paths
 
 
-@pytest.mark.parametrize("url,expected", [
-    ("http://example.com/my%20file.txt", "/my file.txt"),
-    ("https://server/folder/path%3Cname%3E.zip", "/folder/path<name>.zip"),
+@pytest.mark.parametrize('url,expected', [
+    ('http://example.com/my%20file.txt', '/my file.txt'),
+    ('https://server/folder/path%3Cname%3E.zip', '/folder/path<name>.zip'),
 ])
 def test_unquote_url_path(url, expected):
     assert utils.data.unquote_url_path(url) == expected
 
 
-@pytest.mark.parametrize("raw,expected", [
-    ("un:safe<name>|file?.txt", "un_safe_name__file_.txt"),
-    ("already_safe.txt", "already_safe.txt"),
+@pytest.mark.parametrize('raw,expected', [
+    ('un:safe<name>|file?.txt', 'un_safe_name__file_.txt'),
+    ('already_safe.txt', 'already_safe.txt'),
 ])
 def test_sanitize_path(raw, expected):
     assert utils.data.sanitize_path(raw) == expected

--- a/inductiva/utils/data.py
+++ b/inductiva/utils/data.py
@@ -18,7 +18,6 @@ import urllib
 import urllib3
 
 import logging
-import re
 
 ARTIFACTS_DIRNAME = "artifacts"
 INPUT_DIRNAME = "sim_dir"

--- a/inductiva/utils/data.py
+++ b/inductiva/utils/data.py
@@ -16,6 +16,7 @@ import fsspec
 import urllib3
 
 import logging
+import re
 
 ARTIFACTS_DIRNAME = "artifacts"
 INPUT_DIRNAME = "sim_dir"
@@ -73,6 +74,8 @@ def extract_subdir_files(zip_fp: zipfile.ZipFile, dir_name: str,
 
         src_file = zip_fp.open(member)
         target_relative_path = pathlib.Path(member).relative_to(dir_name)
+        target_relative_path = re.sub(r'[<>:"|?*]', "_",
+                                      str(target_relative_path))
         target_path = os.path.join(output_dir, target_relative_path)
 
         os.makedirs(os.path.dirname(target_path), exist_ok=True)


### PR DESCRIPTION
closes https://github.com/inductiva/tasks/issues/1153

This PR fixes two bugs on windows:
- Downloading files with invalid chars on filename;
- Extracting zips with files with invalid chars;