### PR TITLE
Add `auto_delete_disk` parameter

### DIFF
--- a/inductiva/resources/machine_groups.py
+++ b/inductiva/resources/machine_groups.py
@@ -61,6 +61,7 @@ class BaseMachineGroup(ABC):
     provider: Union[ProviderType, str] = "GCP"
     threads_per_core: int = 2
     data_disk_gb: int = 10
+    auto_delete_disk: bool = True
     max_idle_time: Union[datetime.timedelta, int] = 3
     auto_terminate_ts: Optional[datetime.datetime] = None
     auto_terminate_minutes: Optional[int] = None
@@ -337,6 +338,7 @@ class BaseMachineGroup(ABC):
             dynamic_disk_resize_config=self._dynamic_disk_resize_config(),
             custom_vm_image=self._custom_vm_image,
             zone=self.zone,
+            disk_auto_delete=self.auto_delete_disk,
             **kwargs,
         )
 

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -286,7 +286,6 @@ class TaskInfo:
                     table_str += (f"\t\t{ascii_char}> {duration:<15} "
                                   f"{sub_item['alias']}\n")
 
-
         table_str += f"\nData:\n{data_metrics_table}\n"
         if self.estimated_computation_cost:
             estimated_cost = format_utils.currency_formatter(

--- a/inductiva/tasks/task.py
+++ b/inductiva/tasks/task.py
@@ -264,7 +264,6 @@ class TaskInfo:
                           f"{formatted_timestamp:<20} {duration}\n")
 
             for index, sub_item in enumerate(item.get("operations", [])):
-
                 if index + 1 == len(item.get("operations", [])):
                     ascii_char = "└"
                 else:
@@ -283,6 +282,10 @@ class TaskInfo:
                         "command" in sub_item["attributes"]):
                     table_str += (f"\t\t{ascii_char}> {duration:<15} "
                                   f"{sub_item['attributes']['command']}\n")
+                elif item["alias"] == "Spot Reclaimed":
+                    table_str += (f"\t\t{ascii_char}> {duration:<15} "
+                                  f"{sub_item['alias']}\n")
+
 
         table_str += f"\nData:\n{data_metrics_table}\n"
         if self.estimated_computation_cost:


### PR DESCRIPTION
This parameter works like a feature flag.

Only admins can use this parameter.

Used for testing the new saving outputs on preemptions in dev.

## CLI Outputs:

- Task Timeline:

```bash
(inductiva-local-env) ➜  inductiva-web-api git:(hp-upload-outputs-on-preemption) ✗ inductiva tasks info sysg52i73baghq1z2vsjbrx3f

Task status: Spot Reclaimed

Timeline:
	Waiting for Input         at 11/09, 15:34:49      1.022 s
	In Queue                  at 11/09, 15:34:50      40.608 s
	Preparing to Compute      at 11/09, 15:35:31      15.836 s
	In Progress               at 11/09, 15:35:47      9.935 s
		├> 1.247 s         touch test-file.txt
		└> 8.439 s         sleep 300
	Spot Reclaimed            at 11/09, 15:35:57      
		└> 0.442 s         Output Upload
...
```

- Task Storage:

```bash
(inductiva-local-env) ➜  inductiva-web-api git:(hp-upload-outputs-on-preemption) ✗ inductiva storage list sysg52i73baghq1z2vsjbrx3f

 NAME                         SIZE      CREATION TIME
 output-20250911-143702.zip   1.20 KB   11/09, 14:37:02
 input.zip                    114 B     11/09, 14:34:50

Total storage size used:
	Volume: 0 B
	Cost: 0 US$/month

Listed 2 folder(s). Ordered by creation_time.
Use --max-results/-m to control the number of results displayed.
```