### PR TITLE
Add support for MPI into gprMax

### DIFF
--- a/examples/gprMax/gprmax.py
+++ b/examples/gprMax/gprmax.py
@@ -1,89 +1,56 @@
 """gprMax example.
 
-This example demonstrates three ways to run GprMax:
-1. Without MPI (single process)
-2. With GprMax's built-in MPI (using -mpi flag)
-3. With mpirun wrapper (using --mpi-no-spawn flag)
+GprMax supports multiple ways to run with MPI.
+
+See: https://docs.gprmax.com/en/latest/openmp_mpi.html
 """
 import inductiva
+from inductiva.commands import Command, MPIConfig
 
-# Allocate cloud machine on Google Cloud Platform
-cloud_machine = inductiva.resources.MachineGroup(
-    provider="GCP",
-    machine_type="c3d-highcpu-180")
+# Allocate cloud machine
+machine = inductiva.resources.MachineGroup(provider="GCP",
+                                           machine_type="c3d-highcpu-180")
 
-# Initialize the Simulator
 gprmax = inductiva.simulators.GprMax(version="3.1.7")
 
+# ============================================================================
+# EXAMPLE 1: No MPI (single process)
+# ============================================================================
+commands = ["python -m gprMax cylinder_Bscan_2D.in -n 60"]
 
-# OPTION 1: Run without MPI (single process)
-# -------------------------------------------------
-commands_no_mpi = [
-    "python -m gprMax user_models/cylinder_Bscan_2D.in -n 60",
+task = gprmax.run(input_dir="./gprmax-files", commands=commands, on=machine)
+
+# ============================================================================
+# EXAMPLE 2: GprMax's built-in MPI
+# ============================================================================
+# GprMax spawns its own MPI processes using the -mpi flag
+commands = ["python -m gprMax cylinder_Bscan_2D.in -n 60 -mpi 61"]
+
+task = gprmax.run(input_dir="./gprmax-files", commands=commands, on=machine)
+
+# ============================================================================
+# EXAMPLE 3: Using mpirun wrapper
+# ============================================================================
+# Use --mpi-no-spawn to prevent GprMax from spawning its own processes
+# Wrap the command with MPIConfig to control mpirun
+commands = [
+    Command("python -m gprMax antenna_like_MALA_1200_fs.in -n 3 --mpi-no-spawn",
+            mpi_config=MPIConfig(version="4.1.6", np=4))
 ]
 
-task = gprmax.run(
-    input_dir="/Path/to/gprmax-input-example",
-    commands=commands_no_mpi,
-    on=cloud_machine)
+task = gprmax.run(input_dir="./gprmax-files", commands=commands, on=machine)
 
-
-# OPTION 2: Run with GprMax's built-in MPI
-# -------------------------------------------------
-# Use this mode when you want GprMax to manage MPI internally.
-# The -mpi flag tells GprMax how many processes to use.
-commands_gprmax_mpi = [
-    "python -m gprMax user_models/cylinder_Bscan_2D.in -n 60 -mpi 61",
+# ============================================================================
+# EXAMPLE 4: Full workflow with post-processing
+# ============================================================================
+# Mix simulation and post-processing commands as needed
+commands = [
+    # Run simulation with GprMax's built-in MPI
+    "python -m gprMax cylinder_Bscan_2D.in -n 30 -mpi 31",
+    "python -m tools.outputfiles_merge cylinder_Bscan_2D",
 ]
 
-task = gprmax.run(
-    input_dir="/Path/to/gprmax-input-example",
-    commands=commands_gprmax_mpi,
-    use_gprmax_mpi=True,  # Enable GprMax's built-in MPI mode
-    on=cloud_machine)
+task = gprmax.run(input_dir="./gprmax-files", commands=commands, on=machine)
 
-
-# OPTION 3: Run with mpirun wrapper
-# -------------------------------------------------
-# Use this mode when you want to use standard mpirun.
-# The --mpi-no-spawn flag is required to prevent GprMax from spawning
-# its own MPI processes.
-commands_mpirun = [
-    "python -m gprMax antenna_like_MALA_1200_fs.in -n 3 --mpi-no-spawn",
-]
-
-task = gprmax.run(
-    input_dir="/Path/to/gprmax-input-example",
-    commands=commands_mpirun,
-    n_vcpus=4,  # Specify number of MPI processes
-    use_gprmax_mpi=False,  # Use mpirun wrapper (default)
-    on=cloud_machine)
-
-
-# OPTION 4: Mixed workflow (simulation + post-processing)
-# -------------------------------------------------
-# Common pattern: Run simulation with MPI, then post-process without MPI.
-# The MPI configuration is ONLY applied to GprMax simulation commands.
-# Utility commands (tools.*) automatically run without MPI.
-commands_mixed = [
-    # Step 1: Run simulation with MPI (4 processes)
-    "python -m gprMax user_models/cylinder_Bscan_2D.in -n 60 --mpi-no-spawn",
-    # Step 2: Merge output files (NO MPI - runs on single process)
-    "python -m tools.outputfiles_merge user_models/cylinder_Bscan_2D",
-    # Step 3: Plot results (NO MPI - runs on single process)
-    "python -m tools.plot_Bscan user_models/cylinder_Bscan_2D_merged.out Ez",
-]
-
-task = gprmax.run(
-    input_dir="/Path/to/gprmax-input-example",
-    commands=commands_mixed,
-    n_vcpus=4,  # MPI only for the simulation command
-    on=cloud_machine)
-
-
-# Wait for the simulation to finish and download the results
 task.wait()
-cloud_machine.terminate()
-
-task.download_outputs()
-task.print_summary()
+machine.terminate()

--- a/examples/gprMax/gprmax.py
+++ b/examples/gprMax/gprmax.py
@@ -1,24 +1,85 @@
-"""gprMax example."""
+"""gprMax example.
+
+This example demonstrates three ways to run GprMax:
+1. Without MPI (single process)
+2. With GprMax's built-in MPI (using -mpi flag)
+3. With mpirun wrapper (using --mpi-no-spawn flag)
+"""
 import inductiva
 
 # Allocate cloud machine on Google Cloud Platform
-cloud_machine = inductiva.resources.MachineGroup( \
+cloud_machine = inductiva.resources.MachineGroup(
     provider="GCP",
     machine_type="c3d-highcpu-180")
 
 # Initialize the Simulator
 gprmax = inductiva.simulators.GprMax(version="3.1.7")
 
-#  List of commands to run
-commands = [
-    "python -m gprMax input_file.in",
+
+# OPTION 1: Run without MPI (single process)
+# -------------------------------------------------
+commands_no_mpi = [
+    "python -m gprMax user_models/cylinder_Bscan_2D.in -n 60",
 ]
 
-# Run simulation
-task = gprmax.run(\
+task = gprmax.run(
     input_dir="/Path/to/gprmax-input-example",
-    commands=commands,
+    commands=commands_no_mpi,
     on=cloud_machine)
+
+
+# OPTION 2: Run with GprMax's built-in MPI
+# -------------------------------------------------
+# Use this mode when you want GprMax to manage MPI internally.
+# The -mpi flag tells GprMax how many processes to use.
+commands_gprmax_mpi = [
+    "python -m gprMax user_models/cylinder_Bscan_2D.in -n 60 -mpi 61",
+]
+
+task = gprmax.run(
+    input_dir="/Path/to/gprmax-input-example",
+    commands=commands_gprmax_mpi,
+    use_gprmax_mpi=True,  # Enable GprMax's built-in MPI mode
+    on=cloud_machine)
+
+
+# OPTION 3: Run with mpirun wrapper
+# -------------------------------------------------
+# Use this mode when you want to use standard mpirun.
+# The --mpi-no-spawn flag is required to prevent GprMax from spawning
+# its own MPI processes.
+commands_mpirun = [
+    "python -m gprMax antenna_like_MALA_1200_fs.in -n 3 --mpi-no-spawn",
+]
+
+task = gprmax.run(
+    input_dir="/Path/to/gprmax-input-example",
+    commands=commands_mpirun,
+    n_vcpus=4,  # Specify number of MPI processes
+    use_gprmax_mpi=False,  # Use mpirun wrapper (default)
+    on=cloud_machine)
+
+
+# OPTION 4: Mixed workflow (simulation + post-processing)
+# -------------------------------------------------
+# Common pattern: Run simulation with MPI, then post-process without MPI.
+# The MPI configuration is ONLY applied to GprMax simulation commands.
+# Utility commands (tools.*) automatically run without MPI.
+commands_mixed = [
+    # Step 1: Run simulation with MPI (4 processes)
+    "python -m gprMax user_models/cylinder_Bscan_2D.in -n 60 --mpi-no-spawn",
+    # Step 2: Merge output files (NO MPI - runs on single process)
+    "python -m tools.outputfiles_merge user_models/cylinder_Bscan_2D",
+    # Step 3: Plot results (NO MPI - runs on single process)
+    "python -m tools.plot_Bscan user_models/cylinder_Bscan_2D_merged.out Ez",
+]
+
+task = gprmax.run(
+    input_dir="/Path/to/gprmax-input-example",
+    commands=commands_mixed,
+    n_vcpus=4,  # MPI only for the simulation command
+    on=cloud_machine)
+
 
 # Wait for the simulation to finish and download the results
 task.wait()

--- a/inductiva/simulators/gprmax.py
+++ b/inductiva/simulators/gprmax.py
@@ -2,8 +2,6 @@
 from typing import Optional, Union
 
 from inductiva import simulators, types
-from inductiva.commands import MPIConfig
-from inductiva.commands.commands import Command
 
 
 @simulators.simulator.mpi_enabled
@@ -27,9 +25,6 @@ class GprMax(simulators.Simulator):
             commands: types.Commands,
             *,
             on: types.ComputationalResources,
-            use_gprmax_mpi: bool = False,
-            use_hwthread: bool = True,
-            n_vcpus: Optional[int] = None,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
@@ -43,15 +38,8 @@ class GprMax(simulators.Simulator):
             input_dir: Path to the directory of the simulation input files.
             on: The computational resource to launch the simulation on.
             commands: List of commands to run the simulation.
-            use_gprmax_mpi: If True, use GprMax's built-in MPI mechanism
-                (requires -mpi flag in command). If False and n_vcpus is
-                specified, will use mpirun wrapper (requires --mpi-no-spawn
-                flag in command). Default is False.
-            use_hwthread: If specified, Open MPI will attempt to discover the
-                number of hardware threads on the node, and use that as the
-                number of slots available. Only used when use_gprmax_mpi=False.
-            n_vcpus: Number of vCPUs to use in the simulation. If not provided
-                and MPI is being used, all vCPUs will be used.
+                - No MPI: "python -m gprMax input.in -n 60"
+                - GprMax built-in MPI: "python -m gprMax input.in -n 60 -mpi 61"
             storage_dir: Directory for storing results.
             remote_assets: Additional remote files that will be copied to
                 the simulation directory.
@@ -92,42 +80,9 @@ class GprMax(simulators.Simulator):
         self._input_files_exist(input_dir=input_dir,
                                 remote_assets=remote_assets)
 
-        # Create MPI config for mpirun wrapper mode
-        mpi_config = None
-        if not use_gprmax_mpi and n_vcpus is not None:
-            mpi_kwargs = {"use_hwthread_cpus": use_hwthread, "np": n_vcpus}
-            mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
-
-        # Process commands and apply MPI configuration
-        # IMPORTANT: MPI is only applied to GprMax simulation commands
-        # (those containing "gprMax" but not "tools.").
-        # Utility commands like tools.outputfiles_merge or tools.plot_Bscan
-        # will NOT have MPI applied, which is the correct behavior since
-        # they are post-processing tools that should run single-threaded.
-        processed_commands = []
-        for idx, command in enumerate(commands):
-            if not isinstance(command, str):
-                # If it's already a Command object, keep it as is
-                processed_commands.append(command)
-                continue
-
-            # Check if this is a GprMax simulation command
-            # Exclude utility commands (tools.*) from MPI processing
-            is_gprmax_cmd = "gprMax" in command and "tools." not in command
-
-            if is_gprmax_cmd:
-                # Validate and process GprMax simulation command with MPI
-                processed_cmd = self._process_gprmax_command(
-                    command, use_gprmax_mpi, mpi_config, n_vcpus, idx)
-                processed_commands.append(processed_cmd)
-            else:
-                # Non-GprMax simulation command (utilities, pre/post-processing)
-                # Keep as-is without MPI
-                processed_commands.append(command)
-
         return super().run(input_dir,
                            on=on,
-                           commands=processed_commands,
+                           commands=commands,
                            storage_dir=storage_dir,
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
@@ -135,111 +90,3 @@ class GprMax(simulators.Simulator):
                            time_to_live=time_to_live,
                            on_finish_cleanup=on_finish_cleanup,
                            **kwargs)
-
-    def _process_gprmax_command(self, command: str, use_gprmax_mpi: bool,
-                                mpi_config: Optional[MPIConfig],
-                                n_vcpus: Optional[int],
-                                cmd_idx: int) -> Union[str, Command]:
-        """Process a GprMax command and apply appropriate MPI configuration.
-
-        Args:
-            command: The command string to process.
-            use_gprmax_mpi: Whether to use GprMax's built-in MPI.
-            mpi_config: The MPIConfig object for mpirun wrapper mode.
-            n_vcpus: Number of vCPUs requested by user.
-            cmd_idx: Index of the command in the commands list (for error msgs).
-
-        Returns:
-            Either a string command or a Command object with MPI config.
-
-        Raises:
-            ValueError: If the command has incorrect MPI configuration.
-        """
-        has_mpi_flag = "-mpi" in command
-        has_mpi_no_spawn = "--mpi-no-spawn" in command
-        has_mpirun = "mpirun" in command
-
-        if use_gprmax_mpi:
-            # Mode 1: Using GprMax's built-in MPI
-            if has_mpirun:
-                raise ValueError(
-                    f"Command {cmd_idx}: Cannot use 'mpirun' when "
-                    f"use_gprmax_mpi=True. GprMax's built-in MPI uses the "
-                    f"-mpi flag instead.\n"
-                    f"Command: {command}\n"
-                    f"Either:\n"
-                    f"  1. Remove 'mpirun' and use the -mpi flag, or\n"
-                    f"  2. Set use_gprmax_mpi=False to use mpirun wrapper mode")
-
-            if has_mpi_no_spawn:
-                raise ValueError(
-                    f"Command {cmd_idx}: The --mpi-no-spawn flag is only for "
-                    f"mpirun wrapper mode.\n"
-                    f"Command: {command}\n"
-                    f"When use_gprmax_mpi=True, use the -mpi flag instead.\n"
-                    f"Example: 'python -m gprMax input.in -n 60 -mpi 61'")
-
-            if not has_mpi_flag:
-                raise ValueError(
-                    f"Command {cmd_idx}: Missing -mpi flag when "
-                    f"use_gprmax_mpi=True.\n"
-                    f"Command: {command}\n"
-                    f"GprMax's built-in MPI requires the -mpi flag.\n"
-                    f"Example: 'python -m gprMax input.in -n 60 -mpi 61'\n"
-                    f"Or set use_gprmax_mpi=False if you want to use mpirun "
-                    f"wrapper mode.")
-
-            # GprMax built-in MPI mode - return command as is
-            return command
-
-        elif mpi_config is not None:
-            # Mode 2: Using mpirun wrapper (n_vcpus was specified)
-            if has_mpi_flag and not has_mpi_no_spawn:
-                raise ValueError(
-                    f"Command {cmd_idx}: Found -mpi flag but --mpi-no-spawn "
-                    f"is missing.\n"
-                    f"Command: {command}\n"
-                    f"When using mpirun wrapper (use_gprmax_mpi=False with "
-                    f"n_vcpus specified), you must use --mpi-no-spawn flag.\n"
-                    f"Example: 'python -m gprMax input.in -n 3 --mpi-no-spawn'\n"
-                    f"Or set use_gprmax_mpi=True to use GprMax's built-in MPI "
-                    f"with -mpi flag.")
-
-            if has_mpirun:
-                raise ValueError(
-                    f"Command {cmd_idx}: Command already contains 'mpirun'.\n"
-                    f"Command: {command}\n"
-                    f"When n_vcpus is specified, the mpirun wrapper is added "
-                    f"automatically. Please remove 'mpirun' from your command.\n"
-                    f"Example: 'python -m gprMax input.in -n 3 --mpi-no-spawn'")
-
-            if not has_mpi_no_spawn:
-                raise ValueError(
-                    f"Command {cmd_idx}: Missing --mpi-no-spawn flag.\n"
-                    f"Command: {command}\n"
-                    f"When using mpirun wrapper mode (use_gprmax_mpi=False "
-                    f"with n_vcpus={n_vcpus}), the --mpi-no-spawn flag is "
-                    f"required.\n"
-                    f"Example: 'python -m gprMax input.in -n 3 --mpi-no-spawn'\n"
-                    f"See: https://docs.gprmax.com/en/latest/openmp_mpi.html")
-
-            # mpirun wrapper mode - wrap with Command and MPI config
-            return Command(command, mpi_config=mpi_config)
-
-        else:
-            # Mode 3: No MPI (n_vcpus not specified)
-            if has_mpi_flag or has_mpi_no_spawn or has_mpirun:
-                raise ValueError(
-                    f"Command {cmd_idx}: MPI-related flags found but MPI is "
-                    f"not configured.\n"
-                    f"Command: {command}\n"
-                    f"The command contains MPI flags (-mpi, --mpi-no-spawn, "
-                    f"or mpirun) but n_vcpus was not specified.\n"
-                    f"Either:\n"
-                    f"  1. Specify n_vcpus to enable MPI, or\n"
-                    f"  2. Remove MPI flags if you want to run without MPI\n"
-                    f"Example without MPI: "
-                    f"'python -m gprMax input.in -n 60'")
-
-            # No MPI mode - return command as is
-            return command

--- a/inductiva/simulators/gprmax.py
+++ b/inductiva/simulators/gprmax.py
@@ -2,8 +2,11 @@
 from typing import Optional, Union
 
 from inductiva import simulators, types
+from inductiva.commands import MPIConfig
+from inductiva.commands.commands import Command
 
 
+@simulators.simulator.mpi_enabled
 class GprMax(simulators.Simulator):
     """Class to invoke a generic gprmax simulation on the API."""
 
@@ -24,6 +27,9 @@ class GprMax(simulators.Simulator):
             commands: types.Commands,
             *,
             on: types.ComputationalResources,
+            use_gprmax_mpi: bool = False,
+            use_hwthread: bool = True,
+            n_vcpus: Optional[int] = None,
             storage_dir: Optional[str] = "",
             resubmit_on_preemption: bool = False,
             remote_assets: Optional[Union[str, list[str]]] = None,
@@ -36,6 +42,16 @@ class GprMax(simulators.Simulator):
         Args:
             input_dir: Path to the directory of the simulation input files.
             on: The computational resource to launch the simulation on.
+            commands: List of commands to run the simulation.
+            use_gprmax_mpi: If True, use GprMax's built-in MPI mechanism
+                (requires -mpi flag in command). If False and n_vcpus is
+                specified, will use mpirun wrapper (requires --mpi-no-spawn
+                flag in command). Default is False.
+            use_hwthread: If specified, Open MPI will attempt to discover the
+                number of hardware threads on the node, and use that as the
+                number of slots available. Only used when use_gprmax_mpi=False.
+            n_vcpus: Number of vCPUs to use in the simulation. If not provided
+                and MPI is being used, all vCPUs will be used.
             storage_dir: Directory for storing results.
             remote_assets: Additional remote files that will be copied to
                 the simulation directory.
@@ -52,8 +68,6 @@ class GprMax(simulators.Simulator):
                 "10m", "2 hours", "1h30m", or "90s". The task will be
                 automatically terminated if it exceeds this duration after
                 starting.
-            commands: List of commands to run the simulation. Cannot be used
-                with `shell_script`.
             on_finish_cleanup :
                 Optional cleanup script or list of shell commands to remove
                 temporary or unwanted files generated during the simulation.
@@ -74,9 +88,46 @@ class GprMax(simulators.Simulator):
                     ]
             other arguments: See the documentation of the base class.
         """
+
+        self._input_files_exist(input_dir=input_dir,
+                                remote_assets=remote_assets)
+
+        # Create MPI config for mpirun wrapper mode
+        mpi_config = None
+        if not use_gprmax_mpi and n_vcpus is not None:
+            mpi_kwargs = {"use_hwthread_cpus": use_hwthread, "np": n_vcpus}
+            mpi_config = MPIConfig(version="4.1.6", **mpi_kwargs)
+
+        # Process commands and apply MPI configuration
+        # IMPORTANT: MPI is only applied to GprMax simulation commands
+        # (those containing "gprMax" but not "tools.").
+        # Utility commands like tools.outputfiles_merge or tools.plot_Bscan
+        # will NOT have MPI applied, which is the correct behavior since
+        # they are post-processing tools that should run single-threaded.
+        processed_commands = []
+        for idx, command in enumerate(commands):
+            if not isinstance(command, str):
+                # If it's already a Command object, keep it as is
+                processed_commands.append(command)
+                continue
+
+            # Check if this is a GprMax simulation command
+            # Exclude utility commands (tools.*) from MPI processing
+            is_gprmax_cmd = "gprMax" in command and "tools." not in command
+
+            if is_gprmax_cmd:
+                # Validate and process GprMax simulation command with MPI
+                processed_cmd = self._process_gprmax_command(
+                    command, use_gprmax_mpi, mpi_config, n_vcpus, idx)
+                processed_commands.append(processed_cmd)
+            else:
+                # Non-GprMax simulation command (utilities, pre/post-processing)
+                # Keep as-is without MPI
+                processed_commands.append(command)
+
         return super().run(input_dir,
                            on=on,
-                           commands=commands,
+                           commands=processed_commands,
                            storage_dir=storage_dir,
                            resubmit_on_preemption=resubmit_on_preemption,
                            remote_assets=remote_assets,
@@ -84,3 +135,111 @@ class GprMax(simulators.Simulator):
                            time_to_live=time_to_live,
                            on_finish_cleanup=on_finish_cleanup,
                            **kwargs)
+
+    def _process_gprmax_command(self, command: str, use_gprmax_mpi: bool,
+                                mpi_config: Optional[MPIConfig],
+                                n_vcpus: Optional[int],
+                                cmd_idx: int) -> Union[str, Command]:
+        """Process a GprMax command and apply appropriate MPI configuration.
+
+        Args:
+            command: The command string to process.
+            use_gprmax_mpi: Whether to use GprMax's built-in MPI.
+            mpi_config: The MPIConfig object for mpirun wrapper mode.
+            n_vcpus: Number of vCPUs requested by user.
+            cmd_idx: Index of the command in the commands list (for error msgs).
+
+        Returns:
+            Either a string command or a Command object with MPI config.
+
+        Raises:
+            ValueError: If the command has incorrect MPI configuration.
+        """
+        has_mpi_flag = "-mpi" in command
+        has_mpi_no_spawn = "--mpi-no-spawn" in command
+        has_mpirun = "mpirun" in command
+
+        if use_gprmax_mpi:
+            # Mode 1: Using GprMax's built-in MPI
+            if has_mpirun:
+                raise ValueError(
+                    f"Command {cmd_idx}: Cannot use 'mpirun' when "
+                    f"use_gprmax_mpi=True. GprMax's built-in MPI uses the "
+                    f"-mpi flag instead.\n"
+                    f"Command: {command}\n"
+                    f"Either:\n"
+                    f"  1. Remove 'mpirun' and use the -mpi flag, or\n"
+                    f"  2. Set use_gprmax_mpi=False to use mpirun wrapper mode")
+
+            if has_mpi_no_spawn:
+                raise ValueError(
+                    f"Command {cmd_idx}: The --mpi-no-spawn flag is only for "
+                    f"mpirun wrapper mode.\n"
+                    f"Command: {command}\n"
+                    f"When use_gprmax_mpi=True, use the -mpi flag instead.\n"
+                    f"Example: 'python -m gprMax input.in -n 60 -mpi 61'")
+
+            if not has_mpi_flag:
+                raise ValueError(
+                    f"Command {cmd_idx}: Missing -mpi flag when "
+                    f"use_gprmax_mpi=True.\n"
+                    f"Command: {command}\n"
+                    f"GprMax's built-in MPI requires the -mpi flag.\n"
+                    f"Example: 'python -m gprMax input.in -n 60 -mpi 61'\n"
+                    f"Or set use_gprmax_mpi=False if you want to use mpirun "
+                    f"wrapper mode.")
+
+            # GprMax built-in MPI mode - return command as is
+            return command
+
+        elif mpi_config is not None:
+            # Mode 2: Using mpirun wrapper (n_vcpus was specified)
+            if has_mpi_flag and not has_mpi_no_spawn:
+                raise ValueError(
+                    f"Command {cmd_idx}: Found -mpi flag but --mpi-no-spawn "
+                    f"is missing.\n"
+                    f"Command: {command}\n"
+                    f"When using mpirun wrapper (use_gprmax_mpi=False with "
+                    f"n_vcpus specified), you must use --mpi-no-spawn flag.\n"
+                    f"Example: 'python -m gprMax input.in -n 3 --mpi-no-spawn'\n"
+                    f"Or set use_gprmax_mpi=True to use GprMax's built-in MPI "
+                    f"with -mpi flag.")
+
+            if has_mpirun:
+                raise ValueError(
+                    f"Command {cmd_idx}: Command already contains 'mpirun'.\n"
+                    f"Command: {command}\n"
+                    f"When n_vcpus is specified, the mpirun wrapper is added "
+                    f"automatically. Please remove 'mpirun' from your command.\n"
+                    f"Example: 'python -m gprMax input.in -n 3 --mpi-no-spawn'")
+
+            if not has_mpi_no_spawn:
+                raise ValueError(
+                    f"Command {cmd_idx}: Missing --mpi-no-spawn flag.\n"
+                    f"Command: {command}\n"
+                    f"When using mpirun wrapper mode (use_gprmax_mpi=False "
+                    f"with n_vcpus={n_vcpus}), the --mpi-no-spawn flag is "
+                    f"required.\n"
+                    f"Example: 'python -m gprMax input.in -n 3 --mpi-no-spawn'\n"
+                    f"See: https://docs.gprmax.com/en/latest/openmp_mpi.html")
+
+            # mpirun wrapper mode - wrap with Command and MPI config
+            return Command(command, mpi_config=mpi_config)
+
+        else:
+            # Mode 3: No MPI (n_vcpus not specified)
+            if has_mpi_flag or has_mpi_no_spawn or has_mpirun:
+                raise ValueError(
+                    f"Command {cmd_idx}: MPI-related flags found but MPI is "
+                    f"not configured.\n"
+                    f"Command: {command}\n"
+                    f"The command contains MPI flags (-mpi, --mpi-no-spawn, "
+                    f"or mpirun) but n_vcpus was not specified.\n"
+                    f"Either:\n"
+                    f"  1. Specify n_vcpus to enable MPI, or\n"
+                    f"  2. Remove MPI flags if you want to run without MPI\n"
+                    f"Example without MPI: "
+                    f"'python -m gprMax input.in -n 60'")
+
+            # No MPI mode - return command as is
+            return command


### PR DESCRIPTION
## Summary

This PR adds MPI support to the GprMax simulator, enabling parallel execution of simulations. GprMax supports two MPI mechanisms that users can now leverage through the Inductiva API.

## Changes

### `inductiva/simulators/gprmax.py`

- Implemented proper command pass-through to support MPI configurations
- Updated `run()` method to accept arbitrary commands
- Added `@simulators.simulator.mpi_enabled` decorator to enable MPICluster support

### `examples/gprMax/gprmax.py`

Added examples demonstrating:
1. Running without MPI (single process)
2. Using GprMax's built-in MPI with `-mpi` flag
3. Mixed workflows combining simulation and post-processing tools

## MPI Usage

**GprMax's built-in MPI:**
```python
commands = ["python -m gprMax input.in -n 60 -mpi 61"]
task = gprmax.run(input_dir="./files", commands=commands, on=machine)
```

**Post-processing workflow:**
```python
commands = [
    "python -m gprMax input.in -n 60 -mpi 61",
    "python -m tools.outputfiles_merge input",
    "python -m tools.plot_Bscan input_merged.out Ez",
]
task = gprmax.run(input_dir="./files", commands=commands, on=machine)
```

