### PR TITLE
Make Console and Python Client storage listing behavior consistent

### DIFF
--- a/inductiva/storage/storage.py
+++ b/inductiva/storage/storage.py
@@ -125,12 +125,15 @@ def listdir(
             page=page,
             per_page=page_size,
             region=region,
+            # Disable recursion to avoid calculating directory sizes
+            recursive="false",
         )
 
         for file_info in response.contents:
             all_contents.append({
                 "name": file_info.name,
-                "size": round(float(file_info.size_bytes), 3),
+                "size": (round(float(file_info.size_bytes), 3)
+                         if file_info.size_bytes else None),
                 "creation_time": file_info.creation_time,
                 "provider": file_info.provider_id,
                 "region": file_info.region,

--- a/inductiva/utils/format_utils.py
+++ b/inductiva/utils/format_utils.py
@@ -56,8 +56,11 @@ def no_formatter(x, *_):
     return x
 
 
-def bytes_formatter(n_bytes: int) -> str:
+def bytes_formatter(n_bytes: Optional[int]) -> str:
     """Convert bytes to human readable string."""
+    if n_bytes is None:
+        return None
+
     res = float(n_bytes)
 
     for unit in ["B", "KB", "MB", "GB", "TB"]:
@@ -99,7 +102,7 @@ def get_ansi_formatter():
     return emphasis_formatter
 
 
-def datetime_formatter(dt: Union[datetime.datetime, str]) -> str:
+def datetime_formatter(dt: Optional[Union[datetime.datetime, str]]) -> str:
     # get time in local timezone
     if dt is None:
         return None


### PR DESCRIPTION
The Console and the Python Client currently behave differently when listing storage contents: the Console does not use recursion to compute directory sizes, whereas the Python Client does.

This PR makes their behavior consistent.

- Before:

```python
(inductiva-dev-env) ➜  inductiva git:(development) inductiva storage list fastfarm_sim

 NAME             SIZE        CREATION TIME     PROVIDER     REGION
 input.zip        767.18 MB   15/10, 15:20:45   GCP          europe-west1
 5MW_Baseline/    215.82 KB   15/10, 14:27:03   GCP          europe-west1
 TSinflow/        2.15 GB     15/10, 14:24:38   GCP          europe-west1
 WAT_MannBoxDB/   201.33 MB   15/10, 14:24:34   GCP          europe-west1

Listed 4 folder(s). Ordered by creation_time.
Use --max-results/-m to control the number of results displayed.

Current region(s): europe-west1

You have storage in the following regions: europe-west1

Total storage size used across all regions:
	Volume: 169.54 GB
	Cost: 3.16 US$/month
```

- After:

```python
(inductiva-dev-env) ➜  inductiva git:(hp-no-recursive-list) inductiva storage list fastfarm_sim

 NAME             SIZE        CREATION TIME     PROVIDER     REGION
 input.zip        767.18 MB   15/10, 15:20:45   GCP          europe-west1
 5MW_Baseline/    n/a         n/a               GCP          europe-west1
 TSinflow/        n/a         n/a               GCP          europe-west1
 WAT_MannBoxDB/   n/a         n/a               GCP          europe-west1

Listed 4 folder(s). Ordered by creation_time.
Use --max-results/-m to control the number of results displayed.

Current region(s): europe-west1

You have storage in the following regions: europe-west1

Total storage size used across all regions:
	Volume: 169.54 GB
	Cost: 3.16 US$/month
```