### PR TITLE
Disable URL canonical generation

### DIFF
--- a/docs-sources/amr-wind/conf.py
+++ b/docs-sources/amr-wind/conf.py
@@ -103,6 +103,10 @@ ogp_site_name = "Inductiva.AI AMR-Wind"
 ogp_site_url = "https://inductiva.ai/guides/amr-wind"
 ogp_image = "https://inductiva.ai/builds/amr-wind/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/calculix/conf.py
+++ b/docs-sources/calculix/conf.py
@@ -103,6 +103,10 @@ ogp_site_name = "Inductiva.AI Calculix"
 ogp_site_url = "https://inductiva.ai/guides/calculix"
 ogp_image = "https://inductiva.ai/builds/calculix/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/cans/conf.py
+++ b/docs-sources/cans/conf.py
@@ -103,6 +103,10 @@ ogp_site_name = "Inductiva.AI CaNS"
 ogp_site_url = "https://inductiva.ai/guides/cans"
 ogp_image = "https://inductiva.ai/builds/cans/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/cm1/conf.py
+++ b/docs-sources/cm1/conf.py
@@ -103,6 +103,10 @@ ogp_site_name = "Inductiva.AI CM1"
 ogp_site_url = "https://inductiva.ai/guides/cm1"
 ogp_image = "https://inductiva.ai/builds/cm1/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/coawst/conf.py
+++ b/docs-sources/coawst/conf.py
@@ -105,6 +105,10 @@ ogp_site_name = "Inductiva.AI COAWST"
 ogp_site_url = "https://inductiva.ai/guides/coawst"
 ogp_image = "https://inductiva.ai/builds/coawst/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/cp2k/conf.py
+++ b/docs-sources/cp2k/conf.py
@@ -105,6 +105,10 @@ ogp_site_name = "Inductiva.AI CP2K"
 ogp_site_url = "https://inductiva.ai/guides/cp2k"
 ogp_image = "https://inductiva.ai/builds/cp2k/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/delft3d/conf.py
+++ b/docs-sources/delft3d/conf.py
@@ -105,6 +105,10 @@ ogp_site_name = "Inductiva.AI Delft3D"
 ogp_site_url = "https://inductiva.ai/guides/delft3d"
 ogp_image = "https://inductiva.ai/builds/delft3d/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/dualsphysics/conf.py
+++ b/docs-sources/dualsphysics/conf.py
@@ -103,6 +103,10 @@ ogp_site_name = "Inductiva.AI DualSPHysics"
 ogp_site_url = "https://inductiva.ai/guides/dualsphysics"
 ogp_image = "https://inductiva.ai/builds/dualsphysics/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/fds/conf.py
+++ b/docs-sources/fds/conf.py
@@ -103,6 +103,10 @@ ogp_site_name = "Inductiva.AI FDS"
 ogp_site_url = "https://inductiva.ai/guides/fds"
 ogp_image = "https://inductiva.ai/builds/fds/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/fvcom/conf.py
+++ b/docs-sources/fvcom/conf.py
@@ -102,6 +102,10 @@ ogp_site_name = "Inductiva.AI FVCOM"
 ogp_site_url = "https://inductiva.ai/guides/fvcom"
 ogp_image = "https://inductiva.ai/builds/fvcom/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/gromacs/conf.py
+++ b/docs-sources/gromacs/conf.py
@@ -117,6 +117,10 @@ ogp_site_name = "Inductiva.AI GROMACS"
 ogp_site_url = "https://inductiva.ai/guides/gromacs"
 ogp_image = "https://inductiva.ai/builds/gromacs/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/gx/conf.py
+++ b/docs-sources/gx/conf.py
@@ -105,6 +105,10 @@ ogp_site_name = "Inductiva.AI GX"
 ogp_site_url = "https://inductiva.ai/guides/gx"
 ogp_image = "https://inductiva.ai/builds/gx/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/nwchem/conf.py
+++ b/docs-sources/nwchem/conf.py
@@ -102,6 +102,10 @@ ogp_site_name = "Inductiva.AI NWChem"
 ogp_site_url = "https://inductiva.ai/guides/nwchem"
 ogp_image = "https://inductiva.ai/builds/nwchem/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/octopus/conf.py
+++ b/docs-sources/octopus/conf.py
@@ -117,6 +117,10 @@ ogp_site_name = "Inductiva.AI Octopus"
 ogp_site_url = "https://inductiva.ai/guides/octopus"
 ogp_image = "https://inductiva.ai/builds/octopus/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/openfast/conf.py
+++ b/docs-sources/openfast/conf.py
@@ -103,6 +103,10 @@ ogp_site_name = "Inductiva.AI OpenFAST"
 ogp_site_url = "https://inductiva.ai/guides/openfast"
 ogp_image = "https://inductiva.ai/builds/openfast/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/openfoam/conf.py
+++ b/docs-sources/openfoam/conf.py
@@ -102,6 +102,10 @@ ogp_site_name = "Inductiva.AI OpenFOAM"
 ogp_site_url = "https://inductiva.ai/guides/openfoam"
 ogp_image = "https://inductiva.ai/builds/openfoam/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/opensees/conf.py
+++ b/docs-sources/opensees/conf.py
@@ -105,6 +105,10 @@ ogp_site_name = "Inductiva.AI OpenSees"
 ogp_site_url = "https://inductiva.ai/guides/opensees"
 ogp_image = "https://inductiva.ai/builds/opensees/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/opentelemac/conf.py
+++ b/docs-sources/opentelemac/conf.py
@@ -102,6 +102,10 @@ ogp_site_name = "Inductiva.AI OpenTelemac"
 ogp_site_url = "https://inductiva.ai/guides/opentelemac"
 ogp_image = "https://inductiva.ai/builds/opentelemac/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/quantumespresso/conf.py
+++ b/docs-sources/quantumespresso/conf.py
@@ -103,6 +103,10 @@ ogp_site_name = "Inductiva.AI Quantum ESPRESSO"
 ogp_site_url = "https://inductiva.ai/guides/quantumespresso"
 ogp_image = "https://inductiva.ai/builds/quantumespresso/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/reef3d/conf.py
+++ b/docs-sources/reef3d/conf.py
@@ -103,6 +103,10 @@ ogp_site_name = "Inductiva.AI REEF3D"
 ogp_site_url = "https://inductiva.ai/guides/reef3d"
 ogp_image = "https://inductiva.ai/builds/reef3d/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/scale-up/conf.py
+++ b/docs-sources/scale-up/conf.py
@@ -102,6 +102,10 @@ ogp_site_name = "Inductiva.AI Scale Up"
 ogp_site_url = "https://inductiva.ai/guides/scale-up"
 ogp_image = "https://inductiva.ai/builds/scale-up/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/schism/conf.py
+++ b/docs-sources/schism/conf.py
@@ -103,6 +103,10 @@ ogp_site_name = "Inductiva.AI SCHISM"
 ogp_site_url = "https://inductiva.ai/guides/schism"
 ogp_image = "https://inductiva.ai/builds/schism/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/sfincs/conf.py
+++ b/docs-sources/sfincs/conf.py
@@ -102,6 +102,10 @@ ogp_site_name = "Inductiva.AI SFINCS"
 ogp_site_url = "https://inductiva.ai/guides/sfincs"
 ogp_image = "https://inductiva.ai/builds/sfincs/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/snl-swan/conf.py
+++ b/docs-sources/snl-swan/conf.py
@@ -103,6 +103,10 @@ ogp_site_name = "Inductiva.AI SNL-SWAN"
 ogp_site_url = "https://inductiva.ai/guides/snl-swan"
 ogp_image = "https://inductiva.ai/builds/snl-swan/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/splishsplash/conf.py
+++ b/docs-sources/splishsplash/conf.py
@@ -102,6 +102,10 @@ ogp_site_name = "Inductiva.AI SPlisHSPlasH"
 ogp_site_url = "https://inductiva.ai/guides/splishsplash"
 ogp_image = "https://inductiva.ai/builds/splishsplash/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/swan/conf.py
+++ b/docs-sources/swan/conf.py
@@ -102,6 +102,10 @@ ogp_site_name = "Inductiva.AI SWAN"
 ogp_site_url = "https://inductiva.ai/guides/swan"
 ogp_image = "https://inductiva.ai/builds/swan/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/swash/conf.py
+++ b/docs-sources/swash/conf.py
@@ -103,6 +103,10 @@ ogp_site_name = "Inductiva.AI SWASH"
 ogp_site_url = "https://inductiva.ai/guides/swash"
 ogp_image = "https://inductiva.ai/builds/swash/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/systemrequirements/conf.py
+++ b/docs-sources/systemrequirements/conf.py
@@ -102,6 +102,10 @@ ogp_site_name = "Inductiva.AI System Requirements"
 ogp_site_url = "https://inductiva.ai/guides/system-requirements"
 ogp_image = "https://inductiva.ai/builds/system-requirements/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/wavewatch3/conf.py
+++ b/docs-sources/wavewatch3/conf.py
@@ -105,6 +105,10 @@ ogp_site_name = "Inductiva.AI WAVEWATCH III"
 ogp_site_url = "https://inductiva.ai/guides/wavewatch3"
 ogp_image = "https://inductiva.ai/builds/wavewatch3/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/wrf/conf.py
+++ b/docs-sources/wrf/conf.py
@@ -105,6 +105,10 @@ ogp_site_name = "Inductiva.AI WRF"
 ogp_site_url = "https://inductiva.ai/guides/wrf"
 ogp_image = "https://inductiva.ai/builds/wrf/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'

--- a/docs-sources/xbeach/conf.py
+++ b/docs-sources/xbeach/conf.py
@@ -102,6 +102,10 @@ ogp_site_name = "Inductiva.AI XBeach"
 ogp_site_url = "https://inductiva.ai/guides/xbeach"
 ogp_image = "https://inductiva.ai/builds/xbeach/_static/inductiva-social-banner.jpg"
 
+# Disable automatic canonical generation by sphinxext-opengraph.
+# The canonical tag is instead generated on the website itself.
+ogp_enable_canonical = False
+
 # sitemap.xml
 # See https://sphinx-sitemap.readthedocs.io/
 language = 'en'


### PR DESCRIPTION
Canonical tags are generated on the website side, so we need to disable sphinxext-opengraph canonical generation 
to avoid duplicate or multiple canonicals.
