### PR TITLE
Fix python editor dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ install_requires =
   fsspec
   requests
   aiohttp
-  aiortc
   nest_asyncio
   # openapi client requirements
   urllib3 >= 2.1.0, < 3.0.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,5 @@ base_install_requires = config["options"]["install_requires"]
 # support this library, we introduce an environment variable to prevent its
 # unnecessary installation. All other features of the inductiva package will
 # still work.
-setup(
-    install_requires=base_install_requires
-    + ([] if os.getenv("NOAIORTC") else ["aiortc"]),
-)
+setup(install_requires=base_install_requires +
+      ([] if os.getenv("NOAIORTC") else ["aiortc"]),)

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,12 @@ config = read_configuration("setup.cfg")
 base_install_requires = config["options"]["install_requires"]
 
 # Conditionally add aiortc dependency
-# aiortc is needed only for the real-time access to output files of a task, during its execution.
-# As some Python environments (e.g. pyodide) do not support this library, we introduce an
-# environment variable to prevent its unnecessary installation. All other features of the
-# inductiva package will still work.
+# aiortc is needed only for the real-time access to output files of a task,
+# during its execution. As some Python environments (e.g. pyodide) do not
+# support this library, we introduce an environment variable to prevent its
+# unnecessary installation. All other features of the inductiva package will
+# still work.
 setup(
     install_requires=base_install_requires
-    + ([] if os.getenv("NOAIORTC", False) else ["aiortc"]),
+    + ([] if os.getenv("NOAIORTC") else ["aiortc"]),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,12 @@
 """Setup file."""
-from setuptools import setup
 
-setup()
+import os
+from setuptools import setup
+from setuptools.config import read_configuration
+
+# Read configuration from setup.cfg
+config = read_configuration("setup.cfg")
+base_install_requires = config["options"]["install_requires"]
+
+setup(install_requires=base_install_requires +
+      ([] if os.getenv("NOAIORTC", False) else ["aiortc"]),)

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,11 @@ from setuptools.config import read_configuration
 config = read_configuration("setup.cfg")
 base_install_requires = config["options"]["install_requires"]
 
-setup(install_requires=base_install_requires +
-      ([] if os.getenv("NOAIORTC", False) else ["aiortc"]),)
+# Conditionally add aiortc dependency
+# aiortc is needed only for the real-time access to output files of a task, during its execution.
+# As some Python environments (e.g. pyodide) do not support this library, we introduce an
+# environment variable to prevent its unnecessary installation. All other features of the
+# inductiva package will still work.
 setup(
     install_requires=base_install_requires
     + ([] if os.getenv("NOAIORTC", False) else ["aiortc"]),


### PR DESCRIPTION
Set NOAIORTC environment variable for Python editor

Description:
We now set the Python editor environment variable `NOAIORTC=1`via:
`os.environ["NOAIORTC"] = "1"
`

This ensures that when the Python editor installs dependencies, aiortc is excluded.
By doing this, we prevent unnecessary installation of optional packages that could break the Python editor environment.
<img width="848" height="196" alt="image" src="https://github.com/user-attachments/assets/cb5570fc-14f0-43e8-93a7-f9319892523e" />
