### PR TITLE
Add retries to get signed urls function

### DIFF
--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -1,4 +1,5 @@
 """Methods to interact with the user storage resources."""
+import tenacity
 import json
 import datetime
 import itertools
@@ -156,6 +157,7 @@ def _print_contents_table(contents):
     )
 
 
+@tenacity.retry(wait=tenacity.wait_exponential(multiplier=1, min=4, max=30))
 def get_signed_urls(
     paths: List[str],
     operation: Literal["upload", "download"],

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
   pydantic >= 2
   typing-extensions >= 4.7.1
   pytimeparse2
+  tenacity
 
 
 [options.extras_require]


### PR DESCRIPTION
Reference: https://github.com/inductiva/tasks/issues/1215

The signed URLs endpoint returns 502 errors with some (quite low, less than 0.1%) frequency. This PR adds a retry mechanism.