### PR TITLE
Argument to flush output on swash

### DIFF
--- a/inductiva/simulators/swash.py
+++ b/inductiva/simulators/swash.py
@@ -89,8 +89,8 @@ class SWASH(simulators.Simulator):
                         "rm -f logs/debug.log"
                     ]
             gfortran_unbuffered_all: If True, enables immediate flushing of
-                output, potentially degrading performance. Disabling this might
-                cause error files to not appear properly.
+                output, potentially degrading performance. However, disabling
+                this might lead to error files not being written.
         """
 
         if command not in ("swashrun", "swash.exe"):
@@ -105,7 +105,10 @@ class SWASH(simulators.Simulator):
         commands = []
 
         # Set environment variable based on gfortran_unbuffered_all argument
-        env = {"GFORTRAN_UNBUFFERED_ALL": "YES" if gfortran_unbuffered_all else "NO"}
+        env = {
+            "GFORTRAN_UNBUFFERED_ALL":
+                "YES" if gfortran_unbuffered_all else "NO"
+        }
 
         path_config_filename = Path(sim_config_filename)
 


### PR DESCRIPTION
closes https://github.com/inductiva/tasks/issues/1306

This PR adds a new argument `gfortran_unbuffered_all` to swash that sets the `GFORTRAN_UNBUFFERED_ALL` environment variable:

```python
    task = swash.run(
        input_dir=sim_input_dir,
        sim_config_filename=sim_filename,
        on=cloud_machine,
        gfortran_unbuffered_all=True,
    )
 ```
 Note: by default `gfortran_unbuffered_all` is true