### PR TITLE
Fix _convert_path_unix function

### DIFF
--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -336,9 +336,9 @@ def _convert_path_unix(path):
     drive, path = os.path.splitdrive(path)
     if "\\" in path:
         path = str(pathlib.PureWindowsPath(path).as_posix())
-    # preserve the drive if it exists
+    # preserve the drive if it exists (e.g., drive = "D:")
     if drive:
-        path = f"{drive}:{path}"
+        path = f"{drive}{path}"
     return path
 
 


### PR DESCRIPTION
Fixes: https://discord.com/channels/1389190271723638804/1428077488147529808/1428368720018804859

`:` is already included in `drive` after `drive, path = os.path.splitdrive(path)`