### PR TITLE
Update setup requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,11 +30,10 @@ install_requires =
   typing-extensions >= 4.7.1
   pytimeparse2
   tenacity
+  docker
 
 
 [options.extras_require]
-task-runner =
-  docker
 aws =
   awscli
   boto3


### PR DESCRIPTION
Moved `docker` requirement to general requirements because it is used by containers CLI commands.