### PR TITLE
Add the ability for users to pass unswan as a command (only for newer versions of swan)

### DIFF
--- a/docs-sources/swan/faq.md
+++ b/docs-sources/swan/faq.md
@@ -28,6 +28,30 @@ Also, `swanrun` expects the simulation file in the `file.swn` format, while
 `swan.exe` expects the simulation file with the name `INPUT`.
 
 <br>
+
+## 2. Does SWAN support unstructured grids?
+
+Yes, but only in specific versions.
+
+SWAN introduced support for unstructured grids starting from **version 41.45A**.
+Therefore, if you choose **version 41.51** or later, you can enable unstructured
+grid support by setting the `command` argument to `unswan`:
+
+```python
+swan = inductiva.simulators.SWAN( \
+    version="41.51")
+
+task = swan.run(
+    input_dir=input_dir,
+    sim_config_filename="a11refr.swn",
+    command="unswan",
+    on=cloud_machine
+)
+```
+
+> **Note:** Since **version 41.45A** is not available on Inductiva, only **41.51** and newer versions can be used for simulations with unstructured grids.
+
+<br>
 <br>
 
 Still can't find what you're looking for? [Contact Us](mailto:support@inductiva.ai)

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -92,6 +92,11 @@ class SWAN(simulators.Simulator):
                     ]
         """
 
+        if self.version and command == "unswan" and self.version in {
+                "41.31", "41.45"
+        }:
+            raise ValueError("Unswan version 41.31 or 41.45 is not supported.")
+
         if command not in ("swanrun", "swan.exe"):
             raise ValueError("Invalid command. Use 'swanrun' or 'swan.exe'.")
 
@@ -147,6 +152,14 @@ class SWAN(simulators.Simulator):
             swan_exe_command = Command(f"swan.exe {sim_config_filename}",
                                        mpi_config=mpi_config)
             commands.append(swan_exe_command)
+        elif command == "unswan":
+
+            #if the user does not provide n_vcpus use all available by default
+            omp_flag = f"-omp {n_vcpus or on.available_vcpus}"
+
+            swanrun_command = Command(
+                f"unswanrun -input {config_file_only} {omp_flag}")
+            commands.append(swanrun_command)
         return super().run(input_dir,
                            on=on,
                            storage_dir=storage_dir,

--- a/inductiva/simulators/swan.py
+++ b/inductiva/simulators/swan.py
@@ -97,8 +97,9 @@ class SWAN(simulators.Simulator):
         }:
             raise ValueError("Unswan version 41.31 or 41.45 is not supported.")
 
-        if command not in ("swanrun", "swan.exe"):
-            raise ValueError("Invalid command. Use 'swanrun' or 'swan.exe'.")
+        if command not in ("swanrun", "swan.exe", "unswan"):
+            raise ValueError("Invalid command. Use 'swanrun', 'swan.exe' or "
+                             "'unswan'.")
 
         if sim_config_filename is None and command == "swanrun":
             raise ValueError("Simulation configuration file "


### PR DESCRIPTION
This PR adds the ability for users to use unswan, swan with unstructured grids.

unswan is only available on the lastest version of swan (41.45A+)